### PR TITLE
3: Per-family party-size stepper

### DIFF
--- a/src/components/BossMatrix.tsx
+++ b/src/components/BossMatrix.tsx
@@ -34,6 +34,8 @@ const tierByBossId = new Map<string, Map<BossTier, BossDifficulty>>(
 interface BossMatrixProps {
   selectedKeys: string[];
   onToggleKey: (key: string) => void;
+  partySizes: Record<string, number>;
+  onChangePartySize: (family: string, n: number) => void;
 }
 
 function TierHeader({ tier }: { tier: BossTier }) {
@@ -57,14 +59,84 @@ function TierHeader({ tier }: { tier: BossTier }) {
   );
 }
 
+function PartyStepper({
+  family,
+  party,
+  onChangePartySize,
+}: {
+  family: string;
+  party: number;
+  onChangePartySize: (family: string, n: number) => void;
+}) {
+  const atMin = party <= 1;
+  const atMax = party >= 6;
+
+  function handleDec(e: React.MouseEvent) {
+    e.stopPropagation();
+    e.preventDefault();
+    if (atMin) return;
+    onChangePartySize(family, party - 1);
+  }
+
+  function handleInc(e: React.MouseEvent) {
+    e.stopPropagation();
+    e.preventDefault();
+    if (atMax) return;
+    onChangePartySize(family, party + 1);
+  }
+
+  return (
+    <div
+      data-testid={`party-stepper-${family}`}
+      className="inline-flex items-center gap-1.5"
+    >
+      <span className="font-sans text-[9px] uppercase tracking-[0.22em] text-[var(--muted-raw,var(--muted-foreground))]">
+        Party
+      </span>
+      <div
+        className="inline-flex items-center rounded-md border border-[var(--border)]"
+        style={{ background: 'var(--surface)' }}
+      >
+        <button
+          type="button"
+          data-testid={`party-dec-${family}`}
+          aria-label={`Decrease party size for ${family}`}
+          disabled={atMin}
+          onClick={handleDec}
+          className="px-1.5 py-0.5 font-mono-nums text-[10px] text-[var(--muted-raw,var(--muted-foreground))] hover:text-[var(--accent)] disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          −
+        </button>
+        <span className="px-1 font-mono-nums text-[10px] tabular-nums min-w-[1.5rem] text-center">
+          {party}P
+        </span>
+        <button
+          type="button"
+          data-testid={`party-inc-${family}`}
+          aria-label={`Increase party size for ${family}`}
+          disabled={atMax}
+          onClick={handleInc}
+          className="px-1.5 py-0.5 font-mono-nums text-[10px] text-[var(--muted-raw,var(--muted-foreground))] hover:text-[var(--accent)] disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          +
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function FamilyRow({
   boss,
   selectedTier,
+  partySize,
   onToggleKey,
+  onChangePartySize,
 }: {
   boss: Boss;
   selectedTier: BossTier | undefined;
+  partySize: number;
   onToggleKey: (key: string) => void;
+  onChangePartySize: (family: string, n: number) => void;
 }) {
   const tierMap = tierByBossId.get(boss.id)!;
   return (
@@ -75,9 +147,16 @@ function FamilyRow({
     >
       <div
         role="rowheader"
-        className="px-3 py-2 font-display text-sm font-semibold truncate"
+        className="px-3 py-2 flex items-center justify-between gap-2 min-w-0"
       >
-        {boss.name}
+        <span className="font-display text-sm font-semibold truncate">
+          {boss.name}
+        </span>
+        <PartyStepper
+          family={boss.family}
+          party={partySize}
+          onChangePartySize={onChangePartySize}
+        />
       </div>
       {TIER_ORDER.map((tier) => {
         const diff = tierMap.get(tier);
@@ -117,7 +196,7 @@ function FamilyRow({
             ].join(' ')}
             style={isDim ? { opacity: 0.35 } : undefined}
           >
-            {formatMeso(diff.crystalValue, true)}
+            {formatMeso(diff.crystalValue / partySize, true)}
           </button>
         );
       })}
@@ -125,7 +204,12 @@ function FamilyRow({
   );
 }
 
-export function BossMatrix({ selectedKeys, onToggleKey }: BossMatrixProps) {
+export function BossMatrix({
+  selectedKeys,
+  onToggleKey,
+  partySizes,
+  onChangePartySize,
+}: BossMatrixProps) {
   const selectedTierByBoss = new Map<string, BossTier>();
   for (const key of selectedKeys) {
     const parsed = parseKey(key);
@@ -167,13 +251,15 @@ export function BossMatrix({ selectedKeys, onToggleKey }: BossMatrixProps) {
             key={boss.id}
             boss={boss}
             selectedTier={selectedTierByBoss.get(boss.id)}
+            partySize={partySizes[boss.family] ?? 1}
             onToggleKey={onToggleKey}
+            onChangePartySize={onChangePartySize}
           />
         ))}
       </div>
 
       <p className="font-display italic text-xs text-[var(--muted-raw,var(--muted-foreground))]">
-        Tap a cell to pick difficulty.
+        Tap a cell to pick difficulty · adjust party size per family.
       </p>
     </div>
   );

--- a/src/components/BossMatrix.tsx
+++ b/src/components/BossMatrix.tsx
@@ -59,6 +59,9 @@ function TierHeader({ tier }: { tier: BossTier }) {
   );
 }
 
+const STEPPER_BTN_CLASS =
+  'px-1.5 py-0.5 font-mono-nums text-[10px] text-[var(--muted-raw,var(--muted-foreground))] hover:text-[var(--accent)] disabled:opacity-40 disabled:cursor-not-allowed';
+
 function PartyStepper({
   family,
   party,
@@ -71,18 +74,16 @@ function PartyStepper({
   const atMin = party <= 1;
   const atMax = party >= 6;
 
-  function handleDec(e: React.MouseEvent) {
-    e.stopPropagation();
-    e.preventDefault();
-    if (atMin) return;
-    onChangePartySize(family, party - 1);
-  }
-
-  function handleInc(e: React.MouseEvent) {
-    e.stopPropagation();
-    e.preventDefault();
-    if (atMax) return;
-    onChangePartySize(family, party + 1);
+  // Step handlers stop propagation so clicks never fall through to the cell
+  // toggle handler on the enclosing row.
+  function step(delta: -1 | 1) {
+    return (e: React.MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      const next = party + delta;
+      if (next < 1 || next > 6) return;
+      onChangePartySize(family, next);
+    };
   }
 
   return (
@@ -102,8 +103,8 @@ function PartyStepper({
           data-testid={`party-dec-${family}`}
           aria-label={`Decrease party size for ${family}`}
           disabled={atMin}
-          onClick={handleDec}
-          className="px-1.5 py-0.5 font-mono-nums text-[10px] text-[var(--muted-raw,var(--muted-foreground))] hover:text-[var(--accent)] disabled:opacity-40 disabled:cursor-not-allowed"
+          onClick={step(-1)}
+          className={STEPPER_BTN_CLASS}
         >
           −
         </button>
@@ -115,8 +116,8 @@ function PartyStepper({
           data-testid={`party-inc-${family}`}
           aria-label={`Increase party size for ${family}`}
           disabled={atMax}
-          onClick={handleInc}
-          className="px-1.5 py-0.5 font-mono-nums text-[10px] text-[var(--muted-raw,var(--muted-foreground))] hover:text-[var(--accent)] disabled:opacity-40 disabled:cursor-not-allowed"
+          onClick={step(1)}
+          className={STEPPER_BTN_CLASS}
         >
           +
         </button>

--- a/src/components/MuleDetailDrawer.tsx
+++ b/src/components/MuleDetailDrawer.tsx
@@ -202,6 +202,18 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
                     ),
                   });
                 }}
+                partySizes={mule.partySizes ?? {}}
+                onChangePartySize={(family, n) => {
+                  // Clamp here so BossMatrix can stay a dumb view: party size
+                  // is always in [1, 6] by the time it hits storage.
+                  const clamped = Math.max(1, Math.min(6, n));
+                  onUpdate(mule.id, {
+                    partySizes: {
+                      ...(mule.partySizes ?? {}),
+                      [family]: clamped,
+                    },
+                  });
+                }}
               />
             </div>
           </div>

--- a/src/components/__tests__/BossMatrix.test.tsx
+++ b/src/components/__tests__/BossMatrix.test.tsx
@@ -3,21 +3,36 @@ import { render, screen, fireEvent } from '@/test/test-utils'
 import { BossMatrix } from '../BossMatrix'
 import { bosses } from '../../data/bosses'
 import { makeKey, TIER_ORDER } from '../../data/bossSelection'
+import { formatMeso } from '../../utils/meso'
 
-const LUCID = bosses.find((b) => b.family === 'lucid')!.id
+const LUCID_BOSS = bosses.find((b) => b.family === 'lucid')!
+const LUCID = LUCID_BOSS.id
 const HARD_LUCID = makeKey(LUCID, 'hard')
 const NORMAL_LUCID = makeKey(LUCID, 'normal')
+const LUCID_HARD_VALUE = LUCID_BOSS.difficulty.find((d) => d.tier === 'hard')!.crystalValue
 
-const BLACK_MAGE = bosses.find((b) => b.family === 'black-mage')!.id
+const BLACK_MAGE_BOSS = bosses.find((b) => b.family === 'black-mage')!
+const BLACK_MAGE = BLACK_MAGE_BOSS.id
+const BLACK_MAGE_EXTREME_VALUE = BLACK_MAGE_BOSS.difficulty.find((d) => d.tier === 'extreme')!.crystalValue
 const AKECHI = bosses.find((b) => b.family === 'akechi-mitsuhide')!.id
 
 function renderMatrix(
   selectedKeys: string[] = [],
   onToggleKey = vi.fn(),
+  partySizes: Record<string, number> = {},
+  onChangePartySize = vi.fn(),
 ) {
   return {
-    ...render(<BossMatrix selectedKeys={selectedKeys} onToggleKey={onToggleKey} />),
+    ...render(
+      <BossMatrix
+        selectedKeys={selectedKeys}
+        onToggleKey={onToggleKey}
+        partySizes={partySizes}
+        onChangePartySize={onChangePartySize}
+      />,
+    ),
     onToggleKey,
+    onChangePartySize,
   }
 }
 
@@ -51,20 +66,25 @@ describe('BossMatrix', () => {
 
     it('renders each family row with its display name in the leftmost cell', () => {
       renderMatrix()
-      expect(screen.getByRole('rowheader', { name: 'Black Mage' })).toBeTruthy()
-      expect(screen.getByRole('rowheader', { name: 'Lucid' })).toBeTruthy()
-      expect(screen.getByRole('rowheader', { name: 'Akechi Mitsuhide' })).toBeTruthy()
+      // The rowheader now also contains the Party stepper, so use partial matching.
+      const rowHeaders = screen.getAllByRole('rowheader')
+      const names = rowHeaders.map((r) => r.textContent || '')
+      expect(names.some((n) => n.includes('Black Mage'))).toBe(true)
+      expect(names.some((n) => n.includes('Lucid'))).toBe(true)
+      expect(names.some((n) => n.includes('Akechi Mitsuhide'))).toBe(true)
     })
 
     it('sorts family rows by top-tier crystalValue descending (Black Mage first)', () => {
       renderMatrix()
       const rowHeaders = screen.getAllByRole('rowheader')
-      expect(rowHeaders[0].textContent).toBe('Black Mage')
+      expect(rowHeaders[0].textContent).toContain('Black Mage')
     })
 
-    it('renders the caption "Tap a cell to pick difficulty."', () => {
+    it('renders the caption explaining the grid and stepper', () => {
       renderMatrix()
-      expect(screen.getByText('Tap a cell to pick difficulty.')).toBeTruthy()
+      expect(
+        screen.getByText(/Tap a cell to pick difficulty/i),
+      ).toBeTruthy()
     })
   })
 
@@ -167,6 +187,105 @@ describe('BossMatrix', () => {
       const hardCell = screen.getByTestId(`matrix-cell-${LUCID}-hard`)
       fireEvent.click(hardCell)
       expect(onToggleKey).toHaveBeenCalledWith(HARD_LUCID)
+    })
+  })
+
+  describe('party stepper', () => {
+    it('renders a Party label per family row', () => {
+      renderMatrix()
+      // One "PARTY" label per family row.
+      const labels = screen.getAllByText('Party')
+      expect(labels.length).toBe(bosses.length)
+    })
+
+    it('renders a party stepper per family showing "1P" when partySizes is absent', () => {
+      renderMatrix()
+      const stepper = screen.getByTestId(`party-stepper-${LUCID_BOSS.family}`)
+      expect(stepper.textContent).toContain('1P')
+    })
+
+    it('uses the provided partySizes value when present', () => {
+      renderMatrix([], vi.fn(), { [LUCID_BOSS.family]: 3 })
+      const stepper = screen.getByTestId(`party-stepper-${LUCID_BOSS.family}`)
+      expect(stepper.textContent).toContain('3P')
+    })
+
+    it('clicking + calls onChangePartySize with value + 1', () => {
+      const onChangePartySize = vi.fn()
+      renderMatrix([], vi.fn(), { [LUCID_BOSS.family]: 2 }, onChangePartySize)
+      const incBtn = screen.getByTestId(`party-inc-${LUCID_BOSS.family}`)
+      fireEvent.click(incBtn)
+      expect(onChangePartySize).toHaveBeenCalledWith(LUCID_BOSS.family, 3)
+    })
+
+    it('clicking − calls onChangePartySize with value − 1', () => {
+      const onChangePartySize = vi.fn()
+      renderMatrix([], vi.fn(), { [LUCID_BOSS.family]: 3 }, onChangePartySize)
+      const decBtn = screen.getByTestId(`party-dec-${LUCID_BOSS.family}`)
+      fireEvent.click(decBtn)
+      expect(onChangePartySize).toHaveBeenCalledWith(LUCID_BOSS.family, 2)
+    })
+
+    it('does not call onChangePartySize below 1 (clamped to 1 min)', () => {
+      const onChangePartySize = vi.fn()
+      renderMatrix([], vi.fn(), { [LUCID_BOSS.family]: 1 }, onChangePartySize)
+      const decBtn = screen.getByTestId(`party-dec-${LUCID_BOSS.family}`)
+      fireEvent.click(decBtn)
+      expect(onChangePartySize).not.toHaveBeenCalled()
+    })
+
+    it('does not call onChangePartySize above 6 (clamped to 6 max)', () => {
+      const onChangePartySize = vi.fn()
+      renderMatrix([], vi.fn(), { [LUCID_BOSS.family]: 6 }, onChangePartySize)
+      const incBtn = screen.getByTestId(`party-inc-${LUCID_BOSS.family}`)
+      fireEvent.click(incBtn)
+      expect(onChangePartySize).not.toHaveBeenCalled()
+    })
+
+    it('clicking the + button does NOT toggle the cell (event propagation stopped)', () => {
+      const onToggleKey = vi.fn()
+      const onChangePartySize = vi.fn()
+      renderMatrix([], onToggleKey, { [LUCID_BOSS.family]: 2 }, onChangePartySize)
+      const incBtn = screen.getByTestId(`party-inc-${LUCID_BOSS.family}`)
+      fireEvent.click(incBtn)
+      expect(onChangePartySize).toHaveBeenCalledTimes(1)
+      expect(onToggleKey).not.toHaveBeenCalled()
+    })
+
+    it('clicking the − button does NOT toggle the cell (event propagation stopped)', () => {
+      const onToggleKey = vi.fn()
+      const onChangePartySize = vi.fn()
+      renderMatrix([], onToggleKey, { [LUCID_BOSS.family]: 3 }, onChangePartySize)
+      const decBtn = screen.getByTestId(`party-dec-${LUCID_BOSS.family}`)
+      fireEvent.click(decBtn)
+      expect(onChangePartySize).toHaveBeenCalledTimes(1)
+      expect(onToggleKey).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('party-size division', () => {
+    it('shows the full crystalValue in cells when partySize is 1 (default)', () => {
+      renderMatrix()
+      const cell = screen.getByTestId(`matrix-cell-${BLACK_MAGE}-extreme`)
+      expect(cell.textContent).toBe(formatMeso(BLACK_MAGE_EXTREME_VALUE, true))
+    })
+
+    it('divides the displayed meso value by the family party size', () => {
+      renderMatrix([], vi.fn(), { [LUCID_BOSS.family]: 2 })
+      const cell = screen.getByTestId(`matrix-cell-${LUCID}-hard`)
+      expect(cell.textContent).toBe(formatMeso(LUCID_HARD_VALUE / 2, true))
+    })
+
+    it('cells do not contain any "÷N" hint', () => {
+      renderMatrix([], vi.fn(), { [LUCID_BOSS.family]: 2 })
+      const cell = screen.getByTestId(`matrix-cell-${LUCID}-hard`)
+      expect(cell.textContent).not.toContain('÷')
+    })
+
+    it('party size for one family does not affect another family', () => {
+      renderMatrix([], vi.fn(), { [LUCID_BOSS.family]: 4 })
+      const cell = screen.getByTestId(`matrix-cell-${BLACK_MAGE}-extreme`)
+      expect(cell.textContent).toBe(formatMeso(BLACK_MAGE_EXTREME_VALUE, true))
     })
   })
 })

--- a/src/components/__tests__/BossMatrix.test.tsx
+++ b/src/components/__tests__/BossMatrix.test.tsx
@@ -66,9 +66,7 @@ describe('BossMatrix', () => {
 
     it('renders each family row with its display name in the leftmost cell', () => {
       renderMatrix()
-      // The rowheader now also contains the Party stepper, so use partial matching.
-      const rowHeaders = screen.getAllByRole('rowheader')
-      const names = rowHeaders.map((r) => r.textContent || '')
+      const names = screen.getAllByRole('rowheader').map((r) => r.textContent ?? '')
       expect(names.some((n) => n.includes('Black Mage'))).toBe(true)
       expect(names.some((n) => n.includes('Lucid'))).toBe(true)
       expect(names.some((n) => n.includes('Akechi Mitsuhide'))).toBe(true)
@@ -193,7 +191,6 @@ describe('BossMatrix', () => {
   describe('party stepper', () => {
     it('renders a Party label per family row', () => {
       renderMatrix()
-      // One "PARTY" label per family row.
       const labels = screen.getAllByText('Party')
       expect(labels.length).toBe(bosses.length)
     })

--- a/src/components/__tests__/MuleDetailDrawer.test.tsx
+++ b/src/components/__tests__/MuleDetailDrawer.test.tsx
@@ -5,8 +5,12 @@ import { MuleDetailDrawer } from '../MuleDetailDrawer'
 import type { Mule } from '../../types'
 import { bosses } from '../../data/bosses'
 import { makeKey } from '../../data/bossSelection'
+import { formatMeso } from '../../utils/meso'
 
-const LUCID = bosses.find((b) => b.family === 'lucid')!.id
+const LUCID_BOSS = bosses.find((b) => b.family === 'lucid')!
+const LUCID = LUCID_BOSS.id
+const LUCID_FAMILY = LUCID_BOSS.family
+const LUCID_HARD_VALUE = LUCID_BOSS.difficulty.find((d) => d.tier === 'hard')!.crystalValue
 const HARD_LUCID = makeKey(LUCID, 'hard')
 const NORMAL_LUCID = makeKey(LUCID, 'normal')
 
@@ -190,6 +194,80 @@ describe('MuleDetailDrawer', () => {
       expect(onUpdate).toHaveBeenCalledWith('test-mule-1', {
         selectedBosses: [],
       })
+    })
+  })
+
+  describe('party-size stepper integration', () => {
+    it('clicking + on a family stepper calls onUpdate with the incremented partySizes map', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({ onUpdate })
+      const incBtn = screen.getByTestId(`party-inc-${LUCID_FAMILY}`)
+      fireEvent.click(incBtn)
+      expect(onUpdate).toHaveBeenCalledWith('test-mule-1', {
+        partySizes: { [LUCID_FAMILY]: 2 },
+      })
+    })
+
+    it('preserves existing partySizes for other families when updating one', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({
+        mule: {
+          ...baseMule,
+          partySizes: { 'black-mage': 3, [LUCID_FAMILY]: 1 },
+        },
+        onUpdate,
+      })
+      const incBtn = screen.getByTestId(`party-inc-${LUCID_FAMILY}`)
+      fireEvent.click(incBtn)
+      expect(onUpdate).toHaveBeenCalledWith('test-mule-1', {
+        partySizes: { 'black-mage': 3, [LUCID_FAMILY]: 2 },
+      })
+    })
+
+    it('cell meso values visually divide after party size increases', () => {
+      renderDrawer({
+        mule: { ...baseMule, partySizes: { [LUCID_FAMILY]: 2 } },
+      })
+      const hardLucidCell = screen.getByTestId(`matrix-cell-${LUCID}-hard`)
+      expect(hardLucidCell.textContent).toBe(formatMeso(LUCID_HARD_VALUE / 2, true))
+    })
+
+    it('clamps party size at 6 when incrementing from 6 (no-op)', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({
+        mule: { ...baseMule, partySizes: { [LUCID_FAMILY]: 6 } },
+        onUpdate,
+      })
+      const incBtn = screen.getByTestId(`party-inc-${LUCID_FAMILY}`)
+      fireEvent.click(incBtn)
+      // Either the component swallows the click or the drawer clamps it;
+      // the invariant is that onUpdate is never called with a value > 6.
+      for (const call of onUpdate.mock.calls) {
+        const partySizes = (call[1] as { partySizes?: Record<string, number> }).partySizes
+        if (partySizes) {
+          for (const n of Object.values(partySizes)) {
+            expect(n).toBeLessThanOrEqual(6)
+          }
+        }
+      }
+    })
+
+    it('clamps party size at 1 when decrementing from 1 (no-op)', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({
+        mule: { ...baseMule, partySizes: { [LUCID_FAMILY]: 1 } },
+        onUpdate,
+      })
+      const decBtn = screen.getByTestId(`party-dec-${LUCID_FAMILY}`)
+      fireEvent.click(decBtn)
+      for (const call of onUpdate.mock.calls) {
+        const partySizes = (call[1] as { partySizes?: Record<string, number> }).partySizes
+        if (partySizes) {
+          for (const n of Object.values(partySizes)) {
+            expect(n).toBeGreaterThanOrEqual(1)
+          }
+        }
+      }
     })
   })
 })


### PR DESCRIPTION
## Summary

Adds a compact `Party − NP +` stepper to each family row in `BossMatrix`. Populated tier cells now display the **net** meso value (`formatMeso(crystalValue / partySize, true)`) — no `÷N` hint. Party size persists per mule, per family, on `Mule.partySizes: Record<string, number>` (the field already existed on the type; this slice wires the UI).

- Stepper lives inside the left-hand row header cell (no table widening); style uses existing CSS vars (`--surface`, `--border`, `--muted-foreground`, `--accent`) and `font-mono-nums` — no new custom CSS.
- Stepper button clicks call `e.stopPropagation()` + `e.preventDefault()` and are `disabled` at the 1/6 bounds, so they never toggle the underlying cell and never emit out-of-range values.
- Clamp logic is **deliberately duplicated**: `PartyStepper` refuses to emit values outside `[1, 6]`, and the drawer wraps with `Math.max(1, Math.min(6, n))` as defence in depth so storage can never record a bad value regardless of caller. The component contract is: "ask nicely, callback may or may not be invoked".

## Acceptance criteria → test

| Criterion | Test file:line |
| --- | --- |
| `Mule.partySizes?: Record<string, number>` — absent defaults to 1 | `src/components/__tests__/BossMatrix.test.tsx:198` (default "1P") |
| Each family row renders a `Party` label and `− NP +` stepper | `src/components/__tests__/BossMatrix.test.tsx:193` (one label per family), `:198` (stepper present) |
| Stepper clamps at 1 (min) and 6 (max) | `src/components/__tests__/BossMatrix.test.tsx:224`, `:232` (component), `src/components/__tests__/MuleDetailDrawer.test.tsx:240`, `:260` (drawer clamp) |
| Stepper clicks do NOT propagate to the cell click handler | `src/components/__tests__/BossMatrix.test.tsx:240`, `:250` |
| Populated cells show `formatMeso(crystalValue / partySize, true)` | `src/components/__tests__/BossMatrix.test.tsx:273`, `:279` |
| No ÷N hint inside cells | `src/components/__tests__/BossMatrix.test.tsx:285` |
| `onUpdate(muleId, { partySizes: { ...existing, [family]: n } })` | `src/components/__tests__/MuleDetailDrawer.test.tsx:202`, `:211` |

## Stack note

Stacks on #105 → #106 → #107 → #108 → this. Merge order: #105 → #106 → #107 → #108 → this PR. GitHub will auto-retarget the base when the predecessor merges.

## Scope flag

**Income KPI is NOT divided by party size in this slice** — party size is a display concern in the Matrix cells only. The Weekly KPI pill in the drawer and the dashboard KPIs continue to sum full `crystalValue`. The task spec explicitly reserves that decision for a separate slice; flagging here so reviewers can weigh in:

- **Argument to divide the KPI too:** the cell shows `500M ÷ 2 = 250M`, but the KPI still shows `500M`. A user who sets party=2 to model their actual take-home will see an inconsistency.
- **Argument to keep the KPI full:** party size is a per-mule budgeting overlay; the "tracker" primarily tracks gross crystal yield and other mules in the party are tracked separately on their own rows. Dividing would double-deduct when both party members are mules in the roster.

No decision here — flagging only.

## Test plan

- [x] `npm run build` — tsc + vite clean
- [x] `npm test` — 249 / 249 green (18 new: 11 BossMatrix, 5 drawer integration, 2 div/hint assertions)
- [x] `npm run lint` — 2 pre-existing errors (`MuleDetailDrawer` effect setState, `DensityProvider` empty catch), 0 new
- [ ] `npm run e2e` — environment missing chromium deps (browser launch fails, same as predecessor slices); run locally before merge. The Matrix drawer body isn't in any existing snapshot, so no visual drift expected.
- [ ] Manual smoke: open drawer, adjust party on Lotus 1 → 3, confirm cells live-divide; reload, confirm party size persists.

Two commits: feat (red → green) + refactor (unify step handlers, trim narration).

Closes #103