### PR TITLE
[Slice 5/8] MuleCard + AddCard replacement (#87)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -163,7 +163,10 @@ function AppContent() {
           >
             <SortableContext items={mules.map((m) => m.id)} strategy={rectSortingStrategy}>
               <div style={isDragging ? dragBoundaryStyle : {}} className="transition-[border-color,border-style,border-width,border-radius] duration-200" data-drag-boundary>
-                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-4">
+                <div
+                  className="grid gap-4"
+                  style={{ gridTemplateColumns: 'repeat(var(--roster-cols, 6), minmax(0, 1fr))' }}
+                >
                   {mules.map((mule) => (
                     <MuleCharacterCard
                       key={mule.id}

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -339,12 +339,12 @@ describe('App DnD interactions', () => {
     })
   })
 
-  it('applies filter during drag and restores on drag end', async () => {
+  it('reduces opacity during drag and restores on drag end', async () => {
     const { container } = render(<App />)
     const cardA = container.querySelector('[data-mule-card="mule-a"]') as HTMLElement
 
     fireEvent.mouseEnter(cardA)
-    expect(cardA.style.filter).toBeFalsy()
+    expect(cardA.style.opacity).toBe('1')
 
     fireEvent.pointerDown(cardA, {
       pointerId: 1, clientX: 100, clientY: 150,
@@ -356,7 +356,7 @@ describe('App DnD interactions', () => {
     })
 
     await waitFor(() => {
-      expect(cardA.style.filter).toBe('saturate(0.7) brightness(0.9)')
+      expect(cardA.style.opacity).toBe('0.7')
     })
 
     fireEvent.pointerUp(document, {
@@ -365,7 +365,7 @@ describe('App DnD interactions', () => {
     })
 
     await waitFor(() => {
-      expect(cardA.style.filter).toBeFalsy()
+      expect(cardA.style.opacity).toBe('1')
     })
   })
 

--- a/src/components/AddCard.tsx
+++ b/src/components/AddCard.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { Plus } from 'lucide-react'
 
 interface AddCardProps {
   onClick: () => void
@@ -7,52 +6,45 @@ interface AddCardProps {
 
 export function AddCard({ onClick }: AddCardProps) {
   const [isHovered, setIsHovered] = useState(false)
-
   return (
     <div
       data-add-card
       role="button"
       tabIndex={0}
       aria-label="Add mule"
-      className={[
-        'relative w-[200px] h-[300px] rounded-xl cursor-pointer',
-        'border-2 border-dashed',
-        'flex flex-col items-center justify-center gap-3',
-        'transition-[border-color,background-color,box-shadow] duration-200',
-        isHovered
-          ? 'border-[var(--accent-primary)] bg-[color-mix(in_hsl,var(--accent-primary)_6%,transparent)] shadow-[0_0_40px_-10px_var(--accent-primary)]'
-          : 'border-border/60 bg-transparent',
-      ].join(' ')}
       onClick={onClick}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          onClick()
-        }
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() }
       }}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
+      style={{
+        padding: 'var(--card-pad, 16px)',
+        borderRadius: 'var(--radius, 14px)',
+        border: '2px dashed',
+        borderColor: isHovered ? 'var(--accent-raw, var(--accent))' : 'var(--border)',
+        background: isHovered ? 'var(--accent-soft)' : 'transparent',
+        cursor: 'pointer',
+        display: 'grid',
+        placeItems: 'center',
+        transition: 'border-color 150ms, background 150ms',
+        minHeight: 160,
+      }}
     >
-      <div
-        aria-hidden
-        className={[
-          'flex items-center justify-center h-14 w-14 rounded-full transition-all duration-200',
-          isHovered
-            ? 'bg-[color-mix(in_hsl,var(--accent-primary)_15%,transparent)] text-[var(--accent-primary)]'
-            : 'bg-muted/40 text-muted-foreground',
-        ].join(' ')}
-      >
-        <Plus size={22} strokeWidth={2} />
-      </div>
-      <div className="flex flex-col items-center gap-1">
-        <span
-          className={[
-            'font-display text-lg font-semibold transition-colors',
-            isHovered ? 'text-foreground' : 'text-muted-foreground',
-          ].join(' ')}
-        >
-          Add Mule
-        </span>
+      <div style={{ display: 'grid', placeItems: 'center', gap: 10 }}>
+        <div style={{
+          width: 40, height: 40, borderRadius: '50%',
+          background: isHovered ? 'var(--accent-soft)' : 'var(--surface)',
+          border: '1px solid var(--border)',
+          display: 'grid', placeItems: 'center',
+          color: isHovered ? 'var(--accent-raw, var(--accent))' : 'var(--muted-raw, var(--muted-foreground))',
+          fontSize: 24, lineHeight: 1,
+          transition: 'background 150ms, color 150ms',
+        }}>+</div>
+        <span style={{
+          color: 'var(--muted-raw, var(--muted-foreground))',
+          fontSize: 13, fontWeight: 500,
+        }}>Add Mule</span>
       </div>
     </div>
   )

--- a/src/components/ClassSilhouette.tsx
+++ b/src/components/ClassSilhouette.tsx
@@ -1,0 +1,37 @@
+interface ClassSilhouetteProps {
+  klass: string
+  size?: number
+}
+
+export function ClassSilhouette({ klass, size = 72 }: ClassSilhouetteProps) {
+  const k = (klass || '').toLowerCase()
+  const body = (
+    <g>
+      <ellipse cx="36" cy="48" rx="18" ry="20" fill="currentColor" opacity="0.55" />
+      <ellipse cx="36" cy="30" rx="13" ry="14" fill="currentColor" opacity="0.55" />
+    </g>
+  )
+  let hat = null
+  if (k.includes('night lord')) {
+    hat = (
+      <g>
+        <path d="M16 22 Q36 10 56 22 L52 26 Q36 20 20 26 Z" fill="currentColor" opacity="0.9" />
+        <path d="M30 12 Q36 6 42 14 L38 22 L32 22 Z" fill="currentColor" opacity="0.9" />
+      </g>
+    )
+  } else if (k.includes('shadower')) {
+    hat = <path d="M22 30 Q22 14 36 14 Q50 14 50 30 L48 32 Q36 26 24 32 Z" fill="currentColor" opacity="0.9" />
+  } else if (k.includes('bishop') || k.includes('mage')) {
+    hat = <path d="M28 26 L36 8 L44 26 Z" fill="currentColor" opacity="0.9" />
+  } else if (k.includes('kaiser') || k.includes('adele') || k.includes('paladin') || k.includes('hero') || k.includes('dark knight')) {
+    hat = <path d="M24 24 L36 10 L48 24 Z" fill="currentColor" opacity="0.9" />
+  } else if (k) {
+    hat = <path d="M24 26 Q36 16 48 26 L46 28 Q36 22 26 28 Z" fill="currentColor" opacity="0.85" />
+  }
+  return (
+    <svg viewBox="0 0 72 72" width={size} height={size} style={{ color: 'var(--dim, var(--surface-dim))' }} aria-hidden>
+      {body}
+      {hat}
+    </svg>
+  )
+}

--- a/src/components/MuleCharacterCard.tsx
+++ b/src/components/MuleCharacterCard.tsx
@@ -3,14 +3,10 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import type { Mule } from '../types'
 import { useMuleIncome } from '../modules/income-hooks'
-import placeholderPng from '../assets/placeholder.png'
+import { ClassSilhouette } from './ClassSilhouette'
 
 interface MuleCharacterCardProps {
   mule: Mule
@@ -19,123 +15,100 @@ interface MuleCharacterCardProps {
 }
 
 export function MuleCharacterCard({ mule, onClick, onDelete }: MuleCharacterCardProps) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
-    useSortable({ id: mule.id })
-
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: mule.id })
   const { formatted: potentialIncome } = useMuleIncome(mule)
   const [isHovered, setIsHovered] = useState(false)
   const [popoverOpen, setPopoverOpen] = useState(false)
 
+  const hasBosses = mule.selectedBosses.length > 0
   const extraTransitions = isDragging
-    ? 'box-shadow 180ms, border-color 180ms, filter 180ms'
-    : 'box-shadow 180ms, transform 180ms, border-color 180ms, filter 180ms'
+    ? 'box-shadow 180ms, border-color 180ms'
+    : 'box-shadow 180ms, transform 180ms, border-color 180ms'
 
   const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition: [transition, extraTransitions].filter(Boolean).join(', '),
-    filter: isDragging ? 'saturate(0.7) brightness(0.9)' : undefined,
+    opacity: isDragging ? 0.7 : 1,
   }
 
-  function stopPropagation(e: React.SyntheticEvent) {
-    e.stopPropagation()
-  }
-
-  function handleDeleteConfirm() {
-    onDelete(mule.id)
-    setPopoverOpen(false)
-  }
-
-  function handleDeleteCancel() {
-    setPopoverOpen(false)
-  }
-
-  const hasBosses = mule.selectedBosses.length > 0
+  function stopPropagation(e: React.SyntheticEvent) { e.stopPropagation() }
+  function handleDeleteConfirm() { onDelete(mule.id); setPopoverOpen(false) }
+  function handleDeleteCancel() { setPopoverOpen(false) }
 
   return (
     <div
       ref={setNodeRef}
       style={style}
       data-mule-card={mule.id}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
       className="group relative"
       {...attributes}
       {...listeners}
     >
       <div
         onClick={onClick}
-        className={[
-          'relative w-[200px] h-[300px] rounded-xl overflow-hidden cursor-pointer',
-          'border border-border bg-card',
-          'ring-1 ring-inset ring-white/[0.06]',
-          'transition-[transform,box-shadow,border-color] duration-200',
-'hover:-translate-y-0.5 hover:border-[var(--accent-primary)]/60',
-'hover:shadow-[0_18px_40px_-18px_var(--accent-primary),0_0_0_1px_color-mix(in_hsl,var(--accent-primary)_35%,transparent)]',
-        ].join(' ')}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        className="panel cursor-pointer"
+        style={{
+          padding: 'var(--card-pad, 16px)',
+          transform: isHovered && !isDragging ? 'translateY(-2px)' : undefined,
+          boxShadow: isHovered && !isDragging
+            ? '0 8px 32px -8px var(--accent-glow), 0 0 0 1px var(--border)'
+            : '0 0 0 1px var(--border)',
+          transition: 'transform 150ms, box-shadow 150ms',
+        }}
         role="button"
         tabIndex={0}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            onClick()
-          }
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() }
         }}
       >
-        <div className="relative h-[62%] overflow-hidden">
-          <div
-            aria-hidden
-            className="absolute inset-0"
-            style={{
-              background: 'linear-gradient(180deg, var(--surface-raised) 0%, var(--card) 100%)',
-            }}
-          />
-          <img
-            src={placeholderPng}
-            alt={mule.name || 'Mule avatar'}
-            className="absolute inset-0 w-full h-full object-cover opacity-95 mix-blend-normal transition-transform duration-500 group-hover:scale-[1.04]"
-          />
-          <div
-            aria-hidden
-            className="absolute inset-x-0 bottom-0 h-16 pointer-events-none"
-            style={{ background: 'linear-gradient(180deg, transparent, var(--card) 92%)' }}
-          />
-          {mule.level > 0 && (
-            <span className="absolute top-2 left-2 font-mono-nums text-[10px] tracking-wide px-1.5 py-0.5 rounded border border-border/60 bg-background/70 backdrop-blur-sm text-[var(--accent-numeric)]">
-              Lv.{mule.level}
-            </span>
-          )}
+        {mule.level > 0 && (
+          <div style={{
+            position: 'absolute', top: 8, left: 8,
+            fontFamily: 'JetBrains Mono, monospace', fontSize: 10, letterSpacing: '0.1em',
+            color: 'var(--muted-raw, var(--muted-foreground))',
+            padding: '2px 6px', borderRadius: 4,
+            border: '1px solid var(--border)',
+            background: 'var(--surface-2, var(--surface-raised))',
+          }}>Lv.{mule.level}</div>
+        )}
+
+        <div style={{ display: 'grid', placeItems: 'center', padding: '16px 0 8px' }}>
+          <ClassSilhouette klass={mule.muleClass} size={72} />
         </div>
 
-        <div
-          aria-hidden
-          className="absolute left-3 right-3 h-px"
-          style={{
-            top: '62%',
-            background: 'linear-gradient(90deg, transparent, var(--accent-primary), transparent)',
-            opacity: 0.75,
-          }}
-        />
+        <div style={{ marginTop: 4 }}>
+          <div style={{
+            color: mule.name ? 'var(--text, var(--foreground))' : 'var(--muted-raw, var(--muted-foreground))',
+            fontWeight: 600,
+            fontSize: 'var(--mule-name-size, 14px)',
+            fontStyle: mule.name ? 'normal' : 'italic',
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}>
+            {mule.name || 'Unnamed'}
+          </div>
+          <div style={{
+            color: 'var(--muted-raw, var(--muted-foreground))',
+            fontFamily: 'JetBrains Mono, monospace', fontSize: 10,
+            letterSpacing: '0.1em', textTransform: 'uppercase', marginTop: 2,
+          }}>
+            {mule.muleClass || 'No class'}
+          </div>
+        </div>
 
-        <div className="relative h-[38%] px-3 py-3 flex flex-col justify-between">
-          <div className="min-w-0">
-            <p className="font-display text-base font-bold leading-tight truncate">
-              {mule.name || <span className="text-muted-foreground italic font-normal">Unnamed</span>}
-            </p>
-            <p className="mt-0.5 font-sans text-[10px] uppercase tracking-[0.22em] text-[var(--accent-secondary)] truncate">
-              {mule.muleClass || <span className="text-muted-foreground/70">no class</span>}
-            </p>
-          </div>
-          <div className="flex items-baseline justify-between gap-2">
-            <span className="font-sans text-[9px] uppercase tracking-[0.22em] text-muted-foreground">
-              weekly
-            </span>
-            <span className={[
-              'font-mono-nums text-sm',
-              hasBosses ? 'text-[var(--accent-numeric)]' : 'text-muted-foreground/60',
-            ].join(' ')}>
-              {potentialIncome}
-            </span>
-          </div>
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          marginTop: 10, paddingTop: 8, borderTop: '1px solid var(--border)',
+        }}>
+          <span style={{
+            color: 'var(--muted-raw, var(--muted-foreground))',
+            fontFamily: 'JetBrains Mono, monospace', fontSize: 10, letterSpacing: '0.12em',
+          }}>WEEKLY</span>
+          <span style={{
+            color: hasBosses ? 'var(--accent-raw, var(--accent))' : 'var(--dim, var(--surface-dim))',
+            fontFamily: 'JetBrains Mono, monospace', fontSize: 13, fontWeight: 600,
+          }}>{potentialIncome}</span>
         </div>
 
         <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
@@ -143,33 +116,29 @@ export function MuleCharacterCard({ mule, onClick, onDelete }: MuleCharacterCard
             render={
               <button
                 aria-label="Delete mule"
-                className="absolute top-2 right-2 p-1.5 rounded-md text-red-200 hover:text-white bg-black/40 hover:bg-destructive/80 border border-white/10 backdrop-blur-sm"
                 style={{
+                  position: 'absolute', top: 8, right: 8,
+                  padding: '4px 6px', borderRadius: 4,
+                  background: 'var(--surface-2, var(--surface-raised))',
+                  border: '1px solid var(--border)',
+                  color: 'var(--muted-raw, var(--muted-foreground))',
                   opacity: isHovered || popoverOpen ? 1 : 0,
-                  transition: 'opacity 140ms, background-color 140ms, color 140ms',
+                  transition: 'opacity 140ms',
+                  cursor: 'pointer',
+                  display: 'flex', alignItems: 'center',
                 }}
                 onClick={stopPropagation}
                 onPointerDown={stopPropagation}
               />
             }
           >
-            <Trash2 className="h-3.5 w-3.5" />
+            <Trash2 style={{ width: 14, height: 14 }} />
           </PopoverTrigger>
-          <PopoverContent
-            className="w-auto p-3"
-            side="bottom"
-            align="end"
-            onClick={stopPropagation}
-            onPointerDown={stopPropagation}
-          >
+          <PopoverContent className="w-auto p-3" side="bottom" align="end" onClick={stopPropagation} onPointerDown={stopPropagation}>
             <div className="flex items-center gap-2">
-              <span className="font-sans text-sm">Delete this mule?</span>
-              <Button size="sm" variant="destructive" onClick={handleDeleteConfirm}>
-                Yes
-              </Button>
-              <Button size="sm" variant="outline" onClick={handleDeleteCancel}>
-                Cancel
-              </Button>
+              <span className="text-sm">Delete this mule?</span>
+              <Button size="sm" variant="destructive" onClick={handleDeleteConfirm}>Yes</Button>
+              <Button size="sm" variant="outline" onClick={handleDeleteCancel}>Cancel</Button>
             </div>
           </PopoverContent>
         </Popover>

--- a/src/components/__tests__/MuleCharacterCard.test.tsx
+++ b/src/components/__tests__/MuleCharacterCard.test.tsx
@@ -73,7 +73,7 @@ describe('MuleCharacterCard', () => {
 
   it('renders income text', () => {
     renderCard()
-    expect(screen.getByText('weekly')).toBeTruthy()
+    expect(screen.getByText(/weekly/i)).toBeTruthy()
     expect(screen.getByText('0')).toBeTruthy()
   })
 
@@ -87,15 +87,15 @@ describe('MuleCharacterCard', () => {
     expect(screen.getByText('504,000,000')).toBeTruthy()
   })
 
-  it('reduces opacity on hover and restores on mouse leave', () => {
+  it('keeps card opacity at 1 when not dragging', () => {
     const { container } = renderCard()
     const cardWrapper = container.querySelector('[data-mule-card]') as HTMLElement
-    // Hover effects use CSS classes; card wrapper has no inline opacity
-    expect(cardWrapper.style.opacity).toBe('')
+    // Opacity stays at 1 regardless of hover; only drop during active drag.
+    expect(cardWrapper.style.opacity).toBe('1')
     fireEvent.mouseEnter(cardWrapper)
-    expect(cardWrapper.style.opacity).toBe('')
+    expect(cardWrapper.style.opacity).toBe('1')
     fireEvent.mouseLeave(cardWrapper)
-    expect(cardWrapper.style.opacity).toBe('')
+    expect(cardWrapper.style.opacity).toBe('1')
   })
 
   describe('trash icon and delete popover', () => {
@@ -105,7 +105,8 @@ describe('MuleCharacterCard', () => {
       expect(trashButton.style.opacity).toBe('0')
 
       const cardWrapper = container.querySelector('[data-mule-card]') as HTMLElement
-      fireEvent.mouseEnter(cardWrapper)
+      const panel = cardWrapper.querySelector('.panel') as HTMLElement
+      fireEvent.mouseEnter(panel)
       expect(trashButton.style.opacity).toBe('1')
     })
 
@@ -113,11 +114,12 @@ describe('MuleCharacterCard', () => {
       const { container } = renderCard()
       const trashButton = screen.getByRole('button', { name: /delete/i })
       const cardWrapper = container.querySelector('[data-mule-card]') as HTMLElement
+      const panel = cardWrapper.querySelector('.panel') as HTMLElement
 
-      fireEvent.mouseEnter(cardWrapper)
+      fireEvent.mouseEnter(panel)
       expect(trashButton.style.opacity).toBe('1')
 
-      fireEvent.mouseLeave(cardWrapper)
+      fireEvent.mouseLeave(panel)
       expect(trashButton.style.opacity).toBe('0')
     })
 


### PR DESCRIPTION
Implements #87. Replaces MuleCharacterCard with handoff .panel shell + ClassSilhouette SVG. Replaces AddCard with dashed-border style. Preserves dnd-kit drag and delete popover. Updates App.tsx roster grid to use --roster-cols.

Closes #87