### PR TITLE
1C: contentType weekly-only income filter

### DIFF
--- a/src/modules/__tests__/income.test.ts
+++ b/src/modules/__tests__/income.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest'
-import { computeMuleIncome, computeTotalIncome } from '../income'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { computeMuleIncome, computeTotalIncome, sumSelectedKeys } from '../income'
+import * as bossesModule from '../../data/bosses'
 import { bosses } from '../../data/bosses'
 import { makeKey } from '../../data/bossSelection'
+import type { Boss } from '../../types'
 
 const LUCID = bosses.find((b) => b.family === 'lucid')!.id
 const WILL = bosses.find((b) => b.family === 'will')!.id
@@ -111,5 +113,56 @@ describe('computeTotalIncome', () => {
     const result = computeTotalIncome(mules, true)
     expect(result.raw).toBe(504000000)
     expect(result.formatted).toBe('504M')
+  })
+})
+
+describe('sumSelectedKeys contentType filter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('includes only tiers with contentType === "weekly"; daily/monthly contribute 0', () => {
+    // Fixture: a single fake family with a weekly "hard" tier and a monthly
+    // "extreme" tier. Both tiers are selected — only the weekly tier should
+    // sum into the total.
+    const fakeBoss: Boss = {
+      id: 'fixture-mixed-contenttype',
+      name: 'Fixture Mixed',
+      family: 'fixture-mixed',
+      difficulty: [
+        { tier: 'hard', crystalValue: 1_000_000, contentType: 'weekly' },
+        { tier: 'extreme', crystalValue: 9_999_999, contentType: 'monthly' },
+      ],
+    }
+
+    vi.spyOn(bossesModule, 'getBossById').mockImplementation((id) =>
+      id === fakeBoss.id ? fakeBoss : undefined,
+    )
+
+    const weeklyKey = makeKey(fakeBoss.id, 'hard')
+    const monthlyKey = makeKey(fakeBoss.id, 'extreme')
+
+    expect(sumSelectedKeys([weeklyKey, monthlyKey])).toBe(1_000_000)
+  })
+
+  it('drops daily tiers from the sum', () => {
+    const fakeBoss: Boss = {
+      id: 'fixture-daily',
+      name: 'Fixture Daily',
+      family: 'fixture-daily',
+      difficulty: [
+        { tier: 'normal', crystalValue: 42, contentType: 'daily' },
+        { tier: 'hard', crystalValue: 100, contentType: 'weekly' },
+      ],
+    }
+
+    vi.spyOn(bossesModule, 'getBossById').mockImplementation((id) =>
+      id === fakeBoss.id ? fakeBoss : undefined,
+    )
+
+    const dailyKey = makeKey(fakeBoss.id, 'normal')
+    const weeklyKey = makeKey(fakeBoss.id, 'hard')
+
+    expect(sumSelectedKeys([dailyKey, weeklyKey])).toBe(100)
   })
 })

--- a/src/modules/__tests__/income.test.ts
+++ b/src/modules/__tests__/income.test.ts
@@ -122,9 +122,6 @@ describe('sumSelectedKeys contentType filter', () => {
   })
 
   it('includes only tiers with contentType === "weekly"; daily/monthly contribute 0', () => {
-    // Fixture: a single fake family with a weekly "hard" tier and a monthly
-    // "extreme" tier. Both tiers are selected — only the weekly tier should
-    // sum into the total.
     const fakeBoss: Boss = {
       id: 'fixture-mixed-contenttype',
       name: 'Fixture Mixed',

--- a/src/modules/income.ts
+++ b/src/modules/income.ts
@@ -10,9 +10,10 @@ export interface IncomeDisplay {
 /**
  * Sum crystalValues for a list of `<uuid>:<tier>` selection keys.
  *
- * NOTE: contentType filtering (`=== 'weekly'`) lands in slice 1C. For now
- * we sum every matched tier, which preserves current behaviour because
- * slice 1A seeded every tier `contentType: 'weekly'`.
+ * Only tiers whose `contentType === 'weekly'` contribute; daily and monthly
+ * tiers resolve but sum to 0. All slice 1A seed data is `'weekly'`, so this
+ * filter is plumbing that unlocks future daily/monthly boss data without
+ * distorting the current weekly KPI.
  */
 export function sumSelectedKeys(keys: string[]): number {
   let total = 0
@@ -21,7 +22,7 @@ export function sumSelectedKeys(keys: string[]): number {
     if (!parsed) continue
     const boss = getBossById(parsed.bossId)
     const diff = boss?.difficulty.find((d) => d.tier === parsed.tier)
-    if (diff) total += diff.crystalValue
+    if (diff && diff.contentType === 'weekly') total += diff.crystalValue
   }
   return total
 }


### PR DESCRIPTION
## Summary

Filters income summation to only include tiers whose `contentType === 'weekly'`. Daily and monthly tiers resolve through `parseKey`/`getBossById` but contribute `0` to the total.

All slice 1A seed data is `'weekly'`, so production KPIs are numerically identical to slice 1B — this is pure plumbing that unlocks future daily/monthly boss data without distorting the weekly income figure.

## Acceptance criteria → tests

| Criterion | Verified at |
| --- | --- |
| `sumSelectedKeys` (aka `calculatePotentialIncome` per PRD) includes only `contentType === 'weekly'` tiers | `src/modules/income.ts:25`, covered by `src/modules/__tests__/income.test.ts:121-141` |
| `useMuleIncome` + aggregate hooks respect the same filter | Inherited via `computeMuleIncome` / `computeTotalIncome` → `sumSelectedKeys` (`src/modules/income-hooks.ts:13-21`) |
| Mixed-`contentType` fixture verifies daily/monthly selections contribute 0 | `src/modules/__tests__/income.test.ts:119-141` (monthly) and `:143-164` (daily) |
| No KPI change for current production seed data (all `'weekly'`) | Unchanged `computeMuleIncome` / `computeTotalIncome` tests still assert identical numbers (`src/modules/__tests__/income.test.ts:13-114`) |
| `npm run typecheck` / `npm test` green | Local `npm run build` + `npm test` — 220/220 |

## Stack note

This PR stacks on #106 which stacks on #105. Merge order: #105 → #106 → this. GitHub will auto-retarget each PR's base when its predecessor merges.

Closes #101

## Test plan

- [x] `npm run build` — tsc + vite build clean
- [x] `npm test` — 220 / 220 green (218 carried over from #106 + 2 new contentType cases)
- [x] `npm run lint` — 2 errors remain, both pre-existing (`MuleDetailDrawer` effect, `DensityProvider` empty catch). No new lint errors introduced.
- [ ] `npm run e2e` — skipped per task recipe (no rendered-DOM change; seed data is all `'weekly'`)

Three commits follow the TDD red-green-refactor cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)