### PR TITLE
[Slice 8/8] Playwright visual regression tests (#90)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Playwright
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/e2e/dnd.spec.ts
+++ b/e2e/dnd.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+import { seedApp } from './fixtures/seed'
+
+test('can drag a mule card to reorder', async ({ page }) => {
+  await seedApp(page, { theme: 'dark', density: 'comfy' })
+  await page.goto('/')
+  await page.waitForLoadState('networkidle')
+
+  const alpha = page.locator('[data-mule-card="mule-a"]')
+  const beta = page.locator('[data-mule-card="mule-b"]')
+
+  const alphaBox = await alpha.boundingBox()
+  const betaBox = await beta.boundingBox()
+  if (!alphaBox || !betaBox) throw new Error('card bounding box missing')
+
+  // Drag alpha past beta
+  await page.mouse.move(alphaBox.x + alphaBox.width / 2, alphaBox.y + alphaBox.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(alphaBox.x + 10, alphaBox.y + 10, { steps: 5 })
+  await page.mouse.move(betaBox.x + betaBox.width / 2, betaBox.y + betaBox.height / 2, { steps: 10 })
+  await page.mouse.up()
+
+  // After drop, beta should be before alpha in DOM order
+  const cards = page.locator('[data-mule-card]')
+  const ids = await cards.evaluateAll((els) => els.map((el) => el.getAttribute('data-mule-card')))
+  expect(ids.indexOf('mule-b')).toBeLessThan(ids.indexOf('mule-a'))
+})

--- a/e2e/fixtures/seed.ts
+++ b/e2e/fixtures/seed.ts
@@ -1,0 +1,21 @@
+import type { Page } from '@playwright/test'
+
+export const SEED_MULES = [
+  { id: 'mule-a', name: 'Alpha', level: 275, muleClass: 'Bishop', selectedBosses: ['hard-lucid', 'normal-damien'] },
+  { id: 'mule-b', name: 'Beta', level: 260, muleClass: 'Night Lord', selectedBosses: ['chaos-papulatus'] },
+  { id: 'mule-c', name: 'Gamma', level: 245, muleClass: 'Shadower', selectedBosses: [] },
+]
+
+export async function seedApp(
+  page: Page,
+  opts: { theme: 'dark' | 'light'; density: 'comfy' | 'compact' },
+) {
+  await page.addInitScript(
+    ({ theme, density, mules }) => {
+      localStorage.setItem('theme', theme)
+      localStorage.setItem('density', density)
+      localStorage.setItem('maplestory-mule-tracker', JSON.stringify(mules))
+    },
+    { ...opts, mules: SEED_MULES },
+  )
+}

--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test'
+import { seedApp } from './fixtures/seed'
+
+test('theme and density persist across reload', async ({ page }) => {
+  await seedApp(page, { theme: 'light', density: 'compact' })
+  await page.goto('/')
+  await expect(page.locator('html')).toHaveAttribute('data-density', 'compact')
+  await expect(page.locator('body')).toHaveClass(/light/)
+
+  await page.reload()
+  await expect(page.locator('html')).toHaveAttribute('data-density', 'compact')
+  await expect(page.locator('body')).toHaveClass(/light/)
+})
+
+test('toggling density updates data-density attribute live', async ({ page }) => {
+  await seedApp(page, { theme: 'dark', density: 'comfy' })
+  await page.goto('/')
+  await expect(page.locator('html')).toHaveAttribute('data-density', 'comfy')
+
+  await page.getByRole('radio', { name: /compact/i }).click()
+  await expect(page.locator('html')).toHaveAttribute('data-density', 'compact')
+})

--- a/e2e/visual.spec.ts
+++ b/e2e/visual.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test'
+import { seedApp } from './fixtures/seed'
+
+const COMBOS = [
+  { theme: 'dark', density: 'comfy' },
+  { theme: 'dark', density: 'compact' },
+  { theme: 'light', density: 'comfy' },
+  { theme: 'light', density: 'compact' },
+] as const
+
+for (const combo of COMBOS) {
+  test(`renders correctly: ${combo.theme}/${combo.density}`, async ({ page }) => {
+    await seedApp(page, combo)
+    await page.goto('/')
+    // Wait for fonts and layout to settle
+    await page.waitForLoadState('networkidle')
+    await page.waitForTimeout(500)
+    await expect(page).toHaveScreenshot(`app-${combo.theme}-${combo.density}.png`, {
+      fullPage: true,
+      maxDiffPixelRatio: 0.02,
+    })
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.2.2",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^24.12.2",
@@ -2724,6 +2725,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -7838,6 +7855,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
+    "e2e": "playwright test",
+    "e2e:update": "playwright test --update-snapshots",
     "sandcastle": "npx tsx .sandcastle/main.ts",
     "worktree:prune": "git worktree prune && git branch | grep -vE \"^(main|master)$\" | xargs git branch -D"
   },
@@ -36,6 +38,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.2",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^24.12.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium', viewport: { width: 1440, height: 900 } },
+    },
+  ],
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,5 +15,6 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['src/test/setup.ts'],
+    exclude: ['node_modules', 'dist', '.idea', '.git', '.cache', 'e2e/**'],
   },
 })


### PR DESCRIPTION
Implements #90. Adds Playwright with 4 screenshot tests (dark/light × comfy/compact), drag-and-drop interaction test, and localStorage persistence tests. Excludes e2e/ from vitest.

## Notes on baseline snapshots

Playwright is configured and ready to run, but baseline `.png` snapshots were not generated in this PR: the sandbox environment is missing the `libnspr4` system library required by Chromium (`playwright install --with-deps` requires sudo, which is not available). Snapshots will need to be generated the first time these tests run in CI (or locally on a machine with the required system deps).

To regenerate snapshots locally:
```
npx playwright install --with-deps chromium
npm run e2e:update
```

## Verification

- `npm test` — 174 vitest tests pass (e2e/ excluded via `vite.config.ts` `exclude` list)
- `npm run build` — has a pre-existing TS6133 error in `src/App.tsx` unrelated to this PR
- `npm run e2e` — ready to run in CI (blocked locally by missing system libs as noted above)

Closes #90