### PR TITLE
4: Responsive drawer width (mobile full-screen)

### DIFF
--- a/src/components/MuleDetailDrawer.tsx
+++ b/src/components/MuleDetailDrawer.tsx
@@ -60,7 +60,7 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
       <SheetContent
         side="right"
         showCloseButton={false}
-        className="data-[side=right]:w-[640px] data-[side=right]:sm:max-w-[640px] overflow-y-auto p-0"
+        className="data-[side=right]:w-screen data-[side=right]:md:w-[560px] data-[side=right]:md:max-w-[560px] overflow-y-auto p-0"
         style={{ background: 'var(--surface)', borderLeft: '1px solid var(--border)' }}
       >
         <SheetTitle className="sr-only">Mule Details</SheetTitle>

--- a/src/components/__tests__/MuleDetailDrawer.test.tsx
+++ b/src/components/__tests__/MuleDetailDrawer.test.tsx
@@ -123,6 +123,21 @@ describe('MuleDetailDrawer', () => {
     expect(document.querySelector('[data-slot="sheet-content"]')).toBeTruthy()
   })
 
+  // jsdom does not simulate viewport breakpoints, so we assert the class
+  // strings are applied to SheetContent rather than measuring visual widths.
+  // Tailwind handles the actual `<768px` vs `>=768px` switch at runtime.
+  it('applies full-screen width below md and 560px at md+', () => {
+    renderDrawer()
+    const content = document.querySelector(
+      '[data-slot="sheet-content"][data-side="right"]',
+    )
+    expect(content).toBeTruthy()
+    const className = content?.className ?? ''
+    expect(className).toContain('data-[side=right]:w-screen')
+    expect(className).toContain('data-[side=right]:md:w-[560px]')
+    expect(className).toContain('data-[side=right]:md:max-w-[560px]')
+  })
+
   it('renders abbreviated income by default', () => {
     renderDrawer({ mule: { ...baseMule, selectedBosses: [HARD_LUCID] } })
     // "504M" now appears both in the KPI pill and in the Matrix cell, so


### PR DESCRIPTION
## Summary

Make `MuleDetailDrawer`'s `SheetContent` responsive: full-viewport width below Tailwind's `md` breakpoint (`<768px`) and capped at `560px` at `md+`. Replaces the previous fixed `640px` layout.

```diff
- data-[side=right]:w-[640px] data-[side=right]:sm:max-w-[640px]
+ data-[side=right]:w-screen data-[side=right]:md:w-[560px] data-[side=right]:md:max-w-[560px]
```

No other drawer sizing, the Matrix grid, the Identity section, or any CSS vars are touched. `BossMatrix.tsx` is unchanged.

## Acceptance criteria to test

| Criterion | Verified at |
| --- | --- |
| `SheetContent` uses responsive width classes (full-screen <md, 560px md+) | `src/components/__tests__/MuleDetailDrawer.test.tsx:126-140` |
| `MuleDetailDrawer.test.tsx` updated to assert the responsive classes | same test |
| `npm test` all green | 232 / 232 (see test plan) |
| `npm run build` passes (tsc + vite) | see test plan |

`Closes #104`

## jsdom caveat

jsdom does not simulate viewport media queries, so we assert the *class strings are applied* to the rendered element (queried by `[data-slot="sheet-content"][data-side="right"]`) rather than measuring computed widths. Tailwind handles the actual breakpoint switch at runtime. A comment in the test file explains this.

## Stack note

Stacks on #108 (slice 2 — Matrix drawer). Merge order so far: #105 -> #106 -> #107 -> #108 -> (this PR and #109 in either order; both are parallel children of #108).

## e2e status

`npm run e2e` fails in this environment because `libnspr4.so` is missing (Playwright chromium system deps); predecessor slices noted the same. Not a regression from this change. Worth a manual pass once the host's Playwright deps are installed — viewport `{ width: 400, height: 800 }` should render the drawer full-screen; `{ width: 1024, height: 800 }` should render it 560px wide.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 232/232 passing
- [x] `npm run lint` — 2 pre-existing errors, 0 new
- [ ] Manual: resize browser below 768px, open drawer, confirm it spans full viewport and Matrix is readable
- [ ] Manual: resize browser >=768px, open drawer, confirm it's 560px wide with no horizontal scroll and Matrix fits comfortably
- [ ] Manual: verify Identity section, KPI pill, and trash-icon button still render correctly at both widths