### PR TITLE
1A: Boss schema + data rewrite (legacy-id shim)

### DIFF
--- a/src/components/BossCheckboxList.tsx
+++ b/src/components/BossCheckboxList.tsx
@@ -3,10 +3,10 @@ import { Search } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
-import { toggleBoss, getFamilies, type BossDifficulty } from '../data/bossSelection';
+import { toggleBoss, getFamilies, type BossDifficultyLabel } from '../data/bossSelection';
 import { useFormatPreference } from '../modules/income-hooks';
 
-const DIFF_COLOR: Record<BossDifficulty, string> = {
+const DIFF_COLOR: Record<BossDifficultyLabel, string> = {
   Extreme: '#e8533a',
   Chaos: '#c94f8f',
   Hard: '#d98a3a',

--- a/src/data/__tests__/bosses.test.ts
+++ b/src/data/__tests__/bosses.test.ts
@@ -199,7 +199,7 @@ describe('getLegacyBoss', () => {
   );
 
   it('every resolved uuid points to a real Boss whose difficulty[] contains the resolved tier', () => {
-    for (const [legacyId, expectedTier, expectedCrystalValue] of LEGACY_IDS) {
+    for (const [legacyId, , expectedCrystalValue] of LEGACY_IDS) {
       const { uuid, tier, crystalValue } = getLegacyBoss(legacyId)!;
       const boss = getBossById(uuid) as Boss;
       expect(boss).toBeDefined();

--- a/src/data/__tests__/bosses.test.ts
+++ b/src/data/__tests__/bosses.test.ts
@@ -1,41 +1,243 @@
-import { describe, expect, it } from 'vitest'
-import { bosses, calculatePotentialIncome, getBossById } from '../bosses'
+import { describe, expect, it } from 'vitest';
+import {
+  bosses,
+  calculatePotentialIncome,
+  getBossById,
+  getLegacyBoss,
+  ALL_BOSS_IDS,
+} from '../bosses';
+import type { Boss, BossTier, BossContentType } from '../../types';
 
-describe('calculatePotentialIncome', () => {
-  it('returns 0 for empty selection', () => {
-    expect(calculatePotentialIncome([])).toBe(0)
-  })
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-  it('returns crystal value for single boss', () => {
-    expect(calculatePotentialIncome(['hard-lucid'])).toBe(504000000)
-  })
+// All 80 legacy ids from the pre-1A flat dataset. Every one of these
+// must round-trip through getLegacyBoss() to preserve existing mule selections.
+const LEGACY_IDS: Array<readonly [string, BossTier, number]> = [
+  ['extreme-black-mage', 'extreme', 18000000000],
+  ['extreme-kaling', 'extreme', 6026000000],
+  ['extreme-first-adversary', 'extreme', 5880000000],
+  ['extreme-kalos-the-guardian', 'extreme', 5200000000],
+  ['hard-black-mage', 'hard', 4500000000],
+  ['extreme-chosen-seren', 'extreme', 4235000000],
+  ['hard-baldrix', 'hard', 4200000000],
+  ['hard-limbo', 'hard', 3745000000],
+  ['hard-kaling', 'hard', 2990000000],
+  ['hard-first-adversary', 'hard', 2940000000],
+  ['normal-baldrix', 'normal', 2800000000],
+  ['chaos-kalos-the-guardian', 'chaos', 2600000000],
+  ['normal-limbo', 'normal', 2100000000],
+  ['normal-kaling', 'normal', 1506500000],
+  ['extreme-lotus', 'extreme', 1397500000],
+  ['normal-first-adversary', 'normal', 1365000000],
+  ['normal-kalos-the-guardian', 'normal', 1300000000],
+  ['hard-chosen-seren', 'hard', 1096562500],
+  ['easy-kaling', 'easy', 1031250000],
+  ['easy-first-adversary', 'easy', 985000000],
+  ['easy-kalos-the-guardian', 'easy', 937500000],
+  ['normal-chosen-seren', 'normal', 889021875],
+  ['hard-verus-hilla', 'hard', 762105000],
+  ['hard-darknell', 'hard', 667920000],
+  ['hard-will', 'hard', 621810000],
+  ['chaos-guardian-angel-slime', 'chaos', 600578125],
+  ['normal-verus-hilla', 'normal', 581880000],
+  ['chaos-gloom', 'chaos', 563945000],
+  ['hard-lucid', 'hard', 504000000],
+  ['hard-lotus', 'hard', 444675000],
+  ['hard-damien', 'hard', 421875000],
+  ['normal-darknell', 'normal', 316875000],
+  ['normal-gloom', 'normal', 297675000],
+  ['normal-will', 'normal', 279075000],
+  ['normal-lucid', 'normal', 253828125],
+  ['easy-will', 'easy', 246744750],
+  ['easy-lucid', 'easy', 237009375],
+  ['normal-guardian-angel-slime', 'normal', 231673500],
+  ['normal-damien', 'normal', 169000000],
+  ['normal-lotus', 'normal', 162562500],
+  ['akechi-mitsuhide', 'normal', 144000000],
+  ['chaos-papulatus', 'chaos', 132250000],
+  ['chaos-vellum', 'chaos', 105062500],
+  ['hard-magnus', 'hard', 95062500],
+  ['princess-no', 'normal', 81000000],
+  ['chaos-zakum', 'chaos', 81000000],
+  ['chaos-pierre', 'chaos', 81000000],
+  ['chaos-von-bon', 'chaos', 81000000],
+  ['chaos-crimson-queen', 'chaos', 81000000],
+  ['normal-cygnus', 'normal', 72250000],
+  ['chaos-pink-bean', 'chaos', 64000000],
+  ['hard-hilla', 'hard', 56250000],
+  ['easy-cygnus', 'easy', 45562500],
+  ['hard-mori-ranmaru', 'hard', 13322500],
+  ['normal-papulatus', 'normal', 13322500],
+  ['normal-magnus', 'normal', 12960000],
+  ['normal-arkarium', 'normal', 12602500],
+  ['hard-von-leon', 'hard', 12250000],
+  ['normal-von-leon', 'normal', 7290000],
+  ['normal-pink-bean', 'normal', 7022500],
+  ['chaos-horntail', 'chaos', 6760000],
+  ['omni-cln', 'normal', 6250000],
+  ['easy-arkarium', 'easy', 5760000],
+  ['easy-von-leon', 'easy', 5290000],
+  ['normal-horntail', 'normal', 5062500],
+  ['normal-pierre', 'normal', 4840000],
+  ['normal-von-bon', 'normal', 4840000],
+  ['normal-crimson-queen', 'normal', 4840000],
+  ['normal-vellum', 'normal', 4840000],
+  ['easy-horntail', 'easy', 4410000],
+  ['normal-mori-ranmaru', 'normal', 4202500],
+  ['normal-hilla', 'normal', 4000000],
+  ['easy-magnus', 'easy', 3610000],
+  ['easy-papulatus', 'easy', 3422500],
+  ['normal-zakum', 'normal', 3062500],
+  ['easy-zakum', 'easy', 1000000],
+];
 
-  it('sums crystal values for multiple bosses', () => {
-    expect(calculatePotentialIncome(['hard-lucid', 'hard-will'])).toBe(
-      504000000 + 621810000
-    )
-  })
+describe('bosses data (Matrix schema)', () => {
+  it('exposes exactly one Boss per family', () => {
+    const families = new Set(bosses.map((b) => b.family));
+    expect(families.size).toBe(bosses.length);
+    // Guard against drift: the pre-1A dataset had 32 distinct families
+    // (issue #99 approximates as ~26).
+    expect(bosses.length).toBe(32);
+  });
 
-  it('ignores unknown boss IDs and sums the rest', () => {
-    expect(calculatePotentialIncome(['hard-lucid', 'unknown-boss'])).toBe(504000000)
-  })
-})
+  it('every Boss has a stable UUIDv4 id', () => {
+    for (const boss of bosses) {
+      expect(boss.id, `${boss.family} must have a UUID id`).toMatch(UUID_V4);
+    }
+  });
+
+  it('Boss ids are unique', () => {
+    const ids = new Set(bosses.map((b) => b.id));
+    expect(ids.size).toBe(bosses.length);
+  });
+
+  it('display name has no difficulty prefix', () => {
+    const blackMage = bosses.find((b) => b.family === 'black-mage')!;
+    expect(blackMage.name).toBe('Black Mage');
+
+    const lotus = bosses.find((b) => b.family === 'lotus')!;
+    expect(lotus.name).toBe('Lotus');
+
+    const kalos = bosses.find((b) => b.family === 'kalos-the-guardian')!;
+    expect(kalos.name).toBe('Kalos the Guardian');
+  });
+
+  it('every difficulty entry is seeded with contentType "weekly"', () => {
+    for (const boss of bosses) {
+      for (const d of boss.difficulty) {
+        const expected: BossContentType = 'weekly';
+        expect(d.contentType).toBe(expected);
+      }
+    }
+  });
+
+  it('every difficulty entry has a valid BossTier', () => {
+    const validTiers: BossTier[] = ['easy', 'normal', 'hard', 'chaos', 'extreme'];
+    for (const boss of bosses) {
+      for (const d of boss.difficulty) {
+        expect(validTiers).toContain(d.tier);
+      }
+    }
+  });
+
+  it('tier-less bosses collapse to a single { tier: "normal", ... } entry', () => {
+    for (const family of ['akechi-mitsuhide', 'omni-cln', 'princess-no']) {
+      const boss = bosses.find((b) => b.family === family)!;
+      expect(boss, `family ${family} should exist`).toBeDefined();
+      expect(boss.difficulty).toHaveLength(1);
+      expect(boss.difficulty[0].tier).toBe('normal');
+      expect(boss.difficulty[0].contentType).toBe('weekly');
+    }
+  });
+
+  it('names of tier-less bosses stay intact', () => {
+    expect(bosses.find((b) => b.family === 'akechi-mitsuhide')!.name).toBe('Akechi Mitsuhide');
+    expect(bosses.find((b) => b.family === 'omni-cln')!.name).toBe('OMNI-CLN');
+    expect(bosses.find((b) => b.family === 'princess-no')!.name).toBe('Princess No');
+  });
+
+  it('ALL_BOSS_IDS contains every Boss id (family-level)', () => {
+    for (const boss of bosses) {
+      expect(ALL_BOSS_IDS.has(boss.id)).toBe(true);
+    }
+    expect(ALL_BOSS_IDS.size).toBe(bosses.length);
+  });
+});
 
 describe('getBossById', () => {
-  it('returns boss by id', () => {
-    const boss = getBossById('hard-lucid')
-    expect(boss).toBeDefined()
-    expect(boss!.name).toBe('Hard Lucid')
-    expect(boss!.crystalValue).toBe(504000000)
-  })
+  it('returns boss by its UUID id', () => {
+    const lucid = bosses.find((b) => b.family === 'lucid')!;
+    expect(getBossById(lucid.id)).toBe(lucid);
+  });
 
-  it('returns undefined for unknown boss id', () => {
-    expect(getBossById('nonexistent-boss')).toBeUndefined()
-  })
+  it('returns undefined for unknown id', () => {
+    expect(getBossById('nonexistent-boss')).toBeUndefined();
+  });
 
-  it('every boss in the bosses array is retrievable by id', () => {
+  it('every Boss is retrievable by its id', () => {
     for (const boss of bosses) {
-      expect(getBossById(boss.id)).toBe(boss)
+      expect(getBossById(boss.id)).toBe(boss);
     }
-  })
-})
+  });
+});
+
+describe('getLegacyBoss', () => {
+  it('returns undefined for an unknown legacy id', () => {
+    expect(getLegacyBoss('totally-fake-id')).toBeUndefined();
+  });
+
+  it.each(LEGACY_IDS)(
+    'maps legacy id %s to { uuid, tier: %s, crystalValue: %d, contentType: "weekly" }',
+    (legacyId, expectedTier, expectedCrystalValue) => {
+      const result = getLegacyBoss(legacyId);
+      expect(result, `legacy id ${legacyId} must resolve`).toBeDefined();
+      expect(result!.uuid).toMatch(UUID_V4);
+      expect(result!.tier).toBe(expectedTier);
+      expect(result!.crystalValue).toBe(expectedCrystalValue);
+      expect(result!.contentType).toBe('weekly');
+    },
+  );
+
+  it('every resolved uuid points to a real Boss whose difficulty[] contains the resolved tier', () => {
+    for (const [legacyId, expectedTier, expectedCrystalValue] of LEGACY_IDS) {
+      const { uuid, tier, crystalValue } = getLegacyBoss(legacyId)!;
+      const boss = getBossById(uuid) as Boss;
+      expect(boss).toBeDefined();
+      const diff = boss.difficulty.find((d) => d.tier === tier);
+      expect(diff, `${legacyId} → ${boss.family}:${tier}`).toBeDefined();
+      expect(diff!.crystalValue).toBe(expectedCrystalValue);
+      expect(diff!.crystalValue).toBe(crystalValue);
+    }
+  });
+
+  it('covers every legacy id in the pre-1A dataset', () => {
+    // The pre-1A flat dataset held 76 rows (issue #99 approximates as "80").
+    expect(LEGACY_IDS).toHaveLength(76);
+  });
+});
+
+describe('calculatePotentialIncome (legacy-id compatible)', () => {
+  it('returns 0 for empty selection', () => {
+    expect(calculatePotentialIncome([])).toBe(0);
+  });
+
+  it('returns crystal value for a single legacy id', () => {
+    expect(calculatePotentialIncome(['hard-lucid'])).toBe(504000000);
+  });
+
+  it('sums crystal values for multiple legacy ids', () => {
+    expect(calculatePotentialIncome(['hard-lucid', 'hard-will'])).toBe(
+      504000000 + 621810000,
+    );
+  });
+
+  it('ignores unknown legacy ids and sums the rest', () => {
+    expect(calculatePotentialIncome(['hard-lucid', 'unknown-boss'])).toBe(504000000);
+  });
+
+  it('handles tier-less legacy ids (akechi-mitsuhide, princess-no, omni-cln)', () => {
+    expect(calculatePotentialIncome(['akechi-mitsuhide'])).toBe(144000000);
+    expect(calculatePotentialIncome(['princess-no'])).toBe(81000000);
+    expect(calculatePotentialIncome(['omni-cln'])).toBe(6250000);
+  });
+});

--- a/src/data/bossSelection.ts
+++ b/src/data/bossSelection.ts
@@ -1,13 +1,45 @@
-import { bossFamilies, ALL_BOSS_IDS, getBossById } from './bosses';
+import type { BossTier } from '../types';
+import { bosses, getLegacyBoss } from './bosses';
 import { formatMeso } from '../utils/meso';
+
+/**
+ * Difficulty labels used by the pre-1A UI (capitalized tier words).
+ * Kept as strings during slice 1A so BossCheckboxList can keep rendering
+ * difficulty pips exactly as before; internally derived from the new
+ * lowercase `BossTier` union.
+ */
+export type BossDifficulty = 'Extreme' | 'Chaos' | 'Hard' | 'Normal' | 'Easy';
+
+const TIER_LABEL: Record<BossTier, BossDifficulty> = {
+  easy: 'Easy',
+  normal: 'Normal',
+  hard: 'Hard',
+  chaos: 'Chaos',
+  extreme: 'Extreme',
+};
+
+const TIER_LESS_FAMILIES = new Set(['akechi-mitsuhide', 'omni-cln', 'princess-no']);
 
 const DIFFICULTY_PREFIX = /^(Extreme|Chaos|Hard|Normal|Easy) /;
 
-export type BossDifficulty = 'Extreme' | 'Chaos' | 'Hard' | 'Normal' | 'Easy';
-
+/** Pre-1A helper: parse a legacy display name into its difficulty label. */
 export function getDifficulty(name: string): BossDifficulty | null {
   const m = name.match(DIFFICULTY_PREFIX);
   return (m?.[1] as BossDifficulty) ?? null;
+}
+
+/**
+ * Reconstruct the legacy display name for a `(family, tier)` pair. Preserves
+ * the exact strings the pre-1A UI rendered (e.g. "Hard Lucid", "Akechi Mitsuhide").
+ */
+function legacyDisplayName(family: string, tier: BossTier, familyName: string): string {
+  if (TIER_LESS_FAMILIES.has(family)) return familyName;
+  return `${TIER_LABEL[tier]} ${familyName}`;
+}
+
+/** Legacy id for a `(family, tier)` pair. Round-trips through `getLegacyBoss`. */
+function legacyId(family: string, tier: BossTier): string {
+  return TIER_LESS_FAMILIES.has(family) ? family : `${tier}-${family}`;
 }
 
 export interface FamilyView {
@@ -24,46 +56,67 @@ export interface FamilyView {
 }
 
 export function validateBossSelection(ids: string[]): string[] {
-  const valid = ids.filter((id) => ALL_BOSS_IDS.has(id));
+  const valid = ids.filter((id) => getLegacyBoss(id) !== undefined);
   const familyWinners = new Map<string, string>();
   for (const id of valid) {
-    const boss = getBossById(id)!;
-    const currentWinner = familyWinners.get(boss.family);
-    if (!currentWinner || boss.crystalValue > getBossById(currentWinner)!.crystalValue) {
-      familyWinners.set(boss.family, id);
+    const ref = getLegacyBoss(id)!;
+    const currentWinner = familyWinners.get(ref.uuid);
+    const currentValue = currentWinner ? getLegacyBoss(currentWinner)!.crystalValue : -Infinity;
+    if (ref.crystalValue > currentValue) {
+      familyWinners.set(ref.uuid, id);
     }
   }
   const winnerIds = new Set(familyWinners.values());
   return valid.filter((id) => winnerIds.has(id));
 }
 
-export function toggleBoss(selectedIds: string[], bossId: string): string[] {
-  const boss = getBossById(bossId);
-  if (!boss) return selectedIds;
+export function toggleBoss(selectedIds: string[], bossLegacyId: string): string[] {
+  const ref = getLegacyBoss(bossLegacyId);
+  if (!ref) return selectedIds;
   const existingId = selectedIds.find((id) => {
-    const b = getBossById(id);
-    return b?.family === boss.family;
+    const r = getLegacyBoss(id);
+    return r?.uuid === ref.uuid;
   });
-  if (existingId === bossId) return selectedIds.filter((id) => id !== bossId);
-  if (existingId) return selectedIds.map((id) => (id === existingId ? bossId : id));
-  return [...selectedIds, bossId];
+  if (existingId === bossLegacyId) return selectedIds.filter((id) => id !== bossLegacyId);
+  if (existingId) return selectedIds.map((id) => (id === existingId ? bossLegacyId : id));
+  return [...selectedIds, bossLegacyId];
 }
 
-export function getFamilies(selectedIds: string[], search: string, { abbreviated = true }: { abbreviated?: boolean } = {}): FamilyView[] {
+export function getFamilies(
+  selectedIds: string[],
+  search: string,
+  { abbreviated = true }: { abbreviated?: boolean } = {},
+): FamilyView[] {
   const selectedSet = new Set(selectedIds);
 
-  const families: FamilyView[] = bossFamilies.map((bf) => ({
-    family: bf.family,
-    displayName: bf.bosses[0].name.replace(DIFFICULTY_PREFIX, ''),
-    bosses: bf.bosses.map((b) => ({
-      id: b.id,
-      name: b.name,
-      crystalValue: b.crystalValue,
-      formattedValue: formatMeso(b.crystalValue, abbreviated),
-      difficulty: getDifficulty(b.name),
-      selected: selectedSet.has(b.id),
-    })),
-  }));
+  // Build FamilyView rows from the new Boss[] shape. Each family produces
+  // one row whose `bosses` list is a sorted (crystalValue desc) expansion
+  // of the difficulty[] array — mirroring the pre-1A per-tier rows.
+  const families: FamilyView[] = bosses
+    .slice()
+    .sort((a, b) => {
+      const topA = Math.max(...a.difficulty.map((d) => d.crystalValue));
+      const topB = Math.max(...b.difficulty.map((d) => d.crystalValue));
+      return topB - topA;
+    })
+    .map((boss) => ({
+      family: boss.family,
+      displayName: boss.name,
+      bosses: boss.difficulty
+        .slice()
+        .sort((a, b) => b.crystalValue - a.crystalValue)
+        .map((diff) => {
+          const id = legacyId(boss.family, diff.tier);
+          return {
+            id,
+            name: legacyDisplayName(boss.family, diff.tier, boss.name),
+            crystalValue: diff.crystalValue,
+            formattedValue: formatMeso(diff.crystalValue, abbreviated),
+            difficulty: TIER_LESS_FAMILIES.has(boss.family) ? null : TIER_LABEL[diff.tier],
+            selected: selectedSet.has(id),
+          };
+        }),
+    }));
 
   if (!search) return families;
 
@@ -71,6 +124,7 @@ export function getFamilies(selectedIds: string[], search: string, { abbreviated
   return families.filter(
     (f) =>
       f.family.toLowerCase().includes(lower) ||
+      f.displayName.toLowerCase().includes(lower) ||
       f.bosses.some((b) => b.name.toLowerCase().includes(lower)),
   );
 }

--- a/src/data/bossSelection.ts
+++ b/src/data/bossSelection.ts
@@ -1,16 +1,15 @@
 import type { BossTier } from '../types';
-import { bosses, getLegacyBoss } from './bosses';
+import { bosses, getLegacyBoss, legacyIdFor, TIER_LESS_FAMILIES } from './bosses';
 import { formatMeso } from '../utils/meso';
 
 /**
- * Difficulty labels used by the pre-1A UI (capitalized tier words).
- * Kept as strings during slice 1A so BossCheckboxList can keep rendering
- * difficulty pips exactly as before; internally derived from the new
- * lowercase `BossTier` union.
+ * Capitalized difficulty labels used by the pre-1A UI (renders "Hard Lucid",
+ * difficulty pip colors, etc.). Distinct from the `BossDifficulty` *interface*
+ * in `../types` that holds the new `{ tier, crystalValue, contentType }` shape.
  */
-export type BossDifficulty = 'Extreme' | 'Chaos' | 'Hard' | 'Normal' | 'Easy';
+export type BossDifficultyLabel = 'Extreme' | 'Chaos' | 'Hard' | 'Normal' | 'Easy';
 
-const TIER_LABEL: Record<BossTier, BossDifficulty> = {
+const TIER_LABEL: Record<BossTier, BossDifficultyLabel> = {
   easy: 'Easy',
   normal: 'Normal',
   hard: 'Hard',
@@ -18,28 +17,15 @@ const TIER_LABEL: Record<BossTier, BossDifficulty> = {
   extreme: 'Extreme',
 };
 
-const TIER_LESS_FAMILIES = new Set(['akechi-mitsuhide', 'omni-cln', 'princess-no']);
-
 const DIFFICULTY_PREFIX = /^(Extreme|Chaos|Hard|Normal|Easy) /;
 
-/** Pre-1A helper: parse a legacy display name into its difficulty label. */
-export function getDifficulty(name: string): BossDifficulty | null {
+export function getDifficulty(name: string): BossDifficultyLabel | null {
   const m = name.match(DIFFICULTY_PREFIX);
-  return (m?.[1] as BossDifficulty) ?? null;
+  return (m?.[1] as BossDifficultyLabel) ?? null;
 }
 
-/**
- * Reconstruct the legacy display name for a `(family, tier)` pair. Preserves
- * the exact strings the pre-1A UI rendered (e.g. "Hard Lucid", "Akechi Mitsuhide").
- */
 function legacyDisplayName(family: string, tier: BossTier, familyName: string): string {
-  if (TIER_LESS_FAMILIES.has(family)) return familyName;
-  return `${TIER_LABEL[tier]} ${familyName}`;
-}
-
-/** Legacy id for a `(family, tier)` pair. Round-trips through `getLegacyBoss`. */
-function legacyId(family: string, tier: BossTier): string {
-  return TIER_LESS_FAMILIES.has(family) ? family : `${tier}-${family}`;
+  return TIER_LESS_FAMILIES.has(family) ? familyName : `${TIER_LABEL[tier]} ${familyName}`;
 }
 
 export interface FamilyView {
@@ -50,7 +36,7 @@ export interface FamilyView {
     name: string;
     crystalValue: number;
     formattedValue: string;
-    difficulty: BossDifficulty | null;
+    difficulty: BossDifficultyLabel | null;
     selected: boolean;
   }[];
 }
@@ -73,14 +59,16 @@ export function validateBossSelection(ids: string[]): string[] {
 export function toggleBoss(selectedIds: string[], bossLegacyId: string): string[] {
   const ref = getLegacyBoss(bossLegacyId);
   if (!ref) return selectedIds;
-  const existingId = selectedIds.find((id) => {
-    const r = getLegacyBoss(id);
-    return r?.uuid === ref.uuid;
-  });
+  const existingId = selectedIds.find((id) => getLegacyBoss(id)?.uuid === ref.uuid);
   if (existingId === bossLegacyId) return selectedIds.filter((id) => id !== bossLegacyId);
   if (existingId) return selectedIds.map((id) => (id === existingId ? bossLegacyId : id));
   return [...selectedIds, bossLegacyId];
 }
+
+// Precomputed top crystalValue per family → sort comparator stays O(1) lookup.
+const familyTopCrystal = new Map<string, number>(
+  bosses.map((b) => [b.family, Math.max(...b.difficulty.map((d) => d.crystalValue))]),
+);
 
 export function getFamilies(
   selectedIds: string[],
@@ -89,16 +77,9 @@ export function getFamilies(
 ): FamilyView[] {
   const selectedSet = new Set(selectedIds);
 
-  // Build FamilyView rows from the new Boss[] shape. Each family produces
-  // one row whose `bosses` list is a sorted (crystalValue desc) expansion
-  // of the difficulty[] array — mirroring the pre-1A per-tier rows.
   const families: FamilyView[] = bosses
     .slice()
-    .sort((a, b) => {
-      const topA = Math.max(...a.difficulty.map((d) => d.crystalValue));
-      const topB = Math.max(...b.difficulty.map((d) => d.crystalValue));
-      return topB - topA;
-    })
+    .sort((a, b) => familyTopCrystal.get(b.family)! - familyTopCrystal.get(a.family)!)
     .map((boss) => ({
       family: boss.family,
       displayName: boss.name,
@@ -106,7 +87,7 @@ export function getFamilies(
         .slice()
         .sort((a, b) => b.crystalValue - a.crystalValue)
         .map((diff) => {
-          const id = legacyId(boss.family, diff.tier);
+          const id = legacyIdFor(boss.family, diff.tier);
           return {
             id,
             name: legacyDisplayName(boss.family, diff.tier, boss.name),

--- a/src/data/bosses.ts
+++ b/src/data/bosses.ts
@@ -1,4 +1,4 @@
-import type { Boss, BossContentType, BossFamily, BossTier } from '../types';
+import type { Boss, BossContentType, BossTier } from '../types';
 
 /**
  * Matrix-variant Boss data (slice 1A).
@@ -310,35 +310,25 @@ export const bosses: Boss[] = [
   },
 ];
 
-export const ALL_BOSS_IDS: Set<string> = new Set(bosses.map((b) => b.id));
+export const ALL_BOSS_IDS: ReadonlySet<string> = new Set(bosses.map((b) => b.id));
+
+/** Families whose pre-1A legacy id has no difficulty prefix. */
+export const TIER_LESS_FAMILIES: ReadonlySet<string> = new Set([
+  'akechi-mitsuhide',
+  'omni-cln',
+  'princess-no',
+]);
 
 const bossById = new Map<string, Boss>(bosses.map((b) => [b.id, b]));
-const bossByFamily = new Map<string, Boss>(bosses.map((b) => [b.family, b]));
 
 export function getBossById(id: string): Boss | undefined {
   return bossById.get(id);
 }
 
-/**
- * Look up a tier within a family's difficulty[] array. Returns undefined
- * if the family has no entry for the requested tier.
- */
-export function getBossTier(bossId: string, tier: BossTier): import('../types').BossDifficulty | undefined {
-  return bossById.get(bossId)?.difficulty.find((d) => d.tier === tier);
+/** Legacy id for a (family, tier) pair. Round-trips through getLegacyBoss. */
+export function legacyIdFor(family: string, tier: BossTier): string {
+  return TIER_LESS_FAMILIES.has(family) ? family : `${tier}-${family}`;
 }
-
-/**
- * Highest-crystalValue tier for a family, used as the "representative"
- * entry when ordering families or surfacing a single value.
- */
-export function getTopTier(boss: Boss): import('../types').BossDifficulty {
-  return boss.difficulty.reduce((a, b) => (a.crystalValue >= b.crystalValue ? a : b));
-}
-
-export const bossFamilies: BossFamily[] = bosses
-  .slice()
-  .sort((a, b) => getTopTier(b).crystalValue - getTopTier(a).crystalValue)
-  .map((b) => ({ family: b.family, bosses: [b] }));
 
 /**
  * Legacy-id compatibility shim (slice 1A). Maps every `<tier>-<family>`
@@ -352,20 +342,11 @@ export interface LegacyBossRef {
   contentType: BossContentType;
 }
 
-/** Families whose pre-1A legacy id had no difficulty prefix. */
-const TIER_LESS_FAMILIES: ReadonlySet<string> = new Set([
-  'akechi-mitsuhide',
-  'omni-cln',
-  'princess-no',
-]);
-
-const legacyToBoss: Map<string, LegacyBossRef> = (() => {
+const legacyToBoss: ReadonlyMap<string, LegacyBossRef> = (() => {
   const map = new Map<string, LegacyBossRef>();
   for (const boss of bosses) {
-    const tierless = TIER_LESS_FAMILIES.has(boss.family);
     for (const diff of boss.difficulty) {
-      const legacyId = tierless ? boss.family : `${diff.tier}-${boss.family}`;
-      map.set(legacyId, {
+      map.set(legacyIdFor(boss.family, diff.tier), {
         uuid: boss.id,
         tier: diff.tier,
         crystalValue: diff.crystalValue,
@@ -378,11 +359,6 @@ const legacyToBoss: Map<string, LegacyBossRef> = (() => {
 
 export function getLegacyBoss(legacyId: string): LegacyBossRef | undefined {
   return legacyToBoss.get(legacyId);
-}
-
-/** Family lookup by slug (helper for consumers still on legacy ids). */
-export function getBossByFamily(family: string): Boss | undefined {
-  return bossByFamily.get(family);
 }
 
 export function calculatePotentialIncome(selectedLegacyIds: string[]): number {

--- a/src/data/bosses.ts
+++ b/src/data/bosses.ts
@@ -1,111 +1,393 @@
-import type { Boss, BossFamily } from '../types';
+import type { Boss, BossContentType, BossFamily, BossTier } from '../types';
 
+/**
+ * Matrix-variant Boss data (slice 1A).
+ *
+ * One row per family. Each row holds a stable hard-coded UUIDv4 `id`,
+ * a display `name` with no difficulty prefix, and a `difficulty[]` array
+ * of `{ tier, crystalValue, contentType }` entries.
+ *
+ * All tiers are seeded with `contentType: 'weekly'` — the daily/monthly
+ * classification refinement lands in a later slice.
+ *
+ * UUIDs were generated once via `uuid` (v13) and hard-coded here so ids
+ * stay stable across reloads and test runs.
+ */
 export const bosses: Boss[] = [
-  { id: 'extreme-black-mage', name: 'Extreme Black Mage', family: 'black-mage', crystalValue: 18000000000 },
-  { id: 'extreme-kaling', name: 'Extreme Kaling', family: 'kaling', crystalValue: 6026000000 },
-  { id: 'extreme-first-adversary', name: 'Extreme First Adversary', family: 'first-adversary', crystalValue: 5880000000 },
-  { id: 'extreme-kalos-the-guardian', name: 'Extreme Kalos the Guardian', family: 'kalos-the-guardian', crystalValue: 5200000000 },
-  { id: 'hard-black-mage', name: 'Hard Black Mage', family: 'black-mage', crystalValue: 4500000000 },
-  { id: 'extreme-chosen-seren', name: 'Extreme Chosen Seren', family: 'chosen-seren', crystalValue: 4235000000 },
-  { id: 'hard-baldrix', name: 'Hard Baldrix', family: 'baldrix', crystalValue: 4200000000 },
-  { id: 'hard-limbo', name: 'Hard Limbo', family: 'limbo', crystalValue: 3745000000 },
-  { id: 'hard-kaling', name: 'Hard Kaling', family: 'kaling', crystalValue: 2990000000 },
-  { id: 'hard-first-adversary', name: 'Hard First Adversary', family: 'first-adversary', crystalValue: 2940000000 },
-  { id: 'normal-baldrix', name: 'Normal Baldrix', family: 'baldrix', crystalValue: 2800000000 },
-  { id: 'chaos-kalos-the-guardian', name: 'Chaos Kalos the Guardian', family: 'kalos-the-guardian', crystalValue: 2600000000 },
-  { id: 'normal-limbo', name: 'Normal Limbo', family: 'limbo', crystalValue: 2100000000 },
-  { id: 'normal-kaling', name: 'Normal Kaling', family: 'kaling', crystalValue: 1506500000 },
-  { id: 'extreme-lotus', name: 'Extreme Lotus', family: 'lotus', crystalValue: 1397500000 },
-  { id: 'normal-first-adversary', name: 'Normal First Adversary', family: 'first-adversary', crystalValue: 1365000000 },
-  { id: 'normal-kalos-the-guardian', name: 'Normal Kalos the Guardian', family: 'kalos-the-guardian', crystalValue: 1300000000 },
-  { id: 'hard-chosen-seren', name: 'Hard Chosen Seren', family: 'chosen-seren', crystalValue: 1096562500 },
-  { id: 'easy-kaling', name: 'Easy Kaling', family: 'kaling', crystalValue: 1031250000 },
-  { id: 'easy-first-adversary', name: 'Easy First Adversary', family: 'first-adversary', crystalValue: 985000000 },
-  { id: 'easy-kalos-the-guardian', name: 'Easy Kalos the Guardian', family: 'kalos-the-guardian', crystalValue: 937500000 },
-  { id: 'normal-chosen-seren', name: 'Normal Chosen Seren', family: 'chosen-seren', crystalValue: 889021875 },
-  { id: 'hard-verus-hilla', name: 'Hard Verus Hilla', family: 'verus-hilla', crystalValue: 762105000 },
-  { id: 'hard-darknell', name: 'Hard Darknell', family: 'darknell', crystalValue: 667920000 },
-  { id: 'hard-will', name: 'Hard Will', family: 'will', crystalValue: 621810000 },
-  { id: 'chaos-guardian-angel-slime', name: 'Chaos Guardian Angel Slime', family: 'guardian-angel-slime', crystalValue: 600578125 },
-  { id: 'normal-verus-hilla', name: 'Normal Verus Hilla', family: 'verus-hilla', crystalValue: 581880000 },
-  { id: 'chaos-gloom', name: 'Chaos Gloom', family: 'gloom', crystalValue: 563945000 },
-  { id: 'hard-lucid', name: 'Hard Lucid', family: 'lucid', crystalValue: 504000000 },
-  { id: 'hard-lotus', name: 'Hard Lotus', family: 'lotus', crystalValue: 444675000 },
-  { id: 'hard-damien', name: 'Hard Damien', family: 'damien', crystalValue: 421875000 },
-  { id: 'normal-darknell', name: 'Normal Darknell', family: 'darknell', crystalValue: 316875000 },
-  { id: 'normal-gloom', name: 'Normal Gloom', family: 'gloom', crystalValue: 297675000 },
-  { id: 'normal-will', name: 'Normal Will', family: 'will', crystalValue: 279075000 },
-  { id: 'normal-lucid', name: 'Normal Lucid', family: 'lucid', crystalValue: 253828125 },
-  { id: 'easy-will', name: 'Easy Will', family: 'will', crystalValue: 246744750 },
-  { id: 'easy-lucid', name: 'Easy Lucid', family: 'lucid', crystalValue: 237009375 },
-  { id: 'normal-guardian-angel-slime', name: 'Normal Guardian Angel Slime', family: 'guardian-angel-slime', crystalValue: 231673500 },
-  { id: 'normal-damien', name: 'Normal Damien', family: 'damien', crystalValue: 169000000 },
-  { id: 'normal-lotus', name: 'Normal Lotus', family: 'lotus', crystalValue: 162562500 },
-  { id: 'akechi-mitsuhide', name: 'Akechi Mitsuhide', family: 'akechi-mitsuhide', crystalValue: 144000000 },
-  { id: 'chaos-papulatus', name: 'Chaos Papulatus', family: 'papulatus', crystalValue: 132250000 },
-  { id: 'chaos-vellum', name: 'Chaos Vellum', family: 'vellum', crystalValue: 105062500 },
-  { id: 'hard-magnus', name: 'Hard Magnus', family: 'magnus', crystalValue: 95062500 },
-  { id: 'princess-no', name: 'Princess No', family: 'princess-no', crystalValue: 81000000 },
-  { id: 'chaos-zakum', name: 'Chaos Zakum', family: 'zakum', crystalValue: 81000000 },
-  { id: 'chaos-pierre', name: 'Chaos Pierre', family: 'pierre', crystalValue: 81000000 },
-  { id: 'chaos-von-bon', name: 'Chaos Von Bon', family: 'von-bon', crystalValue: 81000000 },
-  { id: 'chaos-crimson-queen', name: 'Chaos Crimson Queen', family: 'crimson-queen', crystalValue: 81000000 },
-  { id: 'normal-cygnus', name: 'Normal Cygnus', family: 'cygnus', crystalValue: 72250000 },
-  { id: 'chaos-pink-bean', name: 'Chaos Pink Bean', family: 'pink-bean', crystalValue: 64000000 },
-  { id: 'hard-hilla', name: 'Hard Hilla', family: 'hilla', crystalValue: 56250000 },
-  { id: 'easy-cygnus', name: 'Easy Cygnus', family: 'cygnus', crystalValue: 45562500 },
-  { id: 'hard-mori-ranmaru', name: 'Hard Mori Ranmaru', family: 'mori-ranmaru', crystalValue: 13322500 },
-  { id: 'normal-papulatus', name: 'Normal Papulatus', family: 'papulatus', crystalValue: 13322500 },
-  { id: 'normal-magnus', name: 'Normal Magnus', family: 'magnus', crystalValue: 12960000 },
-  { id: 'normal-arkarium', name: 'Normal Arkarium', family: 'arkarium', crystalValue: 12602500 },
-  { id: 'hard-von-leon', name: 'Hard Von Leon', family: 'von-leon', crystalValue: 12250000 },
-  { id: 'normal-von-leon', name: 'Normal Von Leon', family: 'von-leon', crystalValue: 7290000 },
-  { id: 'normal-pink-bean', name: 'Normal Pink Bean', family: 'pink-bean', crystalValue: 7022500 },
-  { id: 'chaos-horntail', name: 'Chaos Horntail', family: 'horntail', crystalValue: 6760000 },
-  { id: 'omni-cln', name: 'OMNI-CLN', family: 'omni-cln', crystalValue: 6250000 },
-  { id: 'easy-arkarium', name: 'Easy Arkarium', family: 'arkarium', crystalValue: 5760000 },
-  { id: 'easy-von-leon', name: 'Easy Von Leon', family: 'von-leon', crystalValue: 5290000 },
-  { id: 'normal-horntail', name: 'Normal Horntail', family: 'horntail', crystalValue: 5062500 },
-  { id: 'normal-pierre', name: 'Normal Pierre', family: 'pierre', crystalValue: 4840000 },
-  { id: 'normal-von-bon', name: 'Normal Von Bon', family: 'von-bon', crystalValue: 4840000 },
-  { id: 'normal-crimson-queen', name: 'Normal Crimson Queen', family: 'crimson-queen', crystalValue: 4840000 },
-  { id: 'normal-vellum', name: 'Normal Vellum', family: 'vellum', crystalValue: 4840000 },
-  { id: 'easy-horntail', name: 'Easy Horntail', family: 'horntail', crystalValue: 4410000 },
-  { id: 'normal-mori-ranmaru', name: 'Normal Mori Ranmaru', family: 'mori-ranmaru', crystalValue: 4202500 },
-  { id: 'normal-hilla', name: 'Normal Hilla', family: 'hilla', crystalValue: 4000000 },
-  { id: 'easy-magnus', name: 'Easy Magnus', family: 'magnus', crystalValue: 3610000 },
-  { id: 'easy-papulatus', name: 'Easy Papulatus', family: 'papulatus', crystalValue: 3422500 },
-  { id: 'normal-zakum', name: 'Normal Zakum', family: 'zakum', crystalValue: 3062500 },
-  { id: 'easy-zakum', name: 'Easy Zakum', family: 'zakum', crystalValue: 1000000 },
+  {
+    id: 'a4d1238d-1519-4ea0-bada-16ed3520ddc7',
+    name: 'Black Mage',
+    family: 'black-mage',
+    difficulty: [
+      { tier: 'hard', crystalValue: 4500000000, contentType: 'weekly' },
+      { tier: 'extreme', crystalValue: 18000000000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '0fec4e62-1f8b-45e6-afb7-e137ca2056b3',
+    name: 'Kaling',
+    family: 'kaling',
+    difficulty: [
+      { tier: 'easy', crystalValue: 1031250000, contentType: 'weekly' },
+      { tier: 'normal', crystalValue: 1506500000, contentType: 'weekly' },
+      { tier: 'hard', crystalValue: 2990000000, contentType: 'weekly' },
+      { tier: 'extreme', crystalValue: 6026000000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: 'b4d2a687-ddef-48fa-b6d0-e6873f11a239',
+    name: 'First Adversary',
+    family: 'first-adversary',
+    difficulty: [
+      { tier: 'easy', crystalValue: 985000000, contentType: 'weekly' },
+      { tier: 'normal', crystalValue: 1365000000, contentType: 'weekly' },
+      { tier: 'hard', crystalValue: 2940000000, contentType: 'weekly' },
+      { tier: 'extreme', crystalValue: 5880000000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '94ba4f12-f313-4d5b-bf93-f19221341d89',
+    name: 'Kalos the Guardian',
+    family: 'kalos-the-guardian',
+    difficulty: [
+      { tier: 'easy', crystalValue: 937500000, contentType: 'weekly' },
+      { tier: 'normal', crystalValue: 1300000000, contentType: 'weekly' },
+      { tier: 'chaos', crystalValue: 2600000000, contentType: 'weekly' },
+      { tier: 'extreme', crystalValue: 5200000000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '62e73832-cbae-471f-b5c7-dff68d2fe9d4',
+    name: 'Chosen Seren',
+    family: 'chosen-seren',
+    difficulty: [
+      { tier: 'normal', crystalValue: 889021875, contentType: 'weekly' },
+      { tier: 'hard', crystalValue: 1096562500, contentType: 'weekly' },
+      { tier: 'extreme', crystalValue: 4235000000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: 'e657dc8d-e2ba-414c-9c6e-51c1ed2ba23c',
+    name: 'Baldrix',
+    family: 'baldrix',
+    difficulty: [
+      { tier: 'normal', crystalValue: 2800000000, contentType: 'weekly' },
+      { tier: 'hard', crystalValue: 4200000000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: 'd8c9fbda-6887-49e2-bd32-63e08adc62b6',
+    name: 'Limbo',
+    family: 'limbo',
+    difficulty: [
+      { tier: 'normal', crystalValue: 2100000000, contentType: 'weekly' },
+      { tier: 'hard', crystalValue: 3745000000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: 'b6326724-fa76-47ee-bb62-748da7d5c9b6',
+    name: 'Lotus',
+    family: 'lotus',
+    difficulty: [
+      { tier: 'normal', crystalValue: 162562500, contentType: 'weekly' },
+      { tier: 'hard', crystalValue: 444675000, contentType: 'weekly' },
+      { tier: 'extreme', crystalValue: 1397500000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '5de57685-48b5-44d4-83b9-4b30e2a5a715',
+    name: 'Verus Hilla',
+    family: 'verus-hilla',
+    difficulty: [
+      { tier: 'normal', crystalValue: 581880000, contentType: 'weekly' },
+      { tier: 'hard', crystalValue: 762105000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: 'fb06eeef-20b7-4313-869b-0fa3086df4ef',
+    name: 'Darknell',
+    family: 'darknell',
+    difficulty: [
+      { tier: 'normal', crystalValue: 316875000, contentType: 'weekly' },
+      { tier: 'hard', crystalValue: 667920000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '8922d071-a02a-47ea-80d1-e685bac48bc9',
+    name: 'Will',
+    family: 'will',
+    difficulty: [
+      { tier: 'easy', crystalValue: 246744750, contentType: 'weekly' },
+      { tier: 'normal', crystalValue: 279075000, contentType: 'weekly' },
+      { tier: 'hard', crystalValue: 621810000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: 'b76be02b-ecab-4ea2-a407-5ae87c0e0509',
+    name: 'Guardian Angel Slime',
+    family: 'guardian-angel-slime',
+    difficulty: [
+      { tier: 'normal', crystalValue: 231673500, contentType: 'weekly' },
+      { tier: 'chaos', crystalValue: 600578125, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '94fcece9-7b85-4114-ae34-40c7ce3ff7e5',
+    name: 'Gloom',
+    family: 'gloom',
+    difficulty: [
+      { tier: 'normal', crystalValue: 297675000, contentType: 'weekly' },
+      { tier: 'chaos', crystalValue: 563945000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '3a2e966c-7f0a-4b7d-b577-bb87f2350462',
+    name: 'Lucid',
+    family: 'lucid',
+    difficulty: [
+      { tier: 'easy', crystalValue: 237009375, contentType: 'weekly' },
+      { tier: 'normal', crystalValue: 253828125, contentType: 'weekly' },
+      { tier: 'hard', crystalValue: 504000000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: 'ed7b68c0-5047-4472-b9f3-3ee64214199d',
+    name: 'Damien',
+    family: 'damien',
+    difficulty: [
+      { tier: 'normal', crystalValue: 169000000, contentType: 'weekly' },
+      { tier: 'hard', crystalValue: 421875000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '8004e8a0-b748-42f7-81f9-72635aabb9dd',
+    name: 'Akechi Mitsuhide',
+    family: 'akechi-mitsuhide',
+    difficulty: [{ tier: 'normal', crystalValue: 144000000, contentType: 'weekly' }],
+  },
+  {
+    id: '12f43424-b32f-4874-903f-e253b65026f5',
+    name: 'Papulatus',
+    family: 'papulatus',
+    difficulty: [
+      { tier: 'easy', crystalValue: 3422500, contentType: 'weekly' },
+      { tier: 'normal', crystalValue: 13322500, contentType: 'weekly' },
+      { tier: 'chaos', crystalValue: 132250000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '8a474f62-4613-4173-8ade-5f01f99eed75',
+    name: 'Vellum',
+    family: 'vellum',
+    difficulty: [
+      { tier: 'normal', crystalValue: 4840000, contentType: 'weekly' },
+      { tier: 'chaos', crystalValue: 105062500, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: 'c6acc7a0-8c65-4d69-9eaa-b891bcc44bd6',
+    name: 'Magnus',
+    family: 'magnus',
+    difficulty: [
+      { tier: 'easy', crystalValue: 3610000, contentType: 'weekly' },
+      { tier: 'normal', crystalValue: 12960000, contentType: 'weekly' },
+      { tier: 'hard', crystalValue: 95062500, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '722b4793-d736-4951-8c2f-a281c1e702d1',
+    name: 'Princess No',
+    family: 'princess-no',
+    difficulty: [{ tier: 'normal', crystalValue: 81000000, contentType: 'weekly' }],
+  },
+  {
+    id: '03efcbe1-d6e2-4b48-90ff-337fc6a644ba',
+    name: 'Zakum',
+    family: 'zakum',
+    difficulty: [
+      { tier: 'easy', crystalValue: 1000000, contentType: 'weekly' },
+      { tier: 'normal', crystalValue: 3062500, contentType: 'weekly' },
+      { tier: 'chaos', crystalValue: 81000000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '04a0dda1-b211-41d7-ad51-d035ffca37a6',
+    name: 'Pierre',
+    family: 'pierre',
+    difficulty: [
+      { tier: 'normal', crystalValue: 4840000, contentType: 'weekly' },
+      { tier: 'chaos', crystalValue: 81000000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: 'd873a55b-a3d0-4d95-8571-01233653a2e6',
+    name: 'Von Bon',
+    family: 'von-bon',
+    difficulty: [
+      { tier: 'normal', crystalValue: 4840000, contentType: 'weekly' },
+      { tier: 'chaos', crystalValue: 81000000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '795dd16f-c1e7-418b-8276-831b0389a5a0',
+    name: 'Crimson Queen',
+    family: 'crimson-queen',
+    difficulty: [
+      { tier: 'normal', crystalValue: 4840000, contentType: 'weekly' },
+      { tier: 'chaos', crystalValue: 81000000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: 'df0c8986-1540-4d0c-a71c-3a8d187d68e1',
+    name: 'Cygnus',
+    family: 'cygnus',
+    difficulty: [
+      { tier: 'easy', crystalValue: 45562500, contentType: 'weekly' },
+      { tier: 'normal', crystalValue: 72250000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '572f2a96-5562-4128-aee5-918ef853f7ab',
+    name: 'Pink Bean',
+    family: 'pink-bean',
+    difficulty: [
+      { tier: 'normal', crystalValue: 7022500, contentType: 'weekly' },
+      { tier: 'chaos', crystalValue: 64000000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: 'ece87e2a-fd06-49ca-b6a2-5f243162ca31',
+    name: 'Hilla',
+    family: 'hilla',
+    difficulty: [
+      { tier: 'normal', crystalValue: 4000000, contentType: 'weekly' },
+      { tier: 'hard', crystalValue: 56250000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '2b739dbc-8949-4d53-853a-e1cde5921140',
+    name: 'Mori Ranmaru',
+    family: 'mori-ranmaru',
+    difficulty: [
+      { tier: 'normal', crystalValue: 4202500, contentType: 'weekly' },
+      { tier: 'hard', crystalValue: 13322500, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '493c9f87-44a6-4e0f-9d46-10f340188079',
+    name: 'Arkarium',
+    family: 'arkarium',
+    difficulty: [
+      { tier: 'easy', crystalValue: 5760000, contentType: 'weekly' },
+      { tier: 'normal', crystalValue: 12602500, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: '4a97f9f0-26d0-45ab-842d-b24de5615905',
+    name: 'Von Leon',
+    family: 'von-leon',
+    difficulty: [
+      { tier: 'easy', crystalValue: 5290000, contentType: 'weekly' },
+      { tier: 'normal', crystalValue: 7290000, contentType: 'weekly' },
+      { tier: 'hard', crystalValue: 12250000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: 'e8c1129e-671f-4600-adb1-9548e66a17f9',
+    name: 'Horntail',
+    family: 'horntail',
+    difficulty: [
+      { tier: 'easy', crystalValue: 4410000, contentType: 'weekly' },
+      { tier: 'normal', crystalValue: 5062500, contentType: 'weekly' },
+      { tier: 'chaos', crystalValue: 6760000, contentType: 'weekly' },
+    ],
+  },
+  {
+    id: 'c91e5d28-1211-46c4-a4fc-4dd57e0d2801',
+    name: 'OMNI-CLN',
+    family: 'omni-cln',
+    difficulty: [{ tier: 'normal', crystalValue: 6250000, contentType: 'weekly' }],
+  },
 ];
-
-export const bossFamilies: BossFamily[] = (() => {
-  const familyMap = new Map<string, Boss[]>();
-  for (const boss of bosses) {
-    if (!familyMap.has(boss.family)) {
-      familyMap.set(boss.family, []);
-    }
-    familyMap.get(boss.family)!.push(boss);
-  }
-  return Array.from(familyMap.entries())
-    .map(([family, familyBosses]) => ({
-      family,
-      bosses: familyBosses.sort((a, b) => b.crystalValue - a.crystalValue),
-    }))
-    .sort((a, b) => b.bosses[0].crystalValue - a.bosses[0].crystalValue);
-})();
 
 export const ALL_BOSS_IDS: Set<string> = new Set(bosses.map((b) => b.id));
 
-const bossMap = new Map<string, Boss>(bosses.map((b) => [b.id, b]));
+const bossById = new Map<string, Boss>(bosses.map((b) => [b.id, b]));
+const bossByFamily = new Map<string, Boss>(bosses.map((b) => [b.family, b]));
 
 export function getBossById(id: string): Boss | undefined {
-  return bossMap.get(id);
+  return bossById.get(id);
 }
 
-export function calculatePotentialIncome(selectedBossIds: string[]): number {
-  return selectedBossIds.reduce((sum, id) => {
-    const boss = getBossById(id);
-    return sum + (boss?.crystalValue ?? 0);
+/**
+ * Look up a tier within a family's difficulty[] array. Returns undefined
+ * if the family has no entry for the requested tier.
+ */
+export function getBossTier(bossId: string, tier: BossTier): import('../types').BossDifficulty | undefined {
+  return bossById.get(bossId)?.difficulty.find((d) => d.tier === tier);
+}
+
+/**
+ * Highest-crystalValue tier for a family, used as the "representative"
+ * entry when ordering families or surfacing a single value.
+ */
+export function getTopTier(boss: Boss): import('../types').BossDifficulty {
+  return boss.difficulty.reduce((a, b) => (a.crystalValue >= b.crystalValue ? a : b));
+}
+
+export const bossFamilies: BossFamily[] = bosses
+  .slice()
+  .sort((a, b) => getTopTier(b).crystalValue - getTopTier(a).crystalValue)
+  .map((b) => ({ family: b.family, bosses: [b] }));
+
+/**
+ * Legacy-id compatibility shim (slice 1A). Maps every `<tier>-<family>`
+ * (and the three tier-less `<family>` ids) from the pre-1A dataset to the
+ * corresponding `{ uuid, tier, crystalValue, contentType }` triple.
+ */
+export interface LegacyBossRef {
+  uuid: string;
+  tier: BossTier;
+  crystalValue: number;
+  contentType: BossContentType;
+}
+
+/** Families whose pre-1A legacy id had no difficulty prefix. */
+const TIER_LESS_FAMILIES: ReadonlySet<string> = new Set([
+  'akechi-mitsuhide',
+  'omni-cln',
+  'princess-no',
+]);
+
+const legacyToBoss: Map<string, LegacyBossRef> = (() => {
+  const map = new Map<string, LegacyBossRef>();
+  for (const boss of bosses) {
+    const tierless = TIER_LESS_FAMILIES.has(boss.family);
+    for (const diff of boss.difficulty) {
+      const legacyId = tierless ? boss.family : `${diff.tier}-${boss.family}`;
+      map.set(legacyId, {
+        uuid: boss.id,
+        tier: diff.tier,
+        crystalValue: diff.crystalValue,
+        contentType: diff.contentType,
+      });
+    }
+  }
+  return map;
+})();
+
+export function getLegacyBoss(legacyId: string): LegacyBossRef | undefined {
+  return legacyToBoss.get(legacyId);
+}
+
+/** Family lookup by slug (helper for consumers still on legacy ids). */
+export function getBossByFamily(family: string): Boss | undefined {
+  return bossByFamily.get(family);
+}
+
+export function calculatePotentialIncome(selectedLegacyIds: string[]): number {
+  return selectedLegacyIds.reduce((sum, id) => {
+    const ref = getLegacyBoss(id);
+    return sum + (ref?.crystalValue ?? 0);
   }, 0);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,21 @@
-export interface Boss {
-  id: string;
-  name: string;
-  family: string;
+export type BossTier = 'easy' | 'normal' | 'hard' | 'chaos' | 'extreme';
+export type BossContentType = 'daily' | 'weekly' | 'monthly';
+
+export interface BossDifficulty {
+  tier: BossTier;
   crystalValue: number;
+  contentType: BossContentType;
+}
+
+export interface Boss {
+  /** Stable UUIDv4, hard-coded in bosses.ts. */
+  id: string;
+  /** Display name without any difficulty prefix, e.g. "Black Mage". */
+  name: string;
+  /** Family slug, unchanged from the pre-1A dataset. */
+  family: string;
+  /** One entry per difficulty tier offered for this family. */
+  difficulty: BossDifficulty[];
 }
 
 export interface BossFamily {
@@ -15,5 +28,10 @@ export interface Mule {
   name: string;
   level: number;
   muleClass: string;
+  /**
+   * Slice 1A: still stores legacy string ids (e.g. "hard-lucid",
+   * "akechi-mitsuhide"). The native `<uuid>:<tier>` key migration
+   * lands in slice 1B.
+   */
   selectedBosses: string[];
 }


### PR DESCRIPTION
## Summary

Reshapes the `Boss` data model for the upcoming Matrix drawer while keeping every existing consumer working. No user-visible behaviour change.

- `src/types/index.ts` — adds `BossTier`, `BossContentType`, `BossDifficulty` (now an interface `{ tier, crystalValue, contentType }`). Reshapes `Boss` to `{ id, name, family, difficulty[] }`.
- `src/data/bosses.ts` — rewritten: 32 rows (one per family), each with a hard-coded UUIDv4 id, a display name without a difficulty prefix ("Black Mage", "Lotus", "Kalos the Guardian"), and a `difficulty[]` array of `{ tier, crystalValue, contentType }` entries. All tiers seeded `contentType: 'weekly'`. Tier-less bosses (Akechi Mitsuhide, OMNI-CLN, Princess No) collapse to a single `[{ tier: 'normal', ... }]` entry.
- Adds `getLegacyBoss(legacyId)` — the compatibility shim that round-trips every pre-1A legacy id to `{ uuid, tier, crystalValue, contentType }`. `Mule.selectedBosses` still stores legacy string ids in this slice; the native `<uuid>:<tier>` key migration lands in 1B.
- `src/data/bossSelection.ts` — `toggleBoss`, `validateBossSelection`, and `getFamilies` all derive from the new shape via `getLegacyBoss()` / `legacyIdFor()` so `BossCheckboxList` and `useMules` keep their existing contracts. The capitalized string-union label type renamed to `BossDifficultyLabel` to avoid colliding with the new `BossDifficulty` *interface* in `types`.

Built TDD: red test first, then minimum implementation, then refactor. Three commits mirror the red-green-refactor cycles.

## Acceptance criteria → verification

| Criterion | Verified at |
| --- | --- |
| `BossTier`, `BossContentType`, `BossDifficulty`, `Boss` exported with PRD shape | `src/types/index.ts:1-19`, exercised by compile + `src/data/__tests__/bosses.test.ts:125-141` |
| `bosses.ts` rewritten: one Boss per family, stable UUIDv4 id, no prefix in `name`, `difficulty[]` with seeded `contentType: 'weekly'` | `src/data/__tests__/bosses.test.ts:94-165` |
| Tier-less bosses collapse to a single `{ tier: 'normal', ... }` entry | `src/data/__tests__/bosses.test.ts:143-157` |
| `getLegacyBoss()` resolves every pre-1A legacy id (76 rows; issue approximates as 80) | `src/data/__tests__/bosses.test.ts:184-215` (76 parameterized cases) |
| Existing consumers keep working without runtime change | `src/data/__tests__/bossSelection.test.ts` (all green), `src/components/__tests__/BossCheckboxList.test.tsx` (all green), `src/modules/__tests__/income.test.ts`, `src/hooks/__tests__/useMules.test.ts`, `src/__tests__/App.test.tsx`, `src/components/__tests__/MuleDetailDrawer.test.tsx` — all untouched, all 284 tests green |

`Closes #99`

## Test plan

- [x] `npm run build` — passes (tsc -b + vite build clean)
- [x] `npm test` — 284 / 284 green (96 new bosses tests covering the Matrix schema + `getLegacyBoss` round-trip for all 76 legacy ids)
- [x] `npm run lint` — 3 errors remain, all pre-existing on `main` (MuleDetailDrawer effect, DensityProvider empty catch, useMules empty catch). No new lint errors introduced by this slice.
- [ ] `npm run e2e` — skipped for this slice per the task recipe (no rendered-DOM change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)