### PR TITLE
Add live reset countdown to header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { Sun, Moon } from 'lucide-react'
 import { useTheme } from '../context/ThemeProvider'
+import { ResetCountdown } from './ResetCountdown'
 
 export function Header() {
   const { theme, toggleTheme } = useTheme()
@@ -45,14 +46,17 @@ export function Header() {
               </span>
             </span>
           </div>
-          <button
-            onClick={toggleTheme}
-            className="flex h-8 w-8 items-center justify-center rounded-md transition-colors cursor-pointer"
-            style={{ color: 'var(--muted-raw, var(--muted-foreground))' }}
-            aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
-          >
-            {theme === 'dark' ? <Sun size={16} /> : <Moon size={16} />}
-          </button>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
+            <ResetCountdown />
+            <button
+              onClick={toggleTheme}
+              className="flex h-8 w-8 items-center justify-center rounded-md transition-colors cursor-pointer"
+              style={{ color: 'var(--muted-raw, var(--muted-foreground))' }}
+              aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            >
+              {theme === 'dark' ? <Sun size={16} /> : <Moon size={16} />}
+            </button>
+          </div>
         </div>
       </div>
     </header>

--- a/src/components/ResetCountdown.tsx
+++ b/src/components/ResetCountdown.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react'
+import { formatCountdown, nextWeeklyResetUtc } from '../utils/resetCountdown'
+
+// Reset Countdown widget: ticks once per second and displays the time remaining
+// until the next Reset Anchor (Thursday 00:00 UTC). Desktop (>= sm) renders the
+// Live Countdown Format; below sm switches to the Smart Countdown Format.
+export function ResetCountdown() {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  const remaining = nextWeeklyResetUtc(now) - now
+  const valueStyle = { color: 'var(--text, var(--foreground))' }
+
+  return (
+    <div className="eyebrow-plain" style={{ opacity: 0.7 }}>
+      RESET IN{' '}
+      <span className="hidden sm:inline" style={valueStyle}>
+        {formatCountdown(remaining, 'live')}
+      </span>
+      <span className="sm:hidden" style={valueStyle}>
+        {formatCountdown(remaining, 'smart')}
+      </span>
+    </div>
+  )
+}

--- a/src/utils/__tests__/resetCountdown.test.ts
+++ b/src/utils/__tests__/resetCountdown.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { formatCountdown, nextWeeklyResetUtc } from '../resetCountdown'
+
+// Reset Anchor = Thursday 00:00 UTC. Thursday is ISO weekday 4.
+// JS Date.UTC weekday indices: 0=Sun, 1=Mon, 2=Tue, 3=Wed, 4=Thu, 5=Fri, 6=Sat.
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+describe('nextWeeklyResetUtc', () => {
+  it('returns the following Thursday 00:00 UTC for a Monday mid-day', () => {
+    // 2026-04-13 is a Monday. 12:00 UTC.
+    const now = Date.UTC(2026, 3, 13, 12, 0, 0, 0)
+    const expected = Date.UTC(2026, 3, 16, 0, 0, 0, 0) // Thursday 2026-04-16 00:00 UTC
+    expect(nextWeeklyResetUtc(now)).toBe(expected)
+  })
+
+  it('returns next-day Thursday 00:00 UTC for Wednesday 23:59 UTC', () => {
+    // 2026-04-15 is a Wednesday. 23:59 UTC.
+    const now = Date.UTC(2026, 3, 15, 23, 59, 0, 0)
+    const expected = Date.UTC(2026, 3, 16, 0, 0, 0, 0)
+    expect(nextWeeklyResetUtc(now)).toBe(expected)
+  })
+
+  it('returns 7 days later when called exactly at Thursday 00:00:00.000 UTC', () => {
+    // 2026-04-16 is a Thursday. 00:00:00.000 UTC.
+    const now = Date.UTC(2026, 3, 16, 0, 0, 0, 0)
+    const expected = now + 7 * MS_PER_DAY
+    expect(nextWeeklyResetUtc(now)).toBe(expected)
+  })
+
+  it('returns 7 days later when called at Thursday 00:00:00.001 UTC', () => {
+    const thursday = Date.UTC(2026, 3, 16, 0, 0, 0, 0)
+    const now = thursday + 1
+    const expected = thursday + 7 * MS_PER_DAY
+    expect(nextWeeklyResetUtc(now)).toBe(expected)
+  })
+
+  it('returns the following Thursday 00:00 UTC for a Saturday mid-day', () => {
+    // 2026-04-18 is a Saturday. 12:00 UTC.
+    const now = Date.UTC(2026, 3, 18, 12, 0, 0, 0)
+    // Next Thursday is 2026-04-23.
+    const expected = Date.UTC(2026, 3, 23, 0, 0, 0, 0)
+    expect(nextWeeklyResetUtc(now)).toBe(expected)
+    // Sanity: diff is 4 days 12 hours.
+    expect(expected - now).toBe(4 * MS_PER_DAY + 12 * 60 * 60 * 1000)
+  })
+})
+
+describe("formatCountdown 'live'", () => {
+  it("formats 2d 14h as '2D 14:00:00'", () => {
+    const ms = 2 * 86_400_000 + 14 * 3_600_000
+    expect(formatCountdown(ms, 'live')).toBe('2D 14:00:00')
+  })
+
+  it("zero-pads hours for 4h 12m 37s as '0D 04:12:37'", () => {
+    const ms = 4 * 3_600_000 + 12 * 60_000 + 37 * 1000
+    expect(formatCountdown(ms, 'live')).toBe('0D 04:12:37')
+  })
+
+  it("formats 59s as '0D 00:00:59'", () => {
+    expect(formatCountdown(59 * 1000, 'live')).toBe('0D 00:00:59')
+  })
+
+  it("formats 0ms as '0D 00:00:00'", () => {
+    expect(formatCountdown(0, 'live')).toBe('0D 00:00:00')
+  })
+})
+
+describe("formatCountdown 'smart'", () => {
+  it("formats 2d 14h as '2D 14H'", () => {
+    const ms = 2 * 86_400_000 + 14 * 3_600_000
+    expect(formatCountdown(ms, 'smart')).toBe('2D 14H')
+  })
+
+  it("formats 23h 59m as '23H 59M'", () => {
+    const ms = 23 * 3_600_000 + 59 * 60_000
+    expect(formatCountdown(ms, 'smart')).toBe('23H 59M')
+  })
+
+  it("formats 59m 59s as '59M'", () => {
+    const ms = 59 * 60_000 + 59 * 1000
+    expect(formatCountdown(ms, 'smart')).toBe('59M')
+  })
+
+  it("formats 30s as '<1M'", () => {
+    expect(formatCountdown(30 * 1000, 'smart')).toBe('<1M')
+  })
+
+  it("formats 0ms as '<1M'", () => {
+    expect(formatCountdown(0, 'smart')).toBe('<1M')
+  })
+})

--- a/src/utils/resetCountdown.ts
+++ b/src/utils/resetCountdown.ts
@@ -1,0 +1,63 @@
+// Reset Countdown helpers: pure math for the next Reset Anchor (Thursday 00:00 UTC)
+// and for rendering a remaining duration in either the Live Countdown Format or the
+// Smart Countdown Format. No dependencies — all UTC math via built-in Date / Date.UTC.
+
+const MS_PER_SECOND = 1000
+const MS_PER_MINUTE = 60 * MS_PER_SECOND
+const MS_PER_HOUR = 60 * MS_PER_MINUTE
+const MS_PER_DAY = 24 * MS_PER_HOUR
+
+// JS getUTCDay() returns 0..6 with 4 = Thursday (ISO weekday 4).
+const THURSDAY = 4
+
+/**
+ * Returns the absolute ms timestamp of the next Thursday 00:00:00.000 UTC
+ * strictly after `nowMs`. At (or just after) a Thursday 00:00 UTC, returns the
+ * following Thursday — the reset that just happened is not the "next" one.
+ */
+export function nextWeeklyResetUtc(nowMs: number): number {
+  const now = new Date(nowMs)
+  const todayUtcMidnight = Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+  )
+  // Days until the next Thursday, strictly in the future. If today is Thursday
+  // and we're past 00:00 UTC, or exactly at 00:00 UTC, we want +7 days.
+  const daysUntil =
+    (THURSDAY - now.getUTCDay() + 7) % 7 || 7
+  return todayUtcMidnight + daysUntil * MS_PER_DAY
+}
+
+export type CountdownVariant = 'live' | 'smart'
+
+/**
+ * Formats a remaining duration for the Reset Countdown widget.
+ *
+ * - 'live':  "{D}D HH:MM:SS" — days unbounded, hours zero-padded to 2.
+ * - 'smart': ≥24h → "{d}D {h}H", ≥1h → "{h}H {m}M", ≥1m → "{m}M", <1m → "<1M".
+ *
+ * Negative or zero remainingMs clamps to 0 — in practice that branch only runs
+ * for a single frame between Date.now() crossing the old target and the
+ * component recomputing the new target.
+ */
+export function formatCountdown(remainingMs: number, variant: CountdownVariant): string {
+  const ms = Math.max(0, remainingMs)
+  const days = Math.floor(ms / MS_PER_DAY)
+  const hours = Math.floor((ms % MS_PER_DAY) / MS_PER_HOUR)
+  const minutes = Math.floor((ms % MS_PER_HOUR) / MS_PER_MINUTE)
+
+  if (variant === 'live') {
+    const seconds = Math.floor((ms % MS_PER_MINUTE) / MS_PER_SECOND)
+    return `${days}D ${pad2(hours)}:${pad2(minutes)}:${pad2(seconds)}`
+  }
+
+  if (days > 0) return `${days}D ${hours}H`
+  if (hours > 0) return `${hours}H ${minutes}M`
+  if (minutes > 0) return `${minutes}M`
+  return '<1M'
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0')
+}


### PR DESCRIPTION
## Summary
- Adds a live Reset Countdown widget to the right side of the sticky header, immediately left of the theme toggle, wrapped in a flex container with `gap: 20`.
- Ticks once per second via `useState` + `useEffect(setInterval(1000))`, targeting the next Reset Anchor (Thursday 00:00 UTC). Desktop (>= sm) renders the Live Countdown Format (`{D}D HH:MM:SS`, zero-padded hours); below sm renders the Smart Countdown Format (`2D 14H` / `4H 12M` / `37M` / `<1M`).
- All UTC math lives in pure helpers in `src/utils/resetCountdown.ts`, fully covered by Vitest (14 new test cases). No new npm dependencies; rollover at T=0 is silent.

## Test plan
- [x] `npm test` — all 333 tests green (including 14 new cases covering Thursday-boundary edges and every format case for both variants)
- [x] `npm run build` — succeeds
- [x] `npm run lint` — no new errors introduced (4 pre-existing errors in untouched files: `IncomePieChart.tsx`, `MuleDetailDrawer.tsx`, `DensityProvider.tsx`, all present on `main`)
- [x] Acceptance criteria verified against issue #126

## Notes
Pre-existing lint errors on `main` are unrelated to this change and were not modified.

Closes #126