### PR TITLE
Slice 3: Party stepper cadence-aware

### DIFF
--- a/src/components/BossMatrix.tsx
+++ b/src/components/BossMatrix.tsx
@@ -137,6 +137,7 @@ function FamilyRow({
   onChangePartySize: (family: string, n: number) => void;
 }) {
   const tierMap = tierByBossId.get(boss.id)!;
+  const hasWeeklyTier = boss.difficulty.some((d) => d.cadence === 'weekly');
   return (
     <div
       role="row"
@@ -154,11 +155,13 @@ function FamilyRow({
         >
           {boss.name}
         </span>
-        <PartyStepper
-          family={boss.family}
-          party={partySize}
-          onChangePartySize={onChangePartySize}
-        />
+        {hasWeeklyTier && (
+          <PartyStepper
+            family={boss.family}
+            party={partySize}
+            onChangePartySize={onChangePartySize}
+          />
+        )}
       </div>
       {TIER_ORDER.map((tier) => {
         const diff = tierMap.get(tier);
@@ -180,6 +183,10 @@ function FamilyRow({
         const isSelected = selectedTier === tier;
         const isDim = selectedTier !== undefined && !isSelected;
         const key = makeKey(boss.id, tier);
+        const displayValue =
+          diff.cadence === 'daily'
+            ? diff.crystalValue
+            : diff.crystalValue / partySize;
 
         return (
           <button
@@ -198,7 +205,7 @@ function FamilyRow({
             ].join(' ')}
           >
             <span style={isDim ? { opacity: 0.35 } : undefined}>
-              {formatMeso(diff.crystalValue / partySize, true)}
+              {formatMeso(displayValue, true)}
             </span>
           </button>
         );

--- a/src/components/__tests__/BossMatrix.test.tsx
+++ b/src/components/__tests__/BossMatrix.test.tsx
@@ -16,6 +16,19 @@ const BLACK_MAGE = BLACK_MAGE_BOSS.id
 const BLACK_MAGE_EXTREME_VALUE = BLACK_MAGE_BOSS.difficulty.find((d) => d.tier === 'extreme')!.crystalValue
 const AKECHI = bosses.find((b) => b.family === 'akechi-mitsuhide')!.id
 
+const HORNTAIL_BOSS = bosses.find((b) => b.family === 'horntail')!
+const HORNTAIL = HORNTAIL_BOSS.id
+
+const VELLUM_BOSS = bosses.find((b) => b.family === 'vellum')!
+const VELLUM = VELLUM_BOSS.id
+const VELLUM_NORMAL_VALUE = VELLUM_BOSS.difficulty.find((d) => d.tier === 'normal')!.crystalValue
+const VELLUM_CHAOS_VALUE = VELLUM_BOSS.difficulty.find((d) => d.tier === 'chaos')!.crystalValue
+
+const DAILY_ONLY_FAMILIES = ['horntail', 'von-leon', 'arkarium', 'mori-ranmaru', 'omni-cln']
+const BOSSES_WITH_WEEKLY_TIER_COUNT = bosses.filter((b) =>
+  b.difficulty.some((d) => d.cadence === 'weekly'),
+).length
+
 function renderMatrix(
   selectedKeys: string[] = [],
   onToggleKey = vi.fn(),
@@ -230,10 +243,10 @@ describe('BossMatrix', () => {
   })
 
   describe('party stepper', () => {
-    it('renders a Party label per family row', () => {
+    it('renders a Party label per family row that has at least one weekly tier', () => {
       renderMatrix()
       const labels = screen.getAllByText('Party')
-      expect(labels.length).toBe(bosses.length)
+      expect(labels.length).toBe(BOSSES_WITH_WEEKLY_TIER_COUNT)
     })
 
     it('renders a party stepper per family showing "1" when partySizes is absent', () => {
@@ -325,5 +338,99 @@ describe('BossMatrix', () => {
       const cell = screen.getByTestId(`matrix-cell-${BLACK_MAGE}-extreme`)
       expect(cell.textContent).toBe(formatMeso(BLACK_MAGE_EXTREME_VALUE, true))
     })
+  })
+
+  describe('cadence-aware party stepper visibility', () => {
+    it.each(DAILY_ONLY_FAMILIES)(
+      'omits the party stepper for daily-only family %s',
+      (family) => {
+        renderMatrix()
+        expect(
+          screen.queryByTestId(`party-stepper-${family}`),
+        ).toBeNull()
+      },
+    )
+
+    it('keeps the party stepper on mixed-cadence bosses (Vellum)', () => {
+      renderMatrix()
+      expect(
+        screen.getByTestId(`party-stepper-${VELLUM_BOSS.family}`),
+      ).toBeTruthy()
+    })
+
+    it('keeps the party stepper on weekly-only bosses (Black Mage)', () => {
+      renderMatrix()
+      expect(
+        screen.getByTestId(`party-stepper-${BLACK_MAGE_BOSS.family}`),
+      ).toBeTruthy()
+    })
+
+    it('daily-only rows still render with the same tier column layout as other rows', () => {
+      renderMatrix()
+      const horntailRow = screen
+        .getByTestId(`matrix-cell-${HORNTAIL}-easy`)
+        .closest('[role="row"]') as HTMLElement
+      const lucidRow = screen
+        .getByTestId(`matrix-cell-${LUCID}-easy`)
+        .closest('[role="row"]') as HTMLElement
+      expect(horntailRow.style.gridTemplateColumns).toBe(
+        lucidRow.style.gridTemplateColumns,
+      )
+    })
+  })
+
+  describe('cadence-aware cell displays', () => {
+    it('weekly cells on a mixed boss (Chaos Vellum) divide by party size', () => {
+      renderMatrix([], vi.fn(), { [VELLUM_BOSS.family]: 3 })
+      const chaosCell = screen.getByTestId(`matrix-cell-${VELLUM}-chaos`)
+      expect(chaosCell.textContent).toBe(
+        formatMeso(VELLUM_CHAOS_VALUE / 3, true),
+      )
+    })
+
+    it('daily cells on a mixed boss (Normal Vellum) ignore party size', () => {
+      renderMatrix([], vi.fn(), { [VELLUM_BOSS.family]: 3 })
+      const normalCell = screen.getByTestId(`matrix-cell-${VELLUM}-normal`)
+      expect(normalCell.textContent).toBe(formatMeso(VELLUM_NORMAL_VALUE, true))
+    })
+
+    it('changing party size from 1 to 3 updates only the weekly-tier cell display', () => {
+      const { rerender } = renderMatrix([], vi.fn(), {
+        [VELLUM_BOSS.family]: 1,
+      })
+      const chaosAt1 = screen.getByTestId(`matrix-cell-${VELLUM}-chaos`)
+        .textContent
+      const normalAt1 = screen.getByTestId(`matrix-cell-${VELLUM}-normal`)
+        .textContent
+
+      rerender(
+        <BossMatrix
+          selectedKeys={[]}
+          onToggleKey={vi.fn()}
+          partySizes={{ [VELLUM_BOSS.family]: 3 }}
+          onChangePartySize={vi.fn()}
+        />,
+      )
+
+      const chaosAt3 = screen.getByTestId(`matrix-cell-${VELLUM}-chaos`)
+        .textContent
+      const normalAt3 = screen.getByTestId(`matrix-cell-${VELLUM}-normal`)
+        .textContent
+
+      expect(chaosAt3).not.toBe(chaosAt1)
+      expect(chaosAt3).toBe(formatMeso(VELLUM_CHAOS_VALUE / 3, true))
+      expect(normalAt3).toBe(normalAt1)
+      expect(normalAt3).toBe(formatMeso(VELLUM_NORMAL_VALUE, true))
+    })
+
+    it.each(['easy', 'normal', 'chaos'] as const)(
+      'daily-only boss cells (Horntail %s) ignore party size even if a size is set',
+      (tier) => {
+        renderMatrix([], vi.fn(), { [HORNTAIL_BOSS.family]: 4 })
+        const cell = screen.getByTestId(`matrix-cell-${HORNTAIL}-${tier}`)
+        const diff = HORNTAIL_BOSS.difficulty.find((d) => d.tier === tier)!
+        expect(cell.textContent).toBe(formatMeso(diff.crystalValue, true))
+      },
+    )
   })
 })


### PR DESCRIPTION
## Summary
- Hide the `PartyStepper` on daily-only boss rows (Horntail, Von Leon, Arkarium, Mori Ranmaru, OMNI-CLN) via a per-family `hasWeeklyTier` check.
- Daily tier cells render `formatMeso(diff.crystalValue, true)` (party = 1); weekly tier cells still divide by `partySize`.
- `sumSelectedKeys` untouched — daily ×7 from Slice 1 remains the only cadence math in totals.

## Test plan
- [x] npm test — all green (285 tests, +14 new)
- [x] Acceptance criteria verified:
  - [x] Daily-only rows omit the stepper; grid column layout unchanged (same `gridTemplateColumns` as neighboring rows).
  - [x] Mixed boss (Vellum): partySize 1 → 3 only updates Chaos Vellum cell display; Normal Vellum stays at full crystal value.
  - [x] Weekly-only bosses (Black Mage, Lucid) still show the stepper and divide cells by partySize.

Closes #121