### PR TITLE
[Slice 7/8] Drawer + BossCheckboxList restyle (#89)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { DndContext, closestCenter, type DragEndEvent, type DragOverEvent, PointerSensor, useSensor } from '@dnd-kit/core';
+import { DndContext, closestCenter, type DragOverEvent, PointerSensor, useSensor } from '@dnd-kit/core';
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
 import { restrictToParentElement } from '@dnd-kit/modifiers';
 import { useState, useCallback } from 'react';

--- a/src/components/BossCheckboxList.tsx
+++ b/src/components/BossCheckboxList.tsx
@@ -26,7 +26,7 @@ export function BossCheckboxList({ selectedBosses, onChange }: BossCheckboxListP
         />
         <Input
           placeholder="Search bosses..."
-          className="pl-9 bg-input/40 border-border/60 focus-visible:border-[var(--accent-primary)] focus-visible:ring-[var(--ring)]"
+          className="pl-9 bg-input/40 border-border/60 focus-visible:border-[var(--accent-raw,var(--accent))] focus-visible:ring-[var(--ring)]"
           value={search}
           onChange={(e) => setSearch(e.currentTarget.value)}
         />
@@ -38,11 +38,12 @@ export function BossCheckboxList({ selectedBosses, onChange }: BossCheckboxListP
           return (
             <div
               key={family.family}
-              className="rounded-lg border border-border/50 bg-background/30 pl-3 pr-2 py-2"
+              className="rounded-lg border border-border/50 pl-3 pr-2 py-2"
               style={{
+                background: 'var(--surface-2)',
                 boxShadow: familyHasSelection
-                  ? 'inset 2px 0 0 0 var(--accent-primary)'
-                  : 'inset 2px 0 0 0 color-mix(in hsl, var(--accent-secondary) 35%, transparent)',
+                  ? 'inset 2px 0 0 0 var(--accent-raw, var(--accent))'
+                  : 'inset 2px 0 0 0 color-mix(in srgb, var(--accent-raw, var(--accent)) 35%, transparent)',
               }}
             >
               <div className="flex items-center justify-between mb-1.5">
@@ -61,7 +62,7 @@ export function BossCheckboxList({ selectedBosses, onChange }: BossCheckboxListP
                       className={[
                         'flex items-center gap-3 rounded-md px-2 py-1.5 cursor-pointer transition-colors',
                         boss.selected
-                          ? 'bg-[color-mix(in_hsl,var(--accent-primary)_10%,transparent)]'
+                          ? 'bg-[var(--accent-soft)]'
                           : isLocked
                             ? 'opacity-55 hover:opacity-75'
                             : 'hover:bg-muted/40',
@@ -78,7 +79,7 @@ export function BossCheckboxList({ selectedBosses, onChange }: BossCheckboxListP
                       <span
                         className={[
                           'font-mono-nums text-xs tabular-nums',
-                          boss.selected ? 'text-[var(--accent-numeric)]' : 'text-muted-foreground',
+                          boss.selected ? 'text-[var(--accent-raw,var(--accent-numeric))]' : 'text-muted-foreground',
                         ].join(' ')}
                       >
                         {boss.formattedValue}

--- a/src/components/MuleDetailDrawer.tsx
+++ b/src/components/MuleDetailDrawer.tsx
@@ -31,7 +31,7 @@ function SectionHeading({ children }: { children: React.ReactNode }) {
       <span
         aria-hidden
         className="flex-1 h-px"
-        style={{ background: 'linear-gradient(90deg, color-mix(in hsl, var(--accent-secondary) 55%, transparent), transparent)' }}
+        style={{ background: 'linear-gradient(90deg, var(--accent-raw, var(--accent)), transparent)', opacity: 0.55 }}
       />
     </div>
   );
@@ -59,7 +59,8 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
       <SheetContent
         side="right"
         showCloseButton={false}
-        className="data-[side=right]:w-[640px] data-[side=right]:sm:max-w-[640px] overflow-y-auto p-0 bg-card border-l border-border/70"
+        className="data-[side=right]:w-[640px] data-[side=right]:sm:max-w-[640px] overflow-y-auto p-0"
+        style={{ background: 'var(--surface)', borderLeft: '1px solid var(--border)' }}
       >
         <SheetTitle className="sr-only">Mule Details</SheetTitle>
         <SheetDescription className="sr-only">Edit mule details and boss selection</SheetDescription>
@@ -68,12 +69,12 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
           <div
             aria-hidden
             className="absolute inset-x-0 -top-px h-px"
-            style={{ background: 'linear-gradient(90deg, transparent, var(--accent-primary), transparent)' }}
+            style={{ background: 'linear-gradient(90deg, transparent, var(--accent-raw, var(--accent-primary)), transparent)' }}
           />
           <div
             aria-hidden
             className="absolute -top-24 right-0 h-56 w-56 pointer-events-none blur-3xl opacity-30"
-            style={{ background: 'radial-gradient(closest-side, var(--accent-primary), transparent)' }}
+            style={{ background: 'radial-gradient(closest-side, var(--accent-raw, var(--accent-primary)), transparent)' }}
           />
 
           <div className="relative p-8 flex items-start gap-5 border-b border-border/50">
@@ -103,7 +104,10 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
                   </span>
                 )}
               </div>
-              <div className="mt-3 inline-flex items-baseline gap-2 rounded-lg border border-border/60 bg-background/40 px-3 py-1.5">
+              <div
+                className="mt-3 inline-flex items-baseline gap-2 rounded-lg border border-border/60 px-3 py-1.5"
+                style={{ background: 'var(--surface-2)' }}
+              >
                 <span className="font-sans text-[9px] uppercase tracking-[0.26em] text-muted-foreground">
                   Weekly
                 </span>
@@ -148,7 +152,7 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
                     placeholder="Enter name"
                     value={mule.name}
                     onChange={(e) => onUpdate(mule.id, { name: e.currentTarget.value })}
-                    className="bg-input/40 border-border/60 focus-visible:border-[var(--accent-primary)] focus-visible:ring-[var(--ring)]"
+                    className="bg-input/40 border-border/60 focus-visible:border-[var(--accent-raw,var(--accent))] focus-visible:ring-[var(--ring)]"
                   />
                 </div>
                 <div className="grid grid-cols-2 gap-3">
@@ -163,7 +167,7 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
                       min={0}
                       value={mule.level || ''}
                       onChange={(e) => onUpdate(mule.id, { level: Number(e.currentTarget.value) || 0 })}
-                      className="bg-input/40 border-border/60 focus-visible:border-[var(--accent-primary)] focus-visible:ring-[var(--ring)] font-mono-nums"
+                      className="bg-input/40 border-border/60 focus-visible:border-[var(--accent-raw,var(--accent))] focus-visible:ring-[var(--ring)] font-mono-nums"
                     />
                   </div>
                   <div className="space-y-1.5">
@@ -175,7 +179,7 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
                       placeholder="e.g. Bishop"
                       value={mule.muleClass}
                       onChange={(e) => onUpdate(mule.id, { muleClass: e.currentTarget.value })}
-                      className="bg-input/40 border-border/60 focus-visible:border-[var(--accent-primary)] focus-visible:ring-[var(--ring)]"
+                      className="bg-input/40 border-border/60 focus-visible:border-[var(--accent-raw,var(--accent))] focus-visible:ring-[var(--ring)]"
                     />
                   </div>
                 </div>


### PR DESCRIPTION
Implements #89. Token-layer restyle of MuleDetailDrawer and BossCheckboxList to handoff tokens (--accent-raw, --surface, --surface-2, --accent-soft). No structural changes.\n\nCloses #89