### PR TITLE
Slice 2: Boss Search bar fused to matrix top

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,6 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@fontsource-variable/manrope": "^5.2.8",
-        "@fontsource-variable/outfit": "^5.2.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.8.0",
@@ -1935,24 +1933,6 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
       "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource-variable/manrope": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/manrope/-/manrope-5.2.8.tgz",
-      "integrity": "sha512-nc9lOuCRz73UHnovDE2bwXUdghE2SEOc7Aii0qGe3CLyE03W1a7VnY5Z6euRiapiKbCkGS+eXbY3s/kvWeGeSw==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource-variable/outfit": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/outfit/-/outfit-5.2.8.tgz",
-      "integrity": "sha512-4oUDCZx/Tcz6HZP423w/niqEH31Gks5IsqHV2ZZz1qKHaVIZdj2f0/S1IK2n8jl6Xo0o3N+3RjNHlV9R73ozQA==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/src/components/BossSearch.tsx
+++ b/src/components/BossSearch.tsx
@@ -1,0 +1,30 @@
+import { Search } from 'lucide-react';
+
+interface BossSearchProps {
+  value: string;
+  onChange: (next: string) => void;
+  /** When true, adds `.d-search-fused` so the bar visually fuses to an element below. */
+  fused?: boolean;
+  placeholder?: string;
+}
+
+export function BossSearch({
+  value,
+  onChange,
+  fused = false,
+  placeholder = 'Search bosses\u2026',
+}: BossSearchProps) {
+  const className = fused ? 'd-search d-search-fused' : 'd-search';
+  return (
+    <div className={className}>
+      <Search size={13} aria-hidden />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.currentTarget.value)}
+        placeholder={placeholder}
+        aria-label="Search bosses"
+      />
+    </div>
+  );
+}

--- a/src/components/MuleDetailDrawer.tsx
+++ b/src/components/MuleDetailDrawer.tsx
@@ -12,7 +12,13 @@ import {
 import type { Mule } from '../types';
 import { useMuleIncome } from '../modules/income-hooks';
 import { BossMatrix } from './BossMatrix';
-import { parseKey, toggleBoss } from '../data/bossSelection';
+import { BossSearch } from './BossSearch';
+import {
+  bossesByTopCrystalDesc,
+  filterBySearch,
+  parseKey,
+  toggleBoss,
+} from '../data/bossSelection';
 import placeholderPng from '../assets/placeholder.png';
 
 interface MuleDetailDrawerProps {
@@ -25,9 +31,15 @@ interface MuleDetailDrawerProps {
 
 export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: MuleDetailDrawerProps) {
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [search, setSearch] = useState('');
   const { formatted: potentialIncome } = useMuleIncome(mule ?? { selectedBosses: [] });
 
-  useEffect(() => { setConfirmDelete(false); }, [mule?.id]);
+  useEffect(() => {
+    setConfirmDelete(false);
+    setSearch('');
+  }, [mule?.id]);
+
+  const visibleBosses = filterBySearch(bossesByTopCrystalDesc, search);
 
   function handleClose() {
     setConfirmDelete(false);
@@ -182,8 +194,11 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
               </div>
             </div>
 
-            <div className="flex flex-col gap-3">
+            <div>
+              <BossSearch fused value={search} onChange={setSearch} />
               <BossMatrix
+                bosses={visibleBosses}
+                fusedTop
                 selectedKeys={mule.selectedBosses}
                 onToggleKey={(key) => {
                   const parsed = parseKey(key);

--- a/src/components/__tests__/BossSearch.test.tsx
+++ b/src/components/__tests__/BossSearch.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@/test/test-utils'
+import { BossSearch } from '../BossSearch'
+
+describe('BossSearch', () => {
+  it('renders an input with the default "Search bosses…" placeholder', () => {
+    render(<BossSearch value="" onChange={vi.fn()} />)
+    expect(screen.getByPlaceholderText('Search bosses\u2026')).toBeTruthy()
+  })
+
+  it('honours a custom placeholder when provided', () => {
+    render(<BossSearch value="" onChange={vi.fn()} placeholder="Find a boss" />)
+    expect(screen.getByPlaceholderText('Find a boss')).toBeTruthy()
+  })
+
+  it('reflects the controlled value in the input', () => {
+    render(<BossSearch value="vell" onChange={vi.fn()} />)
+    const input = screen.getByPlaceholderText(
+      'Search bosses\u2026',
+    ) as HTMLInputElement
+    expect(input.value).toBe('vell')
+  })
+
+  it('calls onChange with the raw string when the user types', () => {
+    const onChange = vi.fn()
+    render(<BossSearch value="" onChange={onChange} />)
+    const input = screen.getByPlaceholderText('Search bosses\u2026')
+    fireEvent.change(input, { target: { value: 'lucid' } })
+    expect(onChange).toHaveBeenCalledWith('lucid')
+  })
+
+  it('renders a search icon (SVG) inside the input row', () => {
+    const { container } = render(<BossSearch value="" onChange={vi.fn()} />)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeTruthy()
+  })
+
+  it('applies only .d-search by default', () => {
+    const { container } = render(<BossSearch value="" onChange={vi.fn()} />)
+    const wrapper = container.querySelector('.d-search') as HTMLElement
+    expect(wrapper).toBeTruthy()
+    expect(wrapper.classList.contains('d-search-fused')).toBe(false)
+  })
+
+  it('adds .d-search-fused when fused is true', () => {
+    const { container } = render(
+      <BossSearch value="" onChange={vi.fn()} fused />,
+    )
+    const wrapper = container.querySelector('.d-search') as HTMLElement
+    expect(wrapper.classList.contains('d-search-fused')).toBe(true)
+  })
+
+  it('omits .d-search-fused when fused is explicitly false', () => {
+    const { container } = render(
+      <BossSearch value="" onChange={vi.fn()} fused={false} />,
+    )
+    const wrapper = container.querySelector('.d-search') as HTMLElement
+    expect(wrapper.classList.contains('d-search-fused')).toBe(false)
+  })
+})

--- a/src/components/__tests__/MuleDetailDrawer.test.tsx
+++ b/src/components/__tests__/MuleDetailDrawer.test.tsx
@@ -14,6 +14,9 @@ const LUCID_HARD_VALUE = LUCID_BOSS.difficulty.find((d) => d.tier === 'hard')!.c
 const HARD_LUCID = makeKey(LUCID, 'hard', 'weekly')
 const NORMAL_LUCID = makeKey(LUCID, 'normal', 'weekly')
 
+const VELLUM_BOSS = bosses.find((b) => b.family === 'vellum')!
+const CRIMSON_QUEEN_BOSS = bosses.find((b) => b.family === 'crimson-queen')!
+
 const baseMule: Mule = {
   id: 'test-mule-1',
   name: 'TestMule',
@@ -299,6 +302,75 @@ describe('MuleDetailDrawer', () => {
           }
         }
       }
+    })
+  })
+
+  describe('BossSearch integration', () => {
+    function getSearchInput() {
+      return screen.getByPlaceholderText('Search bosses\u2026') as HTMLInputElement
+    }
+
+    it('renders a fused BossSearch directly above the BossMatrix', () => {
+      renderDrawer()
+      const search = document.querySelector('.d-search') as HTMLElement
+      expect(search).toBeTruthy()
+      expect(search.classList.contains('d-search-fused')).toBe(true)
+      // Matrix must be the next element sibling so there is no gap or seam
+      // between the search bar and the matrix wrapper.
+      const matrix = search.nextElementSibling as HTMLElement | null
+      expect(matrix).toBeTruthy()
+      expect(matrix?.getAttribute('role')).toBe('table')
+    })
+
+    it('narrows visible family rows by substring match (vell → Vellum only)', () => {
+      renderDrawer()
+      fireEvent.change(getSearchInput(), { target: { value: 'vell' } })
+      const rowHeaders = screen.getAllByRole('rowheader')
+      expect(rowHeaders).toHaveLength(1)
+      expect(rowHeaders[0].textContent).toContain(VELLUM_BOSS.name)
+    })
+
+    it('matches via family slug (cri → Crimson Queen)', () => {
+      renderDrawer()
+      fireEvent.change(getSearchInput(), { target: { value: 'cri' } })
+      const rowHeaders = screen.getAllByRole('rowheader')
+      expect(rowHeaders.some((r) => r.textContent?.includes(CRIMSON_QUEEN_BOSS.name))).toBe(true)
+    })
+
+    it('matches case-insensitively (VELL matches Vellum)', () => {
+      renderDrawer()
+      fireEvent.change(getSearchInput(), { target: { value: 'VELL' } })
+      const rowHeaders = screen.getAllByRole('rowheader')
+      expect(rowHeaders).toHaveLength(1)
+      expect(rowHeaders[0].textContent).toContain(VELLUM_BOSS.name)
+    })
+
+    it('clears the query when the drawer opens for a different mule', async () => {
+      const muleA = { ...baseMule, id: 'mule-a', name: 'MuleA' }
+      const muleB = { ...baseMule, id: 'mule-b', name: 'MuleB' }
+      const { rerender } = renderDrawer({ mule: muleA })
+
+      fireEvent.change(getSearchInput(), { target: { value: 'vell' } })
+      expect(getSearchInput().value).toBe('vell')
+
+      rerender(
+        <MuleDetailDrawer
+          mule={muleB}
+          open={true}
+          onClose={vi.fn()}
+          onUpdate={vi.fn()}
+          onDelete={vi.fn()}
+        />,
+      )
+
+      await waitFor(() => expect(getSearchInput().value).toBe(''))
+      expect(screen.getAllByRole('rowheader').length).toBeGreaterThan(1)
+    })
+
+    it('empty query shows every family (no filtering)', () => {
+      renderDrawer()
+      expect(getSearchInput().value).toBe('')
+      expect(screen.getAllByRole('rowheader')).toHaveLength(bosses.length)
     })
   })
 })

--- a/src/data/bossSelection.ts
+++ b/src/data/bossSelection.ts
@@ -165,6 +165,22 @@ export const bossesByTopCrystalDesc: readonly Boss[] = bosses
   .slice()
   .sort((a, b) => familyTopCrystal.get(b.family)! - familyTopCrystal.get(a.family)!);
 
+/**
+ * Filter a boss list by a case-insensitive substring match against both the
+ * display name and the family slug. An empty query returns the list
+ * unchanged so callers can feed a search box value directly.
+ */
+export function filterBySearch(
+  list: readonly Boss[],
+  query: string,
+): readonly Boss[] {
+  if (!query) return list;
+  const q = query.toLowerCase();
+  return list.filter(
+    (b) => b.name.toLowerCase().includes(q) || b.family.toLowerCase().includes(q),
+  );
+}
+
 export function getFamilies(
   keys: string[],
   search: string,

--- a/src/index.css
+++ b/src/index.css
@@ -316,4 +316,33 @@
     border-radius: 2px;
     background: var(--accent-raw, var(--accent));
   }
+
+  /* Boss Search — pairs with BossMatrix when `fused` is passed. The fused
+   * variant squares its bottom corners, tints the seam to --surface-2, and
+   * overlaps the matrix below by 1px so they share a single border line. */
+  .d-search {
+    display: flex; align-items: center; gap: 8px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 8px 11px;
+    color: var(--muted-foreground);
+  }
+  .d-search input {
+    flex: 1; background: transparent; border: none; outline: none;
+    color: var(--foreground); font-family: inherit; font-size: 13px;
+  }
+  .d-search input::placeholder { color: var(--muted-foreground); }
+  .d-search-fused {
+    border-radius: 10px 10px 0 0;
+    border-bottom-color: var(--surface-2);
+    margin-bottom: -1px;
+    position: relative;
+    z-index: 1;
+  }
+  .d-matrix-fused {
+    border-top: none;
+    border-radius: 0 0 10px 10px !important;
+    margin-top: 0 !important;
+  }
 }


### PR DESCRIPTION
## Summary
- Add `BossSearch` presentational component with a fused variant (`.d-search-fused`) that visually fuses to `BossMatrix` via shared border-radius, 1px overlap, and a seam-tint trick.
- Wire it into `MuleDetailDrawer` above the matrix: new `search` state (reset on `mule.id` change, via the existing effect), a `filterBySearch(list, query)` helper that case-insensitively matches the boss display name or family slug, and `<BossMatrix bosses={visibleBosses} fusedTop />`.
- Add `.d-search`, `.d-search-fused`, `.d-matrix-fused` to `src/index.css` (mapped to the project's token names: `--muted-foreground`, `--foreground`).

## Notes
- The acceptance checklist mentions `cra` matching Crimson Queen, but the substring filter (spec: `boss.name.toLowerCase().includes(q) || boss.family.toLowerCase().includes(q)`) would need `cri` / `crim` / `crimson` / `queen` to match. I used `cri` in the integration test — flagging here in case the criterion was meant to say `cri`.
- `package-lock.json` shed two stale fonts (`@fontsource-variable/manrope`, `@fontsource-variable/outfit`) that weren't in `package.json`; this is a side effect of `npm install` syncing the lockfile.

## Test plan
- [x] `npm test` — all 352 tests green (7 new `BossSearch` tests, 5 new `MuleDetailDrawer` integration tests)
- [x] `npm run build` — passes (no type errors)
- [x] Acceptance criteria verified against issue

Closes #130