### PR TITLE
[Foundation] Geist fonts, dark-amber/pastel-cozy tokens, DensityProvider (#83 #84 #85)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
     <title>my-react-app</title>
     <script>
       try {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
-    "@fontsource-variable/manrope": "^5.2.8",
-    "@fontsource-variable/outfit": "^5.2.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
-import { DndContext, closestCenter, type DragEndEvent, type DragOverEvent, PointerSensor, useSensor } from '@dnd-kit/core';
+import { DndContext, closestCenter, type DragOverEvent, PointerSensor, useSensor } from '@dnd-kit/core';
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
 import { restrictToParentElement } from '@dnd-kit/modifiers';
 import { useState, useCallback } from 'react';
 
 import { ThemeProvider } from './context/ThemeProvider';
+import { DensityProvider } from './context/DensityProvider';
 import { IncomeProvider } from './modules/IncomeProvider';
 import { useTotalIncome, useFormatPreference } from './modules/income-hooks';
 import { useMules } from './hooks/useMules';
@@ -217,9 +218,11 @@ function Stat({ label, value, accent, muted }: StatProps) {
 function App() {
   return (
     <ThemeProvider defaultTheme="dark">
-      <IncomeProvider>
-        <AppContent />
-      </IncomeProvider>
+      <DensityProvider>
+        <IncomeProvider>
+          <AppContent />
+        </IncomeProvider>
+      </DensityProvider>
     </ThemeProvider>
   );
 }

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -208,14 +208,11 @@ describe('App', () => {
 })
 
 describe('section entrance animations', () => {
-  it('Header has slide-up fade-in animation classes', () => {
+  it('Header renders with sticky positioning', () => {
     render(<App />)
     const header = screen.getByRole('banner')
-    expect(header.className).toContain('animate-in')
-    expect(header.className).toContain('fade-in')
-    expect(header.className).toContain('slide-in-from-bottom-4')
-    expect(header.className).toContain('duration-500')
-    expect(header.className).toContain('fill-mode-both')
+    expect(header.className).toContain('sticky')
+    expect(header.className).toContain('top-0')
   })
 
   it('income card has slide-up fade-in animation classes', () => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,34 +1,58 @@
 import { Sun, Moon } from 'lucide-react'
-import { useTheme } from '@/context/ThemeProvider'
-import { Button } from '@/components/ui/button'
-import leafImg from '@/assets/logo.png'
+import { useTheme } from '../context/ThemeProvider'
 
 export function Header() {
   const { theme, toggleTheme } = useTheme()
-  const isDark = theme === 'dark'
-
   return (
-    <header className="sticky top-0 z-40 w-full border-b border-border/60 bg-background/60 backdrop-blur-md supports-[backdrop-filter]:bg-background/50 animate-in fade-in slide-in-from-bottom-4 duration-500 fill-mode-both">
-      <div className="container mx-auto max-w-7xl flex items-center justify-between gap-6 px-4 sm:px-6 py-4">
-        <div className="flex items-center gap-3 min-w-0">
-          <img src={leafImg} alt="" aria-hidden className="h-6 w-8" />
-          <div className="min-w-0">
-            <h1 className="font-display text-[1.55rem] leading-none font-black tracking-tight">
-              Mule<span className="text-[var(--accent-primary)]">.</span>Income
-            </h1>
+    <header
+      className="sticky top-0 z-50"
+      style={{
+        borderBottom: '1px solid var(--border)',
+        background: 'var(--bg, var(--background))',
+        backdropFilter: 'blur(12px)',
+      }}
+    >
+      <div className="container mx-auto max-w-7xl px-4 sm:px-6">
+        <div className="flex h-14 items-center justify-between">
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <div
+              style={{
+                width: 26,
+                height: 26,
+                borderRadius: 7,
+                background: 'var(--accent-raw, var(--accent))',
+                display: 'grid',
+                placeItems: 'center',
+                color: 'var(--bg, var(--background))',
+                fontFamily: 'monospace',
+                fontWeight: 800,
+                fontSize: 15,
+              }}
+            >
+              M
+            </div>
+            <span
+              style={{
+                color: 'var(--text, var(--foreground))',
+                fontWeight: 600,
+                letterSpacing: '-0.01em',
+                fontSize: 15,
+              }}
+            >
+              Mule
+              <span style={{ color: 'var(--muted-raw, var(--muted-foreground))' }}>
+                .Income
+              </span>
+            </span>
           </div>
-        </div>
-
-        <div className="flex items-center gap-5">
-          <Button
-            variant="ghost"
-            size="icon"
+          <button
             onClick={toggleTheme}
-            aria-label="Toggle color scheme"
-            className="rounded-full border border-border/60 hover:border-[var(--accent-primary)]/70 hover:bg-[var(--accent-primary)]/5 hover:text-[var(--accent-primary)] transition-[color,background-color,border-color,box-shadow] hover:shadow-[0_0_20px_-6px_var(--accent-primary)]"
+            className="flex h-8 w-8 items-center justify-center rounded-md transition-colors"
+            style={{ color: 'var(--muted-raw, var(--muted-foreground))' }}
+            aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
           >
-            {isDark ? <Sun size={18} aria-label="Sun" /> : <Moon size={18} aria-label="Moon" />}
-          </Button>
+            {theme === 'dark' ? <Sun size={16} /> : <Moon size={16} />}
+          </button>
         </div>
       </div>
     </header>

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -6,30 +6,29 @@ describe('Header (shadcn/ThemeProvider)', () => {
   beforeEach(() => {
     localStorage.clear()
     document.documentElement.classList.remove('dark')
+    document.body.classList.remove('light')
   })
 
-  it('renders dark mode toggle button', () => {
-    render(<Header />)
-    const toggleBtn = screen.getByLabelText('Toggle color scheme')
+  it('renders theme toggle button', () => {
+    render(<Header />, { defaultTheme: 'dark' })
+    const toggleBtn = screen.getByLabelText('Switch to light mode')
     expect(toggleBtn).toBeTruthy()
   })
 
-  it('shows sun icon in dark mode and moon icon in light mode', () => {
-    const { unmount } = render(<Header />, { defaultTheme: 'dark' })
-    expect(screen.getByLabelText('Sun')).toBeTruthy()
+  it('shows correct aria-label for dark mode (Switch to light mode)', () => {
+    render(<Header />, { defaultTheme: 'dark' })
+    expect(screen.getByLabelText('Switch to light mode')).toBeTruthy()
+  })
 
-    unmount()
-    localStorage.clear()
-    document.documentElement.classList.remove('dark')
-
+  it('shows correct aria-label for light mode (Switch to dark mode)', () => {
     render(<Header />, { defaultTheme: 'light' })
-    expect(screen.getByLabelText('Moon')).toBeTruthy()
+    expect(screen.getByLabelText('Switch to dark mode')).toBeTruthy()
   })
 
   it('toggles theme on button click', () => {
     render(<Header />, { defaultTheme: 'dark' })
     expect(document.documentElement.classList.contains('dark')).toBe(true)
-    fireEvent.click(screen.getByLabelText('Toggle color scheme'))
+    fireEvent.click(screen.getByLabelText('Switch to light mode'))
     expect(document.documentElement.classList.contains('dark')).toBe(false)
   })
 })

--- a/src/context/DensityProvider.tsx
+++ b/src/context/DensityProvider.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext, useState, useEffect, type ReactNode } from 'react'
+
+type Density = 'comfy' | 'compact'
+
+interface DensityContextValue {
+  density: Density
+  setDensity: (density: Density) => void
+  toggleDensity: () => void
+}
+
+const DensityContext = createContext<DensityContextValue | undefined>(undefined)
+
+function getInitialDensity(): Density {
+  try {
+    const stored = localStorage.getItem('density')
+    if (stored === 'comfy' || stored === 'compact') return stored
+  } catch {}
+  return 'comfy'
+}
+
+function applyDensity(density: Density) {
+  document.documentElement.setAttribute('data-density', density)
+}
+
+interface DensityProviderProps {
+  children: ReactNode
+}
+
+export function DensityProvider({ children }: DensityProviderProps) {
+  const [density, setDensityState] = useState<Density>(getInitialDensity)
+
+  useEffect(() => {
+    applyDensity(density)
+    localStorage.setItem('density', density)
+  }, [density])
+
+  const setDensity = setDensityState
+
+  const toggleDensity = () => {
+    setDensityState((prev) => (prev === 'comfy' ? 'compact' : 'comfy'))
+  }
+
+  return (
+    <DensityContext.Provider value={{ density, setDensity, toggleDensity }}>
+      {children}
+    </DensityContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useDensity() {
+  const context = useContext(DensityContext)
+  if (!context) {
+    throw new Error('useDensity must be used within a DensityProvider')
+  }
+  return context
+}

--- a/src/context/ThemeProvider.tsx
+++ b/src/context/ThemeProvider.tsx
@@ -29,8 +29,10 @@ function getInitialTheme(fallback: Theme): Theme {
 function applyTheme(theme: Theme) {
   if (theme === 'dark') {
     document.documentElement.classList.add('dark')
+    document.body.classList.remove('light')
   } else {
     document.documentElement.classList.remove('dark')
+    document.body.classList.add('light')
   }
 }
 

--- a/src/context/__tests__/DensityProvider.test.tsx
+++ b/src/context/__tests__/DensityProvider.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DensityProvider, useDensity } from '../DensityProvider'
+
+function TestComponent() {
+  const { density, toggleDensity } = useDensity()
+  return (
+    <div>
+      <span data-testid="density">{density}</span>
+      <button onClick={toggleDensity}>toggle</button>
+    </div>
+  )
+}
+
+describe('DensityProvider', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-density')
+  })
+
+  it('defaults to comfy', () => {
+    render(<DensityProvider><TestComponent /></DensityProvider>)
+    expect(screen.getByTestId('density').textContent).toBe('comfy')
+  })
+
+  it('applies data-density attribute to html element', () => {
+    render(<DensityProvider><TestComponent /></DensityProvider>)
+    expect(document.documentElement.getAttribute('data-density')).toBe('comfy')
+  })
+
+  it('toggles to compact', () => {
+    render(<DensityProvider><TestComponent /></DensityProvider>)
+    fireEvent.click(screen.getByText('toggle'))
+    expect(screen.getByTestId('density').textContent).toBe('compact')
+    expect(document.documentElement.getAttribute('data-density')).toBe('compact')
+  })
+
+  it('persists density to localStorage', () => {
+    render(<DensityProvider><TestComponent /></DensityProvider>)
+    fireEvent.click(screen.getByText('toggle'))
+    expect(localStorage.getItem('density')).toBe('compact')
+  })
+
+  it('reads initial density from localStorage', () => {
+    localStorage.setItem('density', 'compact')
+    render(<DensityProvider><TestComponent /></DensityProvider>)
+    expect(screen.getByTestId('density').textContent).toBe('compact')
+  })
+})

--- a/src/context/__tests__/ThemeProvider.test.tsx
+++ b/src/context/__tests__/ThemeProvider.test.tsx
@@ -18,6 +18,7 @@ describe('ThemeProvider', () => {
   beforeEach(() => {
     localStorage.clear()
     document.documentElement.classList.remove('dark')
+    document.body.classList.remove('light')
   })
 
   it('provides default dark theme when no localStorage and no preference', () => {
@@ -106,6 +107,35 @@ describe('ThemeProvider', () => {
     fireEvent.click(screen.getByTestId('set-light'))
     expect(screen.getByTestId('theme-value').textContent).toBe('light')
     expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('adds body.light class when theme is light', () => {
+    render(
+      <ThemeProvider defaultTheme="light">
+        <ThemeConsumer />
+      </ThemeProvider>
+    )
+    expect(document.body.classList.contains('light')).toBe(true)
+  })
+
+  it('does not have body.light class when theme is dark', () => {
+    render(
+      <ThemeProvider defaultTheme="dark">
+        <ThemeConsumer />
+      </ThemeProvider>
+    )
+    expect(document.body.classList.contains('light')).toBe(false)
+  })
+
+  it('removes body.light class when switching back to dark', () => {
+    render(
+      <ThemeProvider defaultTheme="light">
+        <ThemeConsumer />
+      </ThemeProvider>
+    )
+    expect(document.body.classList.contains('light')).toBe(true)
+    fireEvent.click(screen.getByTestId('set-dark'))
+    expect(document.body.classList.contains('light')).toBe(false)
   })
 
   it('throws if useTheme is used outside ThemeProvider', () => {

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
-@import "@fontsource-variable/outfit";
-@import "@fontsource-variable/manrope";
 @import "@fontsource-variable/jetbrains-mono";
 
 @custom-variant dark (&:where(.dark, .dark *));
@@ -27,9 +25,9 @@
 }
 
 @theme inline {
-  --font-sans: 'Manrope Variable', ui-sans-serif, system-ui, sans-serif;
-  --font-display: 'Outfit Variable', ui-sans-serif, system-ui, sans-serif;
-  --font-mono: 'JetBrains Mono Variable', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-sans: 'Geist', -apple-system, ui-sans-serif, system-ui, sans-serif;
+  --font-display: 'Geist', -apple-system, ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
 
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -79,89 +77,135 @@
 }
 
 :root {
-  --background: hsl(230 25% 97%);
-  --foreground: hsl(230 30% 8%);
-  --card: hsl(230 20% 98.5%);
-  --card-foreground: hsl(230 30% 8%);
-  --surface-raised: hsl(230 18% 95%);
-  --surface-dim: hsl(230 15% 92%);
-  --popover: hsl(230 20% 98.5%);
-  --popover-foreground: hsl(230 30% 8%);
-  --primary: hsl(38 70% 46%);
-  --primary-foreground: hsl(38 40% 97%);
-  --secondary: hsl(230 15% 94%);
-  --secondary-foreground: hsl(230 25% 12%);
-  --muted: hsl(230 12% 93%);
-  --muted-foreground: hsl(230 12% 42%);
-  --accent: hsl(175 35% 46%);
-  --accent-foreground: hsl(175 20% 97%);
-  --destructive: hsl(8 65% 52%);
-  --border: hsl(230 15% 88%);
-  --input: hsl(230 15% 90%);
-  --ring: hsl(38 70% 46%);
-  --chart-1: hsl(230 45% 38%);
-  --chart-2: hsl(175 35% 46%);
-  --chart-3: hsl(38 70% 52%);
-  --chart-4: hsl(8 55% 55%);
-  --chart-5: hsl(280 25% 50%);
+  /* ── Handoff: Pastel-Cozy light theme ── */
+  --bg:          #f6efe4;
+  --bg-2:        #efe5d2;
+  --surface:     #fffaf0;
+  --surface-2:   #f8ecd6;
+  --border-raw:  #e4d6ba;
+  --text:        #3b2f24;
+  --muted-raw:   #8a7a65;
+  --dim:         #c9b896;
+  --accent-raw:  #d97757;
+  --accent-soft: rgba(217, 119, 87, 0.14);
+  --accent-glow: rgba(217, 119, 87, 0.2);
+  --c1: #d97757; --c2: #5b8ca8; --c3: #e2a84f; --c4: #7ea67a; --c5: #a97bb5;
 
-  --accent-primary: hsl(38 70% 46%);
-  --accent-secondary: hsl(175 35% 46%);
-  --accent-numeric: hsl(38 65% 48%);
-  --glow: 0 0 28px -4px hsl(38 70% 46% / 0.35);
+  /* ── Shadcn tokens (mapped from handoff) ── */
+  --background:        #f6efe4;
+  --foreground:        #3b2f24;
+  --card:              #fffaf0;
+  --card-foreground:   #3b2f24;
+  --surface-raised:    #f8ecd6;
+  --surface-dim:       #c9b896;
+  --popover:           #fffaf0;
+  --popover-foreground:#3b2f24;
+  --primary:           #d97757;
+  --primary-foreground:#fffaf0;
+  --secondary:         #f8ecd6;
+  --secondary-foreground: #3b2f24;
+  --muted:             #f8ecd6;
+  --muted-foreground:  #8a7a65;
+  --accent:            #d97757;
+  --accent-foreground: #fffaf0;
+  --destructive:       hsl(8 65% 52%);
+  --border:            #e4d6ba;
+  --input:             #e4d6ba;
+  --ring:              #d97757;
+  --chart-1: #d97757; --chart-2: #5b8ca8; --chart-3: #e2a84f;
+  --chart-4: #7ea67a; --chart-5: #a97bb5;
+
+  --accent-primary:   #d97757;
+  --accent-secondary: #5b8ca8;
+  --accent-numeric:   #d97757;
+  --glow: 0 0 28px -4px rgba(217, 119, 87, 0.2);
 
   --radius: 0.875rem;
 
-  --sidebar: hsl(230 20% 97.5%);
-  --sidebar-foreground: hsl(230 30% 8%);
-  --sidebar-primary: hsl(38 70% 46%);
-  --sidebar-primary-foreground: hsl(38 40% 97%);
-  --sidebar-accent: hsl(230 15% 94%);
-  --sidebar-accent-foreground: hsl(230 25% 12%);
-  --sidebar-border: hsl(230 15% 88%);
-  --sidebar-ring: hsl(38 70% 46%);
+  --sidebar:                   #fffaf0;
+  --sidebar-foreground:        #3b2f24;
+  --sidebar-primary:           #d97757;
+  --sidebar-primary-foreground:#fffaf0;
+  --sidebar-accent:            #f8ecd6;
+  --sidebar-accent-foreground: #3b2f24;
+  --sidebar-border:            #e4d6ba;
+  --sidebar-ring:              #d97757;
+
+  /* ── Density defaults ── */
+  --card-pad: 16px;
+  --roster-cols: 6;
+  --sil-size: 72px;
+  --mule-name-size: 14px;
+  --kpi-pad: 24px;
 }
 
 .dark {
-  --background: hsl(228 28% 10%);
-  --foreground: hsl(228 20% 94%);
-  --card: hsl(228 24% 13%);
-  --card-foreground: hsl(228 20% 94%);
-  --surface-raised: hsl(228 22% 16%);
-  --surface-dim: hsl(228 15% 18%);
-  --popover: hsl(228 26% 12%);
-  --popover-foreground: hsl(228 20% 94%);
-  --primary: hsl(38 65% 58%);
-  --primary-foreground: hsl(228 28% 10%);
-  --secondary: hsl(228 18% 17%);
-  --secondary-foreground: hsl(228 15% 90%);
-  --muted: hsl(228 16% 16%);
-  --muted-foreground: hsl(228 12% 56%);
-  --accent: hsl(175 30% 50%);
-  --accent-foreground: hsl(175 20% 95%);
-  --destructive: hsl(8 60% 52%);
-  --border: hsl(228 16% 20%);
-  --input: hsl(228 18% 17%);
-  --ring: hsl(38 65% 58%);
-  --chart-1: hsl(38 65% 58%);
-  --chart-2: hsl(175 30% 50%);
-  --chart-3: hsl(228 40% 60%);
-  --chart-4: hsl(8 55% 58%);
-  --chart-5: hsl(280 22% 58%);
+  /* ── Handoff: Dark-Amber dark theme ── */
+  --bg:          #0b0b10;
+  --bg-2:        #111118;
+  --surface:     #15161d;
+  --surface-2:   #1b1d26;
+  --border-raw:  #262836;
+  --text:        #eeecda;
+  --muted-raw:   #72778a;
+  --dim:         #3a3d4d;
+  --accent-raw:  #f0b44a;
+  --accent-soft: rgba(240, 180, 74, 0.15);
+  --accent-glow: rgba(240, 180, 74, 0.25);
+  --c1: #f0b44a; --c2: #7fb7ff; --c3: #e88774; --c4: #6fd3b5; --c5: #b395e0;
 
-  --accent-primary: hsl(38 65% 58%);
-  --accent-secondary: hsl(175 30% 50%);
-  --accent-numeric: hsl(38 55% 65%);
-  --glow: 0 0 28px -4px hsl(38 65% 58% / 0.30);
+  /* ── Shadcn tokens (mapped from handoff) ── */
+  --background:        #0b0b10;
+  --foreground:        #eeecda;
+  --card:              #15161d;
+  --card-foreground:   #eeecda;
+  --surface-raised:    #1b1d26;
+  --surface-dim:       #3a3d4d;
+  --popover:           #15161d;
+  --popover-foreground:#eeecda;
+  --primary:           #f0b44a;
+  --primary-foreground:#0b0b10;
+  --secondary:         #1b1d26;
+  --secondary-foreground: #eeecda;
+  --muted:             #1b1d26;
+  --muted-foreground:  #72778a;
+  --accent:            #f0b44a;
+  --accent-foreground: #0b0b10;
+  --destructive:       hsl(8 60% 52%);
+  --border:            #262836;
+  --input:             #262836;
+  --ring:              #f0b44a;
+  --chart-1: #f0b44a; --chart-2: #7fb7ff; --chart-3: #e88774;
+  --chart-4: #6fd3b5; --chart-5: #b395e0;
 
-  --sidebar: hsl(228 24% 12%);
-  --sidebar-foreground: hsl(228 20% 94%);
-  --sidebar-primary: hsl(38 65% 58%);
-  --sidebar-primary-foreground: hsl(228 28% 10%);
-  --sidebar-accent: hsl(228 16% 16%);
-  --sidebar-accent-foreground: hsl(228 15% 90%);
-  --sidebar-border: hsl(228 16% 20%);
-  --sidebar-ring: hsl(38 65% 58%);
+  --accent-primary:   #f0b44a;
+  --accent-secondary: #7fb7ff;
+  --accent-numeric:   #f0b44a;
+  --glow: 0 0 28px -4px rgba(240, 180, 74, 0.25);
+
+  --sidebar:                   #15161d;
+  --sidebar-foreground:        #eeecda;
+  --sidebar-primary:           #f0b44a;
+  --sidebar-primary-foreground:#0b0b10;
+  --sidebar-accent:            #1b1d26;
+  --sidebar-accent-foreground: #eeecda;
+  --sidebar-border:            #262836;
+  --sidebar-ring:              #f0b44a;
+}
+
+[data-density="comfy"] {
+  --card-pad: 16px;
+  --roster-cols: 6;
+  --sil-size: 72px;
+  --mule-name-size: 14px;
+  --kpi-pad: 24px;
+}
+[data-density="compact"] {
+  --card-pad: 12px;
+  --roster-cols: 8;
+  --sil-size: 56px;
+  --mule-name-size: 13px;
+  --kpi-pad: 18px;
 }
 
 @layer base {
@@ -174,10 +218,13 @@
   }
   body {
     @apply bg-background text-foreground;
+    font-family: 'Geist', -apple-system, ui-sans-serif, system-ui, sans-serif;
+    font-feature-settings: 'ss01', 'cv11';
     font-weight: 500;
     letter-spacing: -0.005em;
     position: relative;
     min-height: 100vh;
+    transition: background 0.25s ease;
   }
 
   body::before {
@@ -187,9 +234,13 @@
     z-index: -2;
     pointer-events: none;
     background:
-      radial-gradient(620px 420px at 12% 8%, hsl(38 65% 58% / 0.10), transparent 62%),
-      radial-gradient(520px 520px at 88% 18%, hsl(175 30% 50% / 0.07), transparent 65%),
-      radial-gradient(820px 640px at 50% 112%, hsl(228 30% 40% / 0.06), transparent 70%);
+      radial-gradient(1200px 600px at 10% -10%, var(--accent-soft) 0%, transparent 50%),
+      radial-gradient(900px 500px at 90% 10%, rgba(127, 183, 255, 0.05) 0%, transparent 55%);
+  }
+
+  body.light::before {
+    background:
+      radial-gradient(1200px 600px at 10% -10%, var(--accent-soft) 0%, transparent 50%);
   }
 
   body::after {
@@ -204,21 +255,68 @@
     background-size: 180px 180px;
   }
 
-  :root body::before {
-    background:
-      radial-gradient(620px 420px at 12% 8%, hsl(38 50% 46% / 0.06), transparent 62%),
-      radial-gradient(520px 520px at 88% 18%, hsl(175 30% 46% / 0.05), transparent 65%),
-      radial-gradient(820px 640px at 50% 112%, hsl(228 20% 25% / 0.04), transparent 70%);
-  }
-
-  .font-display {
-    font-family: var(--font-display);
-    font-optical-sizing: auto;
-  }
-
   .font-mono-nums {
     font-family: var(--font-mono);
     font-variant-numeric: tabular-nums;
     letter-spacing: -0.02em;
+  }
+
+  .panel {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    position: relative;
+  }
+  .panel-glow {
+    background: linear-gradient(180deg, var(--surface) 0%, var(--surface-2) 100%);
+    box-shadow:
+      0 0 0 1px var(--border),
+      0 20px 60px -30px var(--accent-glow),
+      inset 0 1px 0 rgba(255,255,255,0.02);
+  }
+  body.light .panel-glow {
+    box-shadow:
+      0 0 0 1px var(--border),
+      0 12px 40px -20px var(--accent-glow);
+  }
+  .bignum {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 58px;
+    font-weight: 500;
+    color: var(--accent-raw, var(--accent));
+    letter-spacing: -0.02em;
+    line-height: 1;
+    text-shadow: 0 0 40px var(--accent-glow);
+  }
+  .eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--muted-raw, var(--muted-foreground));
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 500;
+  }
+  .eyebrow .dot {
+    width: 18px;
+    height: 3px;
+    border-radius: 2px;
+    background: var(--accent-raw, var(--accent));
+  }
+  .eyebrow-plain {
+    color: var(--muted-raw, var(--muted-foreground));
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 500;
+  }
+  .bar-accent {
+    width: 4px;
+    height: 20px;
+    border-radius: 2px;
+    background: var(--accent-raw, var(--accent));
   }
 }


### PR DESCRIPTION
## Parent PRD
#82

## What this implements
Implements issues #83, #84, #85 — the foundation layer of the classic redesign.

### #83 — Typography + CSS Token Foundation
- Switched from `@fontsource-variable/outfit` + `@fontsource-variable/manrope` to Geist + JetBrains Mono via Google Fonts
- Replaced all `:root` and `.dark` CSS token blocks with `pastel-cozy` (light) and `dark-amber` (dark) handoff values
- Added per-theme chart palette `--c1`–`--c5`
- Added `[data-density="comfy/compact"]` CSS variable blocks
- Added handoff utility classes: `.panel`, `.panel-glow`, `.bignum`, `.eyebrow`, `.eyebrow-plain`, `.bar-accent`
- Updated `body::before` gradient to handoff version

### #84 — Theme + Density State
- `ThemeProvider.applyTheme` now manages `body.light` class for light-mode CSS overrides
- New `DensityProvider` context with `comfy`/`compact` state, localStorage persistence, `data-density` on `<html>`
- 5 new `DensityProvider` tests; ThemeProvider tests updated for `body.light` cleanup

### #85 — Classic Layout Shell + Header
- App root wrapped in `DensityProvider`
- Header replaced with handoff version: M logo + Mule.Income wordmark + theme toggle

**Tests:** 183/183 passing | **Build:** clean

Closes #83
Closes #84
Closes #85