### PR TITLE
Slice 2: Independent daily + weekly selections per boss

### DIFF
--- a/src/components/BossMatrix.tsx
+++ b/src/components/BossMatrix.tsx
@@ -36,6 +36,8 @@ const tierByBossId = new Map<string, Map<BossTier, BossDifficulty>>(
   ]),
 );
 
+const EMPTY_TIER_SET: ReadonlySet<BossTier> = new Set();
+
 interface BossMatrixProps {
   selectedKeys: string[];
   onToggleKey: (key: string) => void;
@@ -125,18 +127,25 @@ function PartyStepper({
 
 function FamilyRow({
   boss,
-  selectedTier,
+  selectedTiers,
   partySize,
   onToggleKey,
   onChangePartySize,
 }: {
   boss: Boss;
-  selectedTier: BossTier | undefined;
+  selectedTiers: ReadonlySet<BossTier>;
   partySize: number;
   onToggleKey: (key: string) => void;
   onChangePartySize: (family: string, n: number) => void;
 }) {
   const tierMap = tierByBossId.get(boss.id)!;
+  // A tier cell dims iff another tier of the SAME cadence is selected on this
+  // boss — opposite-cadence tiers stay fully clickable (slice 2).
+  const selectedCadences = new Set(
+    boss.difficulty
+      .filter((d) => selectedTiers.has(d.tier))
+      .map((d) => d.cadence),
+  );
   const hasWeeklyTier = boss.difficulty.some((d) => d.cadence === 'weekly');
   return (
     <div
@@ -180,13 +189,13 @@ function FamilyRow({
           );
         }
 
-        const isSelected = selectedTier === tier;
-        const isDim = selectedTier !== undefined && !isSelected;
-        const key = makeKey(boss.id, tier);
-        const displayValue =
-          diff.cadence === 'daily'
-            ? diff.crystalValue
-            : diff.crystalValue / partySize;
+        const isSelected = selectedTiers.has(tier);
+        const isDim = !isSelected && selectedCadences.has(diff.cadence);
+        const key = makeKey(boss.id, tier, diff.cadence);
+        // Daily cells always render at full crystalValue; only weekly cells
+        // divide by the party size.
+        const displayedValue =
+          diff.cadence === 'daily' ? diff.crystalValue : diff.crystalValue / partySize;
 
         return (
           <button
@@ -205,7 +214,7 @@ function FamilyRow({
             ].join(' ')}
           >
             <span style={isDim ? { opacity: 0.35 } : undefined}>
-              {formatMeso(displayValue, true)}
+              {formatMeso(displayedValue, true)}
             </span>
           </button>
         );
@@ -220,10 +229,15 @@ export function BossMatrix({
   partySizes,
   onChangePartySize,
 }: BossMatrixProps) {
-  const selectedTierByBoss = new Map<string, BossTier>();
+  // Slice 2: a single boss can carry up to one daily + one weekly selection,
+  // so we track the full set of selected tiers per boss (not one winner).
+  const selectedTiersByBoss = new Map<string, Set<BossTier>>();
   for (const key of selectedKeys) {
     const parsed = parseKey(key);
-    if (parsed) selectedTierByBoss.set(parsed.bossId, parsed.tier);
+    if (!parsed) continue;
+    const existing = selectedTiersByBoss.get(parsed.bossId);
+    if (existing) existing.add(parsed.tier);
+    else selectedTiersByBoss.set(parsed.bossId, new Set([parsed.tier]));
   }
 
   return (
@@ -262,7 +276,7 @@ export function BossMatrix({
         <FamilyRow
           key={boss.id}
           boss={boss}
-          selectedTier={selectedTierByBoss.get(boss.id)}
+          selectedTiers={selectedTiersByBoss.get(boss.id) ?? EMPTY_TIER_SET}
           partySize={partySizes[boss.family] ?? 1}
           onToggleKey={onToggleKey}
           onChangePartySize={onChangePartySize}

--- a/src/components/__tests__/BossMatrix.test.tsx
+++ b/src/components/__tests__/BossMatrix.test.tsx
@@ -7,8 +7,9 @@ import { formatMeso } from '../../utils/meso'
 
 const LUCID_BOSS = bosses.find((b) => b.family === 'lucid')!
 const LUCID = LUCID_BOSS.id
-const HARD_LUCID = makeKey(LUCID, 'hard')
-const NORMAL_LUCID = makeKey(LUCID, 'normal')
+// Lucid tiers are all weekly pre- and post-slice-2.
+const HARD_LUCID = makeKey(LUCID, 'hard', 'weekly')
+const NORMAL_LUCID = makeKey(LUCID, 'normal', 'weekly')
 const LUCID_HARD_VALUE = LUCID_BOSS.difficulty.find((d) => d.tier === 'hard')!.crystalValue
 
 const BLACK_MAGE_BOSS = bosses.find((b) => b.family === 'black-mage')!
@@ -16,13 +17,22 @@ const BLACK_MAGE = BLACK_MAGE_BOSS.id
 const BLACK_MAGE_EXTREME_VALUE = BLACK_MAGE_BOSS.difficulty.find((d) => d.tier === 'extreme')!.crystalValue
 const AKECHI = bosses.find((b) => b.family === 'akechi-mitsuhide')!.id
 
-const HORNTAIL_BOSS = bosses.find((b) => b.family === 'horntail')!
-const HORNTAIL = HORNTAIL_BOSS.id
-
+// Mixed-cadence bosses (slice 2).
 const VELLUM_BOSS = bosses.find((b) => b.family === 'vellum')!
 const VELLUM = VELLUM_BOSS.id
 const VELLUM_NORMAL_VALUE = VELLUM_BOSS.difficulty.find((d) => d.tier === 'normal')!.crystalValue
 const VELLUM_CHAOS_VALUE = VELLUM_BOSS.difficulty.find((d) => d.tier === 'chaos')!.crystalValue
+const NORMAL_VELLUM_DAILY = makeKey(VELLUM, 'normal', 'daily')
+const CHAOS_VELLUM_WEEKLY = makeKey(VELLUM, 'chaos', 'weekly')
+
+const PAPULATUS_BOSS = bosses.find((b) => b.family === 'papulatus')!
+const PAPULATUS = PAPULATUS_BOSS.id
+const CHAOS_PAPULATUS_WEEKLY = makeKey(PAPULATUS, 'chaos', 'weekly')
+
+// Daily-only boss (Horntail).
+const HORNTAIL_BOSS = bosses.find((b) => b.family === 'horntail')!
+const HORNTAIL = HORNTAIL_BOSS.id
+const CHAOS_HORNTAIL_DAILY = makeKey(HORNTAIL, 'chaos', 'daily')
 
 const DAILY_ONLY_FAMILIES = ['horntail', 'von-leon', 'arkarium', 'mori-ranmaru', 'omni-cln']
 const BOSSES_WITH_WEEKLY_TIER_COUNT = bosses.filter((b) =>
@@ -146,7 +156,7 @@ describe('BossMatrix', () => {
       renderMatrix([], onToggleKey)
       const normalCell = screen.getByTestId(`matrix-cell-${AKECHI}-normal`)
       fireEvent.click(normalCell)
-      expect(onToggleKey).toHaveBeenCalledWith(makeKey(AKECHI, 'normal'))
+      expect(onToggleKey).toHaveBeenCalledWith(makeKey(AKECHI, 'normal', 'weekly'))
     })
   })
 
@@ -337,6 +347,84 @@ describe('BossMatrix', () => {
       renderMatrix([], vi.fn(), { [LUCID_BOSS.family]: 4 })
       const cell = screen.getByTestId(`matrix-cell-${BLACK_MAGE}-extreme`)
       expect(cell.textContent).toBe(formatMeso(BLACK_MAGE_EXTREME_VALUE, true))
+    })
+
+    // Slice 2: daily tier cells render at full crystalValue — only weekly
+    // tiers divide by party size.
+    it('does not divide daily tier cells by the party size', () => {
+      // Vellum Normal is daily; displayed value stays at full crystalValue
+      // regardless of party size.
+      renderMatrix([], vi.fn(), { [VELLUM_BOSS.family]: 4 })
+      const cell = screen.getByTestId(`matrix-cell-${VELLUM}-normal`)
+      expect(cell.textContent).toBe(formatMeso(VELLUM_NORMAL_VALUE, true))
+    })
+
+    it('still divides weekly tier cells on a mixed boss by the party size', () => {
+      // Vellum Chaos is weekly; divides by party size.
+      renderMatrix([], vi.fn(), { [VELLUM_BOSS.family]: 2 })
+      const cell = screen.getByTestId(`matrix-cell-${VELLUM}-chaos`)
+      expect(cell.textContent).toBe(formatMeso(VELLUM_CHAOS_VALUE / 2, true))
+    })
+  })
+
+  // Slice 2: dimming now respects cadence — opposite-cadence tiers stay active.
+  describe('per-cadence dim (slice 2)', () => {
+    it('selecting a weekly tier on a mixed boss does NOT dim its daily tiers', () => {
+      // Chaos Papulatus (weekly) selected. Papulatus easy/normal are daily.
+      renderMatrix([CHAOS_PAPULATUS_WEEKLY])
+      const easyDaily = screen.getByTestId(`matrix-cell-${PAPULATUS}-easy`)
+      const normalDaily = screen.getByTestId(`matrix-cell-${PAPULATUS}-normal`)
+      expect(easyDaily.getAttribute('data-dim')).not.toBe('true')
+      expect(normalDaily.getAttribute('data-dim')).not.toBe('true')
+    })
+
+    it('selecting a daily tier on a mixed boss does NOT dim its weekly tiers', () => {
+      // Normal Vellum (daily) selected. Chaos Vellum is weekly — stay active.
+      renderMatrix([NORMAL_VELLUM_DAILY])
+      const chaosWeekly = screen.getByTestId(`matrix-cell-${VELLUM}-chaos`)
+      expect(chaosWeekly.getAttribute('data-dim')).not.toBe('true')
+    })
+
+    it('selecting a weekly tier DOES dim other weekly tiers on the same boss', () => {
+      // Hard Magnus is weekly; Magnus has no other weekly tiers, so use
+      // Kalos (chaos weekly) — normal/easy weekly should dim.
+      const KALOS_BOSS = bosses.find((b) => b.family === 'kalos-the-guardian')!
+      const chaosKalos = makeKey(KALOS_BOSS.id, 'chaos', 'weekly')
+      renderMatrix([chaosKalos])
+      const normalCell = screen.getByTestId(`matrix-cell-${KALOS_BOSS.id}-normal`)
+      expect(normalCell.getAttribute('data-dim')).toBe('true')
+    })
+
+    it('selecting a daily tier DOES dim other daily tiers on the same boss', () => {
+      // Horntail easy/normal/chaos are all daily. Selecting chaos dims others.
+      renderMatrix([CHAOS_HORNTAIL_DAILY])
+      const normalCell = screen.getByTestId(`matrix-cell-${HORNTAIL}-normal`)
+      const easyCell = screen.getByTestId(`matrix-cell-${HORNTAIL}-easy`)
+      expect(normalCell.getAttribute('data-dim')).toBe('true')
+      expect(easyCell.getAttribute('data-dim')).toBe('true')
+    })
+
+    it('renders both daily and weekly selections on a mixed boss as on', () => {
+      renderMatrix([NORMAL_VELLUM_DAILY, CHAOS_VELLUM_WEEKLY])
+      const normalCell = screen.getByTestId(`matrix-cell-${VELLUM}-normal`)
+      const chaosCell = screen.getByTestId(`matrix-cell-${VELLUM}-chaos`)
+      expect(normalCell.getAttribute('data-state')).toBe('on')
+      expect(chaosCell.getAttribute('data-state')).toBe('on')
+    })
+  })
+
+  // Slice 2: daily-only bosses omit the party stepper.
+  describe('party stepper visibility (slice 2)', () => {
+    it('renders the party stepper on a mixed-cadence boss row', () => {
+      renderMatrix()
+      const stepper = screen.queryByTestId(`party-stepper-${VELLUM_BOSS.family}`)
+      expect(stepper).not.toBeNull()
+    })
+
+    it('omits the party stepper on a daily-only boss row', () => {
+      renderMatrix()
+      const stepper = screen.queryByTestId(`party-stepper-${HORNTAIL_BOSS.family}`)
+      expect(stepper).toBeNull()
     })
   })
 

--- a/src/components/__tests__/IncomePieChart.test.tsx
+++ b/src/components/__tests__/IncomePieChart.test.tsx
@@ -6,7 +6,8 @@ import { bosses } from '../../data/bosses'
 import { makeKey } from '../../data/bossSelection'
 
 const HILLA = bosses.find((b) => b.family === 'hilla')!.id
-const NORMAL_HILLA = makeKey(HILLA, 'normal')
+// Normal Hilla is a daily tier (slice 2, per the PRD daily classification).
+const NORMAL_HILLA = makeKey(HILLA, 'normal', 'daily')
 
 const muleWithBosses: Mule = {
   id: 'mule-1',

--- a/src/components/__tests__/MuleCharacterCard.test.tsx
+++ b/src/components/__tests__/MuleCharacterCard.test.tsx
@@ -8,7 +8,7 @@ import { bosses } from '../../data/bosses'
 import { makeKey } from '../../data/bossSelection'
 
 const LUCID = bosses.find((b) => b.family === 'lucid')!.id
-const HARD_LUCID = makeKey(LUCID, 'hard')
+const HARD_LUCID = makeKey(LUCID, 'hard', 'weekly')
 
 const baseMule: Mule = {
   id: 'test-mule-1',

--- a/src/components/__tests__/MuleDetailDrawer.test.tsx
+++ b/src/components/__tests__/MuleDetailDrawer.test.tsx
@@ -11,8 +11,8 @@ const LUCID_BOSS = bosses.find((b) => b.family === 'lucid')!
 const LUCID = LUCID_BOSS.id
 const LUCID_FAMILY = LUCID_BOSS.family
 const LUCID_HARD_VALUE = LUCID_BOSS.difficulty.find((d) => d.tier === 'hard')!.crystalValue
-const HARD_LUCID = makeKey(LUCID, 'hard')
-const NORMAL_LUCID = makeKey(LUCID, 'normal')
+const HARD_LUCID = makeKey(LUCID, 'hard', 'weekly')
+const NORMAL_LUCID = makeKey(LUCID, 'normal', 'weekly')
 
 const baseMule: Mule = {
   id: 'test-mule-1',

--- a/src/data/__tests__/bossSelection.test.ts
+++ b/src/data/__tests__/bossSelection.test.ts
@@ -7,13 +7,19 @@ import {
   parseKey,
   TIER_ORDER,
 } from '../bossSelection'
-import { bosses } from '../bosses'
+import { bosses, getBossById } from '../bosses'
 import type { BossTier } from '../../types'
 
 function idForFamily(family: string): string {
   const boss = bosses.find((b) => b.family === family)
   if (!boss) throw new Error(`No boss found for family ${family}`)
   return boss.id
+}
+
+/** Build a selection key, looking up cadence from the real boss data. */
+function key(bossId: string, tier: BossTier): string {
+  const diff = getBossById(bossId)!.difficulty.find((d) => d.tier === tier)!
+  return makeKey(bossId, tier, diff.cadence)
 }
 
 const LUCID = idForFamily('lucid')
@@ -24,6 +30,9 @@ const AKECHI = idForFamily('akechi-mitsuhide')
 const BLACK_MAGE = idForFamily('black-mage')
 const ZAKUM = idForFamily('zakum')
 const KALOS = idForFamily('kalos-the-guardian')
+const VELLUM = idForFamily('vellum')
+const PAPULATUS = idForFamily('papulatus')
+const HORNTAIL = idForFamily('horntail')
 
 describe('TIER_ORDER', () => {
   it('exports tiers in extreme → easy order (hardest first)', () => {
@@ -33,94 +42,175 @@ describe('TIER_ORDER', () => {
 })
 
 describe('makeKey / parseKey', () => {
-  it('makeKey concatenates bossId and tier with a colon', () => {
-    expect(makeKey(LUCID, 'hard')).toBe(`${LUCID}:hard`)
+  it('makeKey joins bossId, tier, and cadence with colons', () => {
+    expect(makeKey(LUCID, 'hard', 'weekly')).toBe(`${LUCID}:hard:weekly`)
   })
 
-  it('parseKey round-trips a valid key', () => {
-    const key = makeKey(LUCID, 'hard')
-    expect(parseKey(key)).toEqual({ bossId: LUCID, tier: 'hard' })
+  it('parseKey round-trips a valid weekly key', () => {
+    const k = makeKey(LUCID, 'hard', 'weekly')
+    expect(parseKey(k)).toEqual({ bossId: LUCID, tier: 'hard', cadence: 'weekly' })
   })
 
-  it('parseKey returns null for a malformed key with no colon', () => {
+  it('parseKey round-trips a valid daily key (Normal Vellum)', () => {
+    const k = makeKey(VELLUM, 'normal', 'daily')
+    expect(parseKey(k)).toEqual({ bossId: VELLUM, tier: 'normal', cadence: 'daily' })
+  })
+
+  it('parseKey returns null for a malformed key with no colons', () => {
     expect(parseKey('hard-lucid')).toBeNull()
   })
 
+  it('parseKey returns null for a two-segment (legacy v2) key', () => {
+    expect(parseKey(`${LUCID}:hard`)).toBeNull()
+  })
+
   it('parseKey returns null when tier is unknown', () => {
-    expect(parseKey(`${LUCID}:mythic`)).toBeNull()
+    expect(parseKey(`${LUCID}:mythic:weekly`)).toBeNull()
+  })
+
+  it('parseKey returns null when cadence segment is unknown', () => {
+    expect(parseKey(`${LUCID}:hard:monthly`)).toBeNull()
+  })
+
+  it('parseKey returns null when cadence disagrees with boss data', () => {
+    // Chaos Vellum is weekly; marking it daily in the key is a stale migration.
+    expect(parseKey(`${VELLUM}:chaos:daily`)).toBeNull()
+    // Hard Lucid is weekly; marking it daily is stale.
+    expect(parseKey(`${LUCID}:hard:daily`)).toBeNull()
   })
 
   it('parseKey returns null when bossId is not in bosses', () => {
-    expect(parseKey('not-a-uuid:hard')).toBeNull()
+    expect(parseKey('not-a-uuid:hard:weekly')).toBeNull()
   })
 })
 
 describe('toggleBoss', () => {
   it('selects a boss in an empty family', () => {
-    expect(toggleBoss([], LUCID, 'hard')).toEqual([makeKey(LUCID, 'hard')])
+    expect(toggleBoss([], LUCID, 'hard')).toEqual([key(LUCID, 'hard')])
   })
 
   it('auto-replaces when selecting a different tier in the same family', () => {
-    const selection = [makeKey(LUCID, 'normal')]
-    expect(toggleBoss(selection, LUCID, 'hard')).toEqual([makeKey(LUCID, 'hard')])
+    const selection = [key(LUCID, 'normal')]
+    expect(toggleBoss(selection, LUCID, 'hard')).toEqual([key(LUCID, 'hard')])
   })
 
   it('deselects when toggling the already-selected tier', () => {
-    const selection = [makeKey(LUCID, 'hard')]
+    const selection = [key(LUCID, 'hard')]
     expect(toggleBoss(selection, LUCID, 'hard')).toEqual([])
   })
 
   it('adds a boss from a different family without conflict', () => {
-    const selection = [makeKey(LUCID, 'hard')]
+    const selection = [key(LUCID, 'hard')]
     expect(toggleBoss(selection, WILL, 'hard')).toEqual([
-      makeKey(LUCID, 'hard'),
-      makeKey(WILL, 'hard'),
+      key(LUCID, 'hard'),
+      key(WILL, 'hard'),
     ])
   })
 
   it('replaces in same family while preserving other families and array order', () => {
-    const selection = [makeKey(WILL, 'normal'), makeKey(LUCID, 'hard')]
+    const selection = [key(WILL, 'normal'), key(LUCID, 'hard')]
     expect(toggleBoss(selection, WILL, 'hard')).toEqual([
-      makeKey(WILL, 'hard'),
-      makeKey(LUCID, 'hard'),
+      key(WILL, 'hard'),
+      key(LUCID, 'hard'),
     ])
   })
 
   it('returns unchanged array for unknown bossId', () => {
-    const selection = [makeKey(LUCID, 'hard')]
+    const selection = [key(LUCID, 'hard')]
     expect(toggleBoss(selection, 'not-a-real-boss-id', 'hard')).toEqual(selection)
   })
 
   it('returns unchanged array when tier is not offered for the boss', () => {
-    const selection = [makeKey(LUCID, 'hard')]
+    const selection = [key(LUCID, 'hard')]
     // Lucid offers easy/normal/hard — chaos is not in its difficulty[]
     expect(toggleBoss(selection, LUCID, 'chaos')).toEqual(selection)
   })
 
   it('handles replace with multiple concurrent selections', () => {
-    const selection = [makeKey(LUCID, 'hard'), makeKey(WILL, 'normal'), makeKey(LOTUS, 'hard')]
+    const selection = [key(LUCID, 'hard'), key(WILL, 'normal'), key(LOTUS, 'hard')]
     expect(toggleBoss(selection, WILL, 'easy')).toEqual([
-      makeKey(LUCID, 'hard'),
-      makeKey(WILL, 'easy'),
-      makeKey(LOTUS, 'hard'),
+      key(LUCID, 'hard'),
+      key(WILL, 'easy'),
+      key(LOTUS, 'hard'),
     ])
+  })
+
+  // Slice 2: mixed-cadence bosses keep one daily + one weekly simultaneously.
+  describe('mixed-cadence boss (Vellum)', () => {
+    it('keeps daily + weekly selections on the same boss simultaneously', () => {
+      // Normal Vellum is daily, Chaos Vellum is weekly.
+      const normalDaily = key(VELLUM, 'normal')
+      const chaosWeekly = key(VELLUM, 'chaos')
+      // Select daily first, then weekly — both stay.
+      let sel = toggleBoss([], VELLUM, 'normal')
+      sel = toggleBoss(sel, VELLUM, 'chaos')
+      expect(sel).toEqual([normalDaily, chaosWeekly])
+    })
+
+    it('picking a weekly tier on a mixed boss leaves the daily selection untouched', () => {
+      // Papulatus: easy/normal are daily; chaos is weekly.
+      const normalDaily = key(PAPULATUS, 'normal')
+      const chaosWeekly = key(PAPULATUS, 'chaos')
+      expect(toggleBoss([normalDaily], PAPULATUS, 'chaos')).toEqual([
+        normalDaily,
+        chaosWeekly,
+      ])
+    })
+
+    it('selecting a different daily tier replaces only the existing daily', () => {
+      // Papulatus: easy (daily) → normal (daily) replaces; chaos weekly stays.
+      const easyDaily = key(PAPULATUS, 'easy')
+      const normalDaily = key(PAPULATUS, 'normal')
+      const chaosWeekly = key(PAPULATUS, 'chaos')
+      expect(toggleBoss([easyDaily, chaosWeekly], PAPULATUS, 'normal')).toEqual([
+        normalDaily,
+        chaosWeekly,
+      ])
+    })
+
+    it('re-clicking an already-selected daily tier clears only the daily', () => {
+      const normalDaily = key(VELLUM, 'normal')
+      const chaosWeekly = key(VELLUM, 'chaos')
+      expect(toggleBoss([normalDaily, chaosWeekly], VELLUM, 'normal')).toEqual([
+        chaosWeekly,
+      ])
+    })
+  })
+
+  describe('daily-only boss (Horntail)', () => {
+    it('selecting a tier on an empty daily-only boss adds the daily key', () => {
+      const chaosDaily = key(HORNTAIL, 'chaos')
+      expect(toggleBoss([], HORNTAIL, 'chaos')).toEqual([chaosDaily])
+    })
+
+    it('selecting a different daily tier replaces the sibling', () => {
+      // Horntail: easy, normal, chaos are all daily.
+      const normalDaily = key(HORNTAIL, 'normal')
+      const chaosDaily = key(HORNTAIL, 'chaos')
+      expect(toggleBoss([normalDaily], HORNTAIL, 'chaos')).toEqual([chaosDaily])
+    })
+
+    it('re-clicking the selected daily tier clears it', () => {
+      const chaosDaily = key(HORNTAIL, 'chaos')
+      expect(toggleBoss([chaosDaily], HORNTAIL, 'chaos')).toEqual([])
+    })
   })
 })
 
 describe('validateBossSelection', () => {
   it('removes unknown keys', () => {
     expect(
-      validateBossSelection([makeKey(LUCID, 'hard'), 'stale-id', 'another:stale']),
-    ).toEqual([makeKey(LUCID, 'hard')])
+      validateBossSelection([key(LUCID, 'hard'), 'stale-id', 'another:stale']),
+    ).toEqual([key(LUCID, 'hard')])
   })
 
   it('drops keys with unknown bossId', () => {
-    expect(validateBossSelection(['not-a-uuid:hard'])).toEqual([])
+    expect(validateBossSelection(['not-a-uuid:hard:weekly'])).toEqual([])
   })
 
   it('drops keys with a tier not offered for the boss', () => {
     // Lucid does not offer chaos
-    expect(validateBossSelection([makeKey(LUCID, 'chaos')])).toEqual([])
+    expect(validateBossSelection([`${LUCID}:chaos:weekly`])).toEqual([])
   })
 
   it('returns empty array when all keys invalid', () => {
@@ -128,7 +218,7 @@ describe('validateBossSelection', () => {
   })
 
   it('returns input when all keys valid and no family conflicts', () => {
-    const keys = [makeKey(LUCID, 'hard'), makeKey(WILL, 'hard')]
+    const keys = [key(LUCID, 'hard'), key(WILL, 'hard')]
     expect(validateBossSelection(keys)).toEqual(keys)
   })
 
@@ -137,53 +227,69 @@ describe('validateBossSelection', () => {
   })
 
   it('keeps highest-value tier per family when duplicates exist', () => {
-    const keys = [makeKey(LUCID, 'normal'), makeKey(LUCID, 'hard')]
-    expect(validateBossSelection(keys)).toEqual([makeKey(LUCID, 'hard')])
+    const keys = [key(LUCID, 'normal'), key(LUCID, 'hard')]
+    expect(validateBossSelection(keys)).toEqual([key(LUCID, 'hard')])
   })
 
   it('preserves original order among kept entries', () => {
     const keys = [
-      makeKey(WILL, 'hard'),
-      makeKey(LUCID, 'normal'),
-      makeKey(LUCID, 'hard'),
+      key(WILL, 'hard'),
+      key(LUCID, 'normal'),
+      key(LUCID, 'hard'),
     ]
     expect(validateBossSelection(keys)).toEqual([
-      makeKey(WILL, 'hard'),
-      makeKey(LUCID, 'hard'),
+      key(WILL, 'hard'),
+      key(LUCID, 'hard'),
     ])
   })
 
   it('removes both invalid and duplicate-family entries', () => {
     const keys = [
       'fake-key',
-      makeKey(LUCID, 'easy'),
-      makeKey(LUCID, 'hard'),
-      makeKey(WILL, 'hard'),
+      key(LUCID, 'easy'),
+      key(LUCID, 'hard'),
+      key(WILL, 'hard'),
     ]
     expect(validateBossSelection(keys)).toEqual([
-      makeKey(LUCID, 'hard'),
-      makeKey(WILL, 'hard'),
+      key(LUCID, 'hard'),
+      key(WILL, 'hard'),
     ])
   })
 
   it('handles three tiers from same family keeping highest', () => {
     const keys = [
-      makeKey(LUCID, 'easy'),
-      makeKey(LUCID, 'normal'),
-      makeKey(LUCID, 'hard'),
+      key(LUCID, 'easy'),
+      key(LUCID, 'normal'),
+      key(LUCID, 'hard'),
     ]
-    expect(validateBossSelection(keys)).toEqual([makeKey(LUCID, 'hard')])
+    expect(validateBossSelection(keys)).toEqual([key(LUCID, 'hard')])
   })
 
   it('keeps singletons across families', () => {
-    const keys = [makeKey(LUCID, 'hard'), makeKey(WILL, 'hard'), makeKey(DAMIEN, 'hard')]
+    const keys = [key(LUCID, 'hard'), key(WILL, 'hard'), key(DAMIEN, 'hard')]
     expect(validateBossSelection(keys)).toEqual(keys)
+  })
+
+  // Slice 2: per-cadence winner — one daily + one weekly per boss.
+  it('keeps a daily and a weekly winner on the same boss simultaneously', () => {
+    const keys = [key(VELLUM, 'normal'), key(VELLUM, 'chaos')]
+    expect(validateBossSelection(keys)).toEqual(keys)
+  })
+
+  it('keeps only the highest daily when two daily tiers conflict', () => {
+    // Papulatus easy + normal are both daily → normal wins (higher value).
+    const easyDaily = key(PAPULATUS, 'easy')
+    const normalDaily = key(PAPULATUS, 'normal')
+    const chaosWeekly = key(PAPULATUS, 'chaos')
+    expect(
+      validateBossSelection([easyDaily, normalDaily, chaosWeekly]),
+    ).toEqual([normalDaily, chaosWeekly])
   })
 })
 
 describe('getFamilies', () => {
   it('returns all families with correct selected flags', () => {
-    const families = getFamilies([makeKey(LUCID, 'hard')], '')
+    const families = getFamilies([key(LUCID, 'hard')], '')
     const lucidFamily = families.find((f) => f.family === 'lucid')!
     expect(lucidFamily).toBeDefined()
 
@@ -228,11 +334,11 @@ describe('getFamilies', () => {
     }
   })
 
-  it('each tier entry carries a `key` equal to makeKey(bossId, tier)', () => {
+  it('each tier entry carries a `key` equal to makeKey(bossId, tier, cadence)', () => {
     const families = getFamilies([], '')
     const lucidFamily = families.find((f) => f.family === 'lucid')!
     const hardLucid = lucidFamily.bosses.find((b) => b.tier === 'hard')!
-    expect(hardLucid.key).toBe(makeKey(LUCID, 'hard'))
+    expect(hardLucid.key).toBe(makeKey(LUCID, 'hard', 'weekly'))
   })
 
   it('populates crystalValue on each tier', () => {
@@ -338,23 +444,35 @@ describe('getFamilies', () => {
 })
 
 describe('cross-reference sanity', () => {
-  it('BLACK_MAGE extreme tier is a valid key', () => {
-    const key = makeKey(BLACK_MAGE, 'extreme')
-    expect(parseKey(key)).toEqual({ bossId: BLACK_MAGE, tier: 'extreme' })
+  it('BLACK_MAGE extreme tier is a valid weekly key', () => {
+    const k = makeKey(BLACK_MAGE, 'extreme', 'weekly')
+    expect(parseKey(k)).toEqual({
+      bossId: BLACK_MAGE,
+      tier: 'extreme',
+      cadence: 'weekly',
+    })
   })
 
-  it('ZAKUM easy tier is a valid key', () => {
-    const key = makeKey(ZAKUM, 'easy')
-    expect(parseKey(key)).toEqual({ bossId: ZAKUM, tier: 'easy' })
+  it('ZAKUM easy tier is a valid daily key', () => {
+    const k = makeKey(ZAKUM, 'easy', 'daily')
+    expect(parseKey(k)).toEqual({ bossId: ZAKUM, tier: 'easy', cadence: 'daily' })
   })
 
-  it('KALOS chaos tier is a valid key', () => {
-    const key = makeKey(KALOS, 'chaos')
-    expect(parseKey(key)).toEqual({ bossId: KALOS, tier: 'chaos' })
+  it('KALOS chaos tier is a valid weekly key', () => {
+    const k = makeKey(KALOS, 'chaos', 'weekly')
+    expect(parseKey(k)).toEqual({
+      bossId: KALOS,
+      tier: 'chaos',
+      cadence: 'weekly',
+    })
   })
 
-  it('AKECHI normal tier is a valid key (tier-less family)', () => {
-    const key = makeKey(AKECHI, 'normal')
-    expect(parseKey(key)).toEqual({ bossId: AKECHI, tier: 'normal' })
+  it('AKECHI normal tier is a valid weekly key (tier-less family)', () => {
+    const k = makeKey(AKECHI, 'normal', 'weekly')
+    expect(parseKey(k)).toEqual({
+      bossId: AKECHI,
+      tier: 'normal',
+      cadence: 'weekly',
+    })
   })
 })

--- a/src/data/bossSelection.ts
+++ b/src/data/bossSelection.ts
@@ -1,10 +1,12 @@
-import type { Boss, BossDifficulty, BossTier } from '../types';
+import type { Boss, BossCadence, BossDifficulty, BossTier } from '../types';
 import { bosses, getBossById, TIER_LESS_FAMILIES } from './bosses';
 import { formatMeso } from '../utils/meso';
 
 /**
- * Selection key format: `<bossUuid>:<tier>`. Stored directly on
- * `Mule.selectedBosses`. Use `makeKey` / `parseKey` to construct or decode.
+ * Selection key format: `<bossUuid>:<tier>:<cadence>` (e.g.
+ * `a4d1238d-…:chaos:weekly`). Stored directly on `Mule.selectedBosses`. Use
+ * `makeKey` / `parseKey` to construct or decode — the cadence segment lets a
+ * single boss carry independent daily and weekly selections simultaneously.
  */
 
 /** Tier order used by the Matrix component (columns, extreme → easy, hardest first). */
@@ -12,10 +14,12 @@ export const TIER_ORDER: BossTier[] = ['extreme', 'chaos', 'hard', 'normal', 'ea
 
 const TIER_SET: ReadonlySet<BossTier> = new Set(TIER_ORDER);
 
+const CADENCE_SET: ReadonlySet<BossCadence> = new Set(['daily', 'weekly']);
+
 /**
  * Capitalized difficulty label for the pip colour / row name prefix. Distinct
  * from the `BossDifficulty` *interface* in `../types` that holds the
- * `{ tier, crystalValue }` shape.
+ * `{ tier, crystalValue, cadence }` shape.
  */
 export type BossDifficultyLabel = 'Extreme' | 'Chaos' | 'Hard' | 'Normal' | 'Easy';
 
@@ -27,23 +31,39 @@ const TIER_LABEL: Record<BossTier, BossDifficultyLabel> = {
   extreme: 'Extreme',
 };
 
-/** Build a native selection key from a boss id and tier. */
-export function makeKey(bossId: string, tier: BossTier): string {
-  return `${bossId}:${tier}`;
+/** Build a native selection key from a boss id, tier, and cadence. */
+export function makeKey(bossId: string, tier: BossTier, cadence: BossCadence): string {
+  return `${bossId}:${tier}:${cadence}`;
 }
 
-/** Parse a selection key. Returns null if malformed, unknown boss, or tier not offered. */
-export function parseKey(key: string): { bossId: string; tier: BossTier } | null {
-  const colon = key.lastIndexOf(':');
-  if (colon < 0) return null;
-  const tierStr = key.slice(colon + 1);
+/**
+ * Parse a selection key. Returns null if malformed, unknown boss, tier not
+ * offered, or if the cadence segment disagrees with the boss data. Splits
+ * on the last two colons so `bossId` (a UUID with its own dashes) stays
+ * intact as the prefix.
+ */
+export function parseKey(
+  key: string,
+): { bossId: string; tier: BossTier; cadence: BossCadence } | null {
+  const lastColon = key.lastIndexOf(':');
+  if (lastColon < 0) return null;
+  const tierColon = key.lastIndexOf(':', lastColon - 1);
+  if (tierColon < 0) return null;
+
+  const tierStr = key.slice(tierColon + 1, lastColon);
+  const cadenceStr = key.slice(lastColon + 1);
   if (!TIER_SET.has(tierStr as BossTier)) return null;
-  const bossId = key.slice(0, colon);
+  if (!CADENCE_SET.has(cadenceStr as BossCadence)) return null;
+
+  const bossId = key.slice(0, tierColon);
   const boss = getBossById(bossId);
   if (!boss) return null;
+
   const tier = tierStr as BossTier;
-  if (!boss.difficulty.some((d) => d.tier === tier)) return null;
-  return { bossId, tier };
+  const cadence = cadenceStr as BossCadence;
+  const diff = boss.difficulty.find((d) => d.tier === tier);
+  if (!diff || diff.cadence !== cadence) return null;
+  return { bossId, tier, cadence };
 }
 
 function resolveKey(key: string): { boss: Boss; diff: BossDifficulty } | null {
@@ -61,7 +81,7 @@ function resolveKey(key: string): { boss: Boss; diff: BossDifficulty } | null {
 export interface FamilyRow {
   bossId: string;
   tier: BossTier;
-  /** Selection key = `makeKey(bossId, tier)`. Also used as React list key. */
+  /** Selection key = `makeKey(bossId, tier, cadence)`. Also used as React list key. */
   key: string;
   /** Display label — "<Tier> <Family>" for tiered families, bare family name otherwise. */
   name: string;
@@ -83,18 +103,32 @@ function rowLabel(family: string, tier: BossTier, familyName: string): string {
 }
 
 export function validateBossSelection(keys: string[]): string[] {
-  interface ResolvedKey { key: string; bossId: string; crystalValue: number }
+  interface ResolvedKey {
+    key: string;
+    bossId: string;
+    cadence: BossCadence;
+    crystalValue: number;
+  }
   const resolved: ResolvedKey[] = [];
   for (const key of keys) {
     const r = resolveKey(key);
-    if (r) resolved.push({ key, bossId: r.boss.id, crystalValue: r.diff.crystalValue });
+    if (r) {
+      resolved.push({
+        key,
+        bossId: r.boss.id,
+        cadence: r.diff.cadence,
+        crystalValue: r.diff.crystalValue,
+      });
+    }
   }
 
-  // Pick the first-seen key with the highest crystalValue per family.
+  // One winner per (bossId, cadence): a boss can retain one daily AND one
+  // weekly selection simultaneously.
   const winner = new Map<string, ResolvedKey>();
   for (const r of resolved) {
-    const current = winner.get(r.bossId);
-    if (!current || r.crystalValue > current.crystalValue) winner.set(r.bossId, r);
+    const bucket = `${r.bossId}:${r.cadence}`;
+    const current = winner.get(bucket);
+    if (!current || r.crystalValue > current.crystalValue) winner.set(bucket, r);
   }
   const winnerKeys = new Set(Array.from(winner.values(), (w) => w.key));
   return resolved.filter((r) => winnerKeys.has(r.key)).map((r) => r.key);
@@ -102,10 +136,17 @@ export function validateBossSelection(keys: string[]): string[] {
 
 export function toggleBoss(keys: string[], bossId: string, tier: BossTier): string[] {
   const boss = getBossById(bossId);
-  if (!boss || !boss.difficulty.some((d) => d.tier === tier)) return keys;
+  if (!boss) return keys;
+  const diff = boss.difficulty.find((d) => d.tier === tier);
+  if (!diff) return keys;
 
-  const target = makeKey(bossId, tier);
-  const existingKey = keys.find((k) => parseKey(k)?.bossId === bossId);
+  const target = makeKey(bossId, tier, diff.cadence);
+  // Same-cadence sibling on the same boss: opposite-cadence selections are
+  // untouched so a mule can keep one daily + one weekly simultaneously.
+  const existingKey = keys.find((k) => {
+    const p = parseKey(k);
+    return p?.bossId === bossId && p.cadence === diff.cadence;
+  });
   if (existingKey === target) return keys.filter((k) => k !== target);
   if (existingKey) return keys.map((k) => (k === existingKey ? target : k));
   return [...keys, target];
@@ -138,7 +179,7 @@ export function getFamilies(
       .slice()
       .sort((a, b) => b.crystalValue - a.crystalValue)
       .map((diff): FamilyRow => {
-        const key = makeKey(boss.id, diff.tier);
+        const key = makeKey(boss.id, diff.tier, diff.cadence);
         return {
           bossId: boss.id,
           tier: diff.tier,

--- a/src/hooks/__tests__/useMules.test.ts
+++ b/src/hooks/__tests__/useMules.test.ts
@@ -4,11 +4,22 @@ import { useMules } from '../useMules'
 import { bosses } from '../../data/bosses'
 import { makeKey } from '../../data/bossSelection'
 
-const LUCID = bosses.find((b) => b.family === 'lucid')!.id
+const LUCID_BOSS = bosses.find((b) => b.family === 'lucid')!
+const VELLUM_BOSS = bosses.find((b) => b.family === 'vellum')!
+const LUCID = LUCID_BOSS.id
 const WILL = bosses.find((b) => b.family === 'will')!.id
-const HARD_LUCID = makeKey(LUCID, 'hard')
-const NORMAL_LUCID = makeKey(LUCID, 'normal')
-const HARD_WILL = makeKey(WILL, 'hard')
+const VELLUM = VELLUM_BOSS.id
+// Slice 2 keys: <uuid>:<tier>:<cadence>. Lucid tiers are all weekly.
+const HARD_LUCID = makeKey(LUCID, 'hard', 'weekly')
+const NORMAL_LUCID = makeKey(LUCID, 'normal', 'weekly')
+const HARD_WILL = makeKey(WILL, 'hard', 'weekly')
+// Vellum: Normal is daily, Chaos is weekly.
+const NORMAL_VELLUM_DAILY = makeKey(VELLUM, 'normal', 'daily')
+const CHAOS_VELLUM_WEEKLY = makeKey(VELLUM, 'chaos', 'weekly')
+// Legacy v2 (slice-1B) two-segment keys that should be upgraded on load.
+const LEGACY_HARD_LUCID = `${LUCID}:hard`
+const LEGACY_NORMAL_VELLUM = `${VELLUM}:normal`
+const LEGACY_CHAOS_VELLUM = `${VELLUM}:chaos`
 
 let localStorageStore: Record<string, string> = {}
 let sessionStorageStore: Record<string, string> = {}
@@ -63,7 +74,7 @@ describe('useMules', () => {
 
     it('loads valid data (native-key payload) from localStorage', () => {
       const payload = {
-        schemaVersion: 2,
+        schemaVersion: 3,
         mules: [
           {
             id: 'a',
@@ -88,7 +99,7 @@ describe('useMules', () => {
 
     it('drops structurally invalid mules and keeps valid ones', () => {
       const payload = {
-        schemaVersion: 2,
+        schemaVersion: 3,
         mules: [
           {
             id: 'valid',
@@ -117,7 +128,7 @@ describe('useMules', () => {
 
     it('prunes unknown keys from selectedBosses on load', () => {
       const payload = {
-        schemaVersion: 2,
+        schemaVersion: 3,
         mules: [
           {
             id: 'a',
@@ -135,7 +146,7 @@ describe('useMules', () => {
 
     it('enforces one-per-family on load', () => {
       const payload = {
-        schemaVersion: 2,
+        schemaVersion: 3,
         mules: [
           {
             id: 'a',
@@ -169,7 +180,7 @@ describe('useMules', () => {
       expect(result.current.mules[0].selectedBosses).toEqual([])
     })
 
-    it('stamps schemaVersion: 2 on the persisted payload after migration', () => {
+    it('stamps the current schemaVersion on the persisted payload after migration', () => {
       const legacyRoot = [
         {
           id: 'a',
@@ -182,7 +193,7 @@ describe('useMules', () => {
       localStorageStore['maplestory-mule-tracker'] = JSON.stringify(legacyRoot)
       renderHook(() => useMules())
       const saved = JSON.parse(localStorageStore['maplestory-mule-tracker'])
-      expect(saved.schemaVersion).toBe(2)
+      expect(saved.schemaVersion).toBe(3)
       expect(saved.mules[0].selectedBosses).toEqual([])
     })
 
@@ -218,12 +229,11 @@ describe('useMules', () => {
       expect(result.current.mules[0].partySizes).toEqual({})
     })
 
-    it('skips migration when schemaVersion: 2 is already present', () => {
-      // Even if a stray legacy-looking id slipped through, a payload already
-      // tagged v2 is trusted — the validator still prunes unknown keys but
-      // does not wipe the whole selection.
+    it('loads a schemaVersion: 3 payload as-is without wiping', () => {
+      // A payload already tagged v3 is trusted — the validator still prunes
+      // unknown keys but does not wipe the whole selection.
       const payload = {
-        schemaVersion: 2,
+        schemaVersion: 3,
         mules: [
           {
             id: 'a',
@@ -245,11 +255,11 @@ describe('useMules', () => {
         result.current.addMule()
       })
       const saved = JSON.parse(localStorageStore['maplestory-mule-tracker'])
-      expect(saved.schemaVersion).toBe(2)
+      expect(saved.schemaVersion).toBe(3)
       expect(Array.isArray(saved.mules)).toBe(true)
     })
 
-    it('a fresh toggle after migration persists as a <uuid>:<tier> key', () => {
+    it('a fresh toggle after migration persists as a <uuid>:<tier>:<cadence> key', () => {
       const legacyRoot = [
         {
           id: 'a',
@@ -265,8 +275,110 @@ describe('useMules', () => {
         result.current.updateMule('a', { selectedBosses: [HARD_WILL] })
       })
       const saved = JSON.parse(localStorageStore['maplestory-mule-tracker'])
-      expect(saved.schemaVersion).toBe(2)
+      expect(saved.schemaVersion).toBe(3)
       expect(saved.mules[0].selectedBosses).toEqual([HARD_WILL])
+    })
+  })
+
+  describe('v2 → v3 migration (upgrade in place)', () => {
+    it('upgrades <uuid>:<tier> keys to <uuid>:<tier>:<cadence> on load', () => {
+      const v2Payload = {
+        schemaVersion: 2,
+        mules: [
+          {
+            id: 'a',
+            name: 'V2User',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [LEGACY_HARD_LUCID],
+            partySizes: { lucid: 3 },
+          },
+        ],
+      }
+      localStorageStore['maplestory-mule-tracker'] = JSON.stringify(v2Payload)
+      const { result } = renderHook(() => useMules())
+      expect(result.current.mules[0].selectedBosses).toEqual([HARD_LUCID])
+      // Party sizes survive the upgrade untouched.
+      expect(result.current.mules[0].partySizes).toEqual({ lucid: 3 })
+    })
+
+    it('upgrades mixed daily + weekly v2 keys on the same boss', () => {
+      // Vellum had Normal (daily) and Chaos (weekly) pre-slice-2.
+      const v2Payload = {
+        schemaVersion: 2,
+        mules: [
+          {
+            id: 'a',
+            name: 'V2User',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [LEGACY_NORMAL_VELLUM, LEGACY_CHAOS_VELLUM],
+          },
+        ],
+      }
+      localStorageStore['maplestory-mule-tracker'] = JSON.stringify(v2Payload)
+      const { result } = renderHook(() => useMules())
+      expect(result.current.mules[0].selectedBosses).toEqual([
+        NORMAL_VELLUM_DAILY,
+        CHAOS_VELLUM_WEEKLY,
+      ])
+    })
+
+    it('silently drops v2 entries whose boss is no longer in the dataset', () => {
+      const v2Payload = {
+        schemaVersion: 2,
+        mules: [
+          {
+            id: 'a',
+            name: 'V2User',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [LEGACY_HARD_LUCID, 'unknown-boss-id:hard'],
+          },
+        ],
+      }
+      localStorageStore['maplestory-mule-tracker'] = JSON.stringify(v2Payload)
+      const { result } = renderHook(() => useMules())
+      expect(result.current.mules[0].selectedBosses).toEqual([HARD_LUCID])
+    })
+
+    it('silently drops v2 entries whose tier is not offered for the boss', () => {
+      const v2Payload = {
+        schemaVersion: 2,
+        mules: [
+          {
+            id: 'a',
+            name: 'V2User',
+            level: 200,
+            muleClass: 'Hero',
+            // Lucid does not offer chaos — drop.
+            selectedBosses: [LEGACY_HARD_LUCID, `${LUCID}:chaos`],
+          },
+        ],
+      }
+      localStorageStore['maplestory-mule-tracker'] = JSON.stringify(v2Payload)
+      const { result } = renderHook(() => useMules())
+      expect(result.current.mules[0].selectedBosses).toEqual([HARD_LUCID])
+    })
+
+    it('bumps the persisted schemaVersion to 3 after loading a v2 payload', () => {
+      const v2Payload = {
+        schemaVersion: 2,
+        mules: [
+          {
+            id: 'a',
+            name: 'V2User',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [LEGACY_HARD_LUCID],
+          },
+        ],
+      }
+      localStorageStore['maplestory-mule-tracker'] = JSON.stringify(v2Payload)
+      renderHook(() => useMules())
+      const saved = JSON.parse(localStorageStore['maplestory-mule-tracker'])
+      expect(saved.schemaVersion).toBe(3)
+      expect(saved.mules[0].selectedBosses).toEqual([HARD_LUCID])
     })
   })
 
@@ -335,7 +447,7 @@ describe('useMules', () => {
   describe('updateMule', () => {
     it('prunes stale keys on update', () => {
       const payload = {
-        schemaVersion: 2,
+        schemaVersion: 3,
         mules: [
           {
             id: 'a',
@@ -358,7 +470,7 @@ describe('useMules', () => {
 
     it('enforces one-per-family on update', () => {
       const payload = {
-        schemaVersion: 2,
+        schemaVersion: 3,
         mules: [
           {
             id: 'a',
@@ -399,7 +511,7 @@ describe('useMules', () => {
   describe('deleteMule', () => {
     it('removes a mule by id', () => {
       const payload = {
-        schemaVersion: 2,
+        schemaVersion: 3,
         mules: [
           {
             id: 'a',
@@ -422,7 +534,7 @@ describe('useMules', () => {
   describe('reorderMules', () => {
     it('reorders mules', () => {
       const payload = {
-        schemaVersion: 2,
+        schemaVersion: 3,
         mules: [
           {
             id: 'a',
@@ -452,7 +564,7 @@ describe('useMules', () => {
   describe('sessionStorage fallback read-back', () => {
     it('reads mules from sessionStorage when localStorage returns null', () => {
       const payload = {
-        schemaVersion: 2,
+        schemaVersion: 3,
         mules: [
           {
             id: 'a',
@@ -471,7 +583,7 @@ describe('useMules', () => {
 
     it('prefers localStorage over sessionStorage when both exist', () => {
       const localStorageMules = {
-        schemaVersion: 2,
+        schemaVersion: 3,
         mules: [
           {
             id: 'ls',
@@ -483,7 +595,7 @@ describe('useMules', () => {
         ],
       }
       const sessionStorageMules = {
-        schemaVersion: 2,
+        schemaVersion: 3,
         mules: [
           {
             id: 'ss',
@@ -530,7 +642,7 @@ describe('useMules', () => {
   describe('self-healing via useEffect', () => {
     it('self-heals cleaned data through useEffect, not loadMules', () => {
       const payload = {
-        schemaVersion: 2,
+        schemaVersion: 3,
         mules: [
           {
             id: 'a',

--- a/src/hooks/useMules.ts
+++ b/src/hooks/useMules.ts
@@ -1,11 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import { v4 as uuidv4 } from 'uuid';
-import type { Mule } from '../types';
-import { validateBossSelection } from '../data/bossSelection';
+import type { BossTier, Mule } from '../types';
+import { getBossById } from '../data/bosses';
+import { makeKey, validateBossSelection } from '../data/bossSelection';
 
 const STORAGE_KEY = 'maplestory-mule-tracker';
 const FALLBACK_KEY = 'maplestory-mule-tracker-fallback';
-const CURRENT_SCHEMA_VERSION = 2;
+const CURRENT_SCHEMA_VERSION = 3;
 
 const LEGACY_ID_PREFIX = /^(extreme|hard|chaos|normal|easy)-/;
 
@@ -23,7 +24,27 @@ function readPartySizes(raw: unknown): Record<string, number> {
   return out;
 }
 
-function validateMule(raw: unknown, opts: { wipeLegacy: boolean }): Mule | null {
+/**
+ * Upgrade a single v2 `<uuid>:<tier>` selection key to the v3
+ * `<uuid>:<tier>:<cadence>` shape by resolving cadence from the boss data.
+ * Returns null for unresolvable entries (unknown boss or tier no longer
+ * offered) — the loader drops those silently.
+ */
+function upgradeV2Key(key: string): string | null {
+  const colon = key.lastIndexOf(':');
+  if (colon < 0) return null;
+  const bossId = key.slice(0, colon);
+  const tier = key.slice(colon + 1) as BossTier;
+  const boss = getBossById(bossId);
+  if (!boss) return null;
+  const diff = boss.difficulty.find((d) => d.tier === tier);
+  if (!diff) return null;
+  return makeKey(bossId, tier, diff.cadence);
+}
+
+type LoadMode = 'wipe' | 'upgradeV2' | 'asIs';
+
+function validateMule(raw: unknown, mode: LoadMode): Mule | null {
   if (typeof raw !== 'object' || raw === null) return null;
   const obj = raw as Record<string, unknown>;
   if (typeof obj.id !== 'string') return null;
@@ -33,14 +54,29 @@ function validateMule(raw: unknown, opts: { wipeLegacy: boolean }): Mule | null 
   if (!Array.isArray(obj.selectedBosses)) return null;
 
   const rawSelected = obj.selectedBosses as string[];
-  const wipe = opts.wipeLegacy && rawSelected.some(isLegacyId);
+  const wipe = mode === 'wipe' && rawSelected.some(isLegacyId);
+
+  let selectedBosses: string[];
+  if (wipe) {
+    selectedBosses = [];
+  } else if (mode === 'upgradeV2') {
+    // In-place upgrade of v2 `<uuid>:<tier>` keys. Unresolvable entries drop.
+    const upgraded: string[] = [];
+    for (const key of rawSelected) {
+      const next = upgradeV2Key(key);
+      if (next !== null) upgraded.push(next);
+    }
+    selectedBosses = validateBossSelection(upgraded);
+  } else {
+    selectedBosses = validateBossSelection(rawSelected);
+  }
 
   return {
     id: obj.id,
     name: obj.name,
     level: obj.level,
     muleClass: obj.muleClass,
-    selectedBosses: wipe ? [] : validateBossSelection(rawSelected),
+    selectedBosses,
     partySizes: wipe ? {} : readPartySizes(obj.partySizes),
   };
 }
@@ -52,22 +88,29 @@ interface PersistedRoot {
 }
 
 /**
- * Parse a persisted payload into { mules, wipeLegacy }. Accepts either the
- * legacy "top-level array" shape (triggers wipe-on-load) or the new
- * { schemaVersion, mules } envelope.
+ * Parse a persisted payload into { mules, mode }. Mode controls migration:
+ *  - 'wipe': pre-1B array shape / `schemaVersion < 2` → drop legacy selections.
+ *  - 'upgradeV2': `schemaVersion === 2` → upgrade `<uuid>:<tier>` keys to
+ *    `<uuid>:<tier>:<cadence>` in place (slice 2, v2 → v3).
+ *  - 'asIs': `schemaVersion === 3` → keys already in the current shape.
  */
-function parsePayload(raw: string): { mules: unknown[]; wipeLegacy: boolean } | null {
+function parsePayload(raw: string): { mules: unknown[]; mode: LoadMode } | null {
   try {
     const parsed: unknown = JSON.parse(raw);
     if (Array.isArray(parsed)) {
       // Pre-1B shape — root is bare array; always migrate.
-      return { mules: parsed, wipeLegacy: true };
+      return { mules: parsed, mode: 'wipe' };
     }
     if (typeof parsed === 'object' && parsed !== null) {
       const root = parsed as Partial<PersistedRoot>;
       if (Array.isArray(root.mules)) {
-        const wipeLegacy = root.schemaVersion !== CURRENT_SCHEMA_VERSION;
-        return { mules: root.mules, wipeLegacy };
+        const mode: LoadMode =
+          root.schemaVersion === CURRENT_SCHEMA_VERSION
+            ? 'asIs'
+            : root.schemaVersion === 2
+              ? 'upgradeV2'
+              : 'wipe';
+        return { mules: root.mules, mode };
       }
     }
     return null;
@@ -100,9 +143,7 @@ export function useMules() {
       if (data === null) return [];
       const payload = parsePayload(data);
       if (!payload) return [];
-      const validated = payload.mules.map((m) =>
-        validateMule(m, { wipeLegacy: payload.wipeLegacy }),
-      );
+      const validated = payload.mules.map((m) => validateMule(m, payload.mode));
       return validated.filter((m): m is Mule => m !== null);
     } catch {
       return [];

--- a/src/modules/__tests__/income-provider.test.tsx
+++ b/src/modules/__tests__/income-provider.test.tsx
@@ -14,8 +14,8 @@ import { makeKey } from '../../data/bossSelection'
 
 const LUCID = bosses.find((b) => b.family === 'lucid')!.id
 const WILL = bosses.find((b) => b.family === 'will')!.id
-const HARD_LUCID = makeKey(LUCID, 'hard')
-const HARD_WILL = makeKey(WILL, 'hard')
+const HARD_LUCID = makeKey(LUCID, 'hard', 'weekly')
+const HARD_WILL = makeKey(WILL, 'hard', 'weekly')
 
 function FormatPreferenceConsumer() {
   const { abbreviated, toggle } = useFormatPreference()

--- a/src/modules/__tests__/income-toggle-integration.test.tsx
+++ b/src/modules/__tests__/income-toggle-integration.test.tsx
@@ -7,8 +7,8 @@ import { makeKey } from '../../data/bossSelection'
 
 const LUCID = bosses.find((b) => b.family === 'lucid')!.id
 const WILL = bosses.find((b) => b.family === 'will')!.id
-const HARD_LUCID = makeKey(LUCID, 'hard')
-const HARD_WILL = makeKey(WILL, 'hard')
+const HARD_LUCID = makeKey(LUCID, 'hard', 'weekly')
+const HARD_WILL = makeKey(WILL, 'hard', 'weekly')
 
 function MuleIncomeDisplay({ mule, index }: { mule: { selectedBosses: string[] }; index: number }) {
   const income = useMuleIncome(mule)

--- a/src/modules/__tests__/income.test.ts
+++ b/src/modules/__tests__/income.test.ts
@@ -7,8 +7,8 @@ import type { Boss } from '../../types'
 
 const LUCID = bosses.find((b) => b.family === 'lucid')!.id
 const WILL = bosses.find((b) => b.family === 'will')!.id
-const HARD_LUCID = makeKey(LUCID, 'hard')
-const HARD_WILL = makeKey(WILL, 'hard')
+const HARD_LUCID = makeKey(LUCID, 'hard', 'weekly')
+const HARD_WILL = makeKey(WILL, 'hard', 'weekly')
 
 describe('computeMuleIncome', () => {
   it('returns correct raw and formatted for a mule with selected bosses (abbreviated)', () => {
@@ -141,7 +141,10 @@ describe('sumSelectedKeys cadence multiplier', () => {
     }
     mockBosses(weeklyBoss, dailyBoss)
 
-    const keys = [makeKey(weeklyBoss.id, 'hard'), makeKey(dailyBoss.id, 'normal')]
+    const keys = [
+      makeKey(weeklyBoss.id, 'hard', 'weekly'),
+      makeKey(dailyBoss.id, 'normal', 'daily'),
+    ]
     // weekly × 1 + daily × 7
     expect(sumSelectedKeys(keys)).toBe(1_000_000 + 100 * 7)
   })
@@ -158,15 +161,18 @@ describe('sumSelectedKeys cadence multiplier', () => {
     }
     mockBosses(mixedBoss)
 
-    const keys = [makeKey(mixedBoss.id, 'normal'), makeKey(mixedBoss.id, 'chaos')]
+    const keys = [
+      makeKey(mixedBoss.id, 'normal', 'daily'),
+      makeKey(mixedBoss.id, 'chaos', 'weekly'),
+    ]
     expect(sumSelectedKeys(keys)).toBe(10 * 7 + 1000)
   })
 
   it('applies ×7 to the PRD daily fixtures (Normal Vellum, Chaos Horntail)', () => {
     const vellum = bosses.find((b) => b.family === 'vellum')!
     const horntail = bosses.find((b) => b.family === 'horntail')!
-    const normalVellum = makeKey(vellum.id, 'normal')
-    const chaosHorntail = makeKey(horntail.id, 'chaos')
+    const normalVellum = makeKey(vellum.id, 'normal', 'daily')
+    const chaosHorntail = makeKey(horntail.id, 'chaos', 'daily')
     expect(sumSelectedKeys([normalVellum])).toBe(4_840_000 * 7)
     expect(sumSelectedKeys([chaosHorntail])).toBe(6_760_000 * 7)
     expect(sumSelectedKeys([normalVellum, chaosHorntail])).toBe(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,14 +1,17 @@
 export type BossTier = 'easy' | 'normal' | 'hard' | 'chaos' | 'extreme';
 
+/**
+ * Per-tier cadence: daily tiers are farmable up to 7× per week and fold into
+ * the weekly headline at `crystalValue × 7`; weekly tiers clear once. The
+ * selection-key format carries the cadence segment explicitly so a single
+ * boss can retain one daily + one weekly selection simultaneously.
+ */
+export type BossCadence = 'daily' | 'weekly';
+
 export interface BossDifficulty {
   tier: BossTier;
   crystalValue: number;
-  /**
-   * Per-tier cadence (single source of truth). Daily tiers are farmable up to
-   * 7× per week and contribute `crystalValue × 7` to the weekly headline;
-   * weekly tiers contribute `crystalValue` once.
-   */
-  cadence: 'daily' | 'weekly';
+  cadence: BossCadence;
 }
 
 export interface Boss {
@@ -33,9 +36,11 @@ export interface Mule {
   level: number;
   muleClass: string;
   /**
-   * Slice 1B: native `<uuid>:<tier>` selection keys (e.g.
-   * "a4d1238d-…:extreme"). Use `makeKey`/`parseKey` from
-   * `src/data/bossSelection.ts` to construct / decode.
+   * Slice 2: native `<uuid>:<tier>:<cadence>` selection keys (e.g.
+   * "a4d1238d-…:chaos:weekly"). The cadence segment lets a single boss
+   * carry independent daily + weekly selections simultaneously. Use
+   * `makeKey`/`parseKey` from `src/data/bossSelection.ts` to construct /
+   * decode.
    */
   selectedBosses: string[];
   /**


### PR DESCRIPTION
## Summary

- Selection keys become `<bossId>:<tier>:<cadence>` so a mule can keep one daily and one weekly selection on the same boss (e.g. Chaos Vellum + Normal Vellum) at once; `toggleBoss` replaces same-cadence siblings and leaves opposite-cadence selections untouched.
- `BossMatrix` dims only same-cadence siblings, drops the party stepper on daily-only bosses (Horntail, Von Leon, Arkarium, Mori Ranmaru, OMNI-CLN), and renders daily cells at full `crystalValue` (weekly cells still divide by party size).
- `useMules` bumps `CURRENT_SCHEMA_VERSION` to 3 and upgrades v2 `<uuid>:<tier>` keys to `<uuid>:<tier>:<cadence>` in place on load — unresolvable entries drop silently, `partySizes` survives, pre-1B shapes still wipe.

## Test plan

- [x] `npm test` — 298 tests green (19 files)
- [x] `npx tsc -b` clean
- [x] `makeKey` / `parseKey` round-trip + reject two-segment, malformed, and stale-cadence keys
- [x] `toggleBoss` covers mixed-boss daily+weekly coexistence, same-cadence replacement, re-click clears, daily-only boss regression
- [x] `validateBossSelection` keeps one winner per `(bossId, cadence)`
- [x] `useMules` v2 → v3 upgrade tests: bump, mixed-boss upgrade, unknown-boss / unknown-tier drop, partySizes preserved
- [x] `BossMatrix` component tests cover per-cadence dim, stepper hidden on daily-only rows, daily cell not divided by party size
- [ ] Manual check (to do post-merge): select Chaos Vellum + Normal Vellum, confirm both highlight; Chaos Papulatus dims only other weekly Papulatus tiers; reload persists both selections

Closes #120