### PR TITLE
Slice 3: Matrix Toolbar shell + Cadence Filter

### DIFF
--- a/src/components/MatrixToolbar.tsx
+++ b/src/components/MatrixToolbar.tsx
@@ -1,0 +1,79 @@
+export type CadenceFilter = 'All' | 'Weekly' | 'Daily';
+export type PresetKey = 'CRA' | 'CTENE';
+
+interface MatrixToolbarProps {
+  filter: CadenceFilter;
+  onFilterChange: (next: CadenceFilter) => void;
+  /** Slice 4+: unused here. Declared now so the API is stable. */
+  activePresets: ReadonlySet<PresetKey>;
+  /** Slice 4+: unused here. Declared now so the API is stable. */
+  onTogglePreset: (preset: PresetKey) => void;
+  /** Slice 4+: unused here. Declared now so the API is stable. */
+  weeklyCount: number;
+  /** Slice 4+: unused here. Declared now so the API is stable. */
+  onReset: () => void;
+}
+
+function CadenceIcon({ children }: { children: React.ReactNode }) {
+  return (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden
+      style={{ marginRight: 4 }}
+    >
+      {children}
+    </svg>
+  );
+}
+
+const CADENCES: ReadonlyArray<{ value: CadenceFilter; icon: React.ReactNode }> = [
+  { value: 'All', icon: null },
+  {
+    value: 'Weekly',
+    icon: (
+      <CadenceIcon>
+        <rect x="3" y="4" width="18" height="18" rx="2" />
+        <line x1="16" y1="2" x2="16" y2="6" />
+        <line x1="8" y1="2" x2="8" y2="6" />
+        <line x1="3" y1="10" x2="21" y2="10" />
+      </CadenceIcon>
+    ),
+  },
+  {
+    value: 'Daily',
+    icon: (
+      <CadenceIcon>
+        <circle cx="12" cy="12" r="10" />
+        <polyline points="12 6 12 12 16 14" />
+      </CadenceIcon>
+    ),
+  },
+];
+
+export function MatrixToolbar({ filter, onFilterChange }: MatrixToolbarProps) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div className="d-c-toggle" role="group" aria-label="Cadence filter">
+        {CADENCES.map(({ value, icon }) => (
+          <button
+            key={value}
+            type="button"
+            className={filter === value ? 'on' : ''}
+            onClick={() => onFilterChange(value)}
+          >
+            {icon}
+            {value}
+          </button>
+        ))}
+      </div>
+      {/* Right-side slot reserved for preset toggles, count, and reset in
+          later slices — intentionally empty in this slice. */}
+      <div aria-hidden />
+    </div>
+  );
+}

--- a/src/components/MuleDetailDrawer.tsx
+++ b/src/components/MuleDetailDrawer.tsx
@@ -13,6 +13,8 @@ import type { Mule } from '../types';
 import { useMuleIncome } from '../modules/income-hooks';
 import { BossMatrix } from './BossMatrix';
 import { BossSearch } from './BossSearch';
+import { MatrixToolbar, type CadenceFilter } from './MatrixToolbar';
+import type { Boss } from '../types';
 import {
   bossesByTopCrystalDesc,
   filterBySearch,
@@ -20,6 +22,17 @@ import {
   toggleBoss,
 } from '../data/bossSelection';
 import placeholderPng from '../assets/placeholder.png';
+
+const EMPTY_PRESETS: ReadonlySet<'CRA' | 'CTENE'> = new Set();
+
+function filterByCadence(
+  list: readonly Boss[],
+  filter: CadenceFilter,
+): readonly Boss[] {
+  if (filter === 'All') return list;
+  const cadence = filter === 'Weekly' ? 'weekly' : 'daily';
+  return list.filter((b) => b.difficulty.some((d) => d.cadence === cadence));
+}
 
 interface MuleDetailDrawerProps {
   mule: Mule | null;
@@ -32,14 +45,19 @@ interface MuleDetailDrawerProps {
 export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: MuleDetailDrawerProps) {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [search, setSearch] = useState('');
+  const [filter, setFilter] = useState<CadenceFilter>('All');
   const { formatted: potentialIncome } = useMuleIncome(mule ?? { selectedBosses: [] });
 
   useEffect(() => {
     setConfirmDelete(false);
     setSearch('');
+    setFilter('All');
   }, [mule?.id]);
 
-  const visibleBosses = filterBySearch(bossesByTopCrystalDesc, search);
+  const visibleBosses = filterBySearch(
+    filterByCadence(bossesByTopCrystalDesc, filter),
+    search,
+  );
 
   function handleClose() {
     setConfirmDelete(false);
@@ -195,35 +213,45 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
             </div>
 
             <div>
-              <BossSearch fused value={search} onChange={setSearch} />
-              <BossMatrix
-                bosses={visibleBosses}
-                fusedTop
-                selectedKeys={mule.selectedBosses}
-                onToggleKey={(key) => {
-                  const parsed = parseKey(key);
-                  if (!parsed) return;
-                  onUpdate(mule.id, {
-                    selectedBosses: toggleBoss(
-                      mule.selectedBosses,
-                      parsed.bossId,
-                      parsed.tier,
-                    ),
-                  });
-                }}
-                partySizes={mule.partySizes ?? {}}
-                onChangePartySize={(family, n) => {
-                  // Clamp here so BossMatrix can stay a dumb view: party size
-                  // is always in [1, 6] by the time it hits storage.
-                  const clamped = Math.max(1, Math.min(6, n));
-                  onUpdate(mule.id, {
-                    partySizes: {
-                      ...(mule.partySizes ?? {}),
-                      [family]: clamped,
-                    },
-                  });
-                }}
+              <MatrixToolbar
+                filter={filter}
+                onFilterChange={setFilter}
+                activePresets={EMPTY_PRESETS}
+                onTogglePreset={() => {}}
+                weeklyCount={0}
+                onReset={() => {}}
               />
+              <div className="mt-2">
+                <BossSearch fused value={search} onChange={setSearch} />
+                <BossMatrix
+                  bosses={visibleBosses}
+                  fusedTop
+                  selectedKeys={mule.selectedBosses}
+                  onToggleKey={(key) => {
+                    const parsed = parseKey(key);
+                    if (!parsed) return;
+                    onUpdate(mule.id, {
+                      selectedBosses: toggleBoss(
+                        mule.selectedBosses,
+                        parsed.bossId,
+                        parsed.tier,
+                      ),
+                    });
+                  }}
+                  partySizes={mule.partySizes ?? {}}
+                  onChangePartySize={(family, n) => {
+                    // Clamp here so BossMatrix can stay a dumb view: party size
+                    // is always in [1, 6] by the time it hits storage.
+                    const clamped = Math.max(1, Math.min(6, n));
+                    onUpdate(mule.id, {
+                      partySizes: {
+                        ...(mule.partySizes ?? {}),
+                        [family]: clamped,
+                      },
+                    });
+                  }}
+                />
+              </div>
             </div>
           </div>
         </div>}

--- a/src/components/__tests__/MatrixToolbar.test.tsx
+++ b/src/components/__tests__/MatrixToolbar.test.tsx
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@/test/test-utils'
+
+import { MatrixToolbar } from '../MatrixToolbar'
+
+const noop = () => {}
+const EMPTY_PRESETS: ReadonlySet<'CRA' | 'CTENE'> = new Set()
+
+function renderToolbar(
+  overrides: Partial<Parameters<typeof MatrixToolbar>[0]> = {},
+) {
+  const props = {
+    filter: 'All' as const,
+    onFilterChange: vi.fn(),
+    activePresets: EMPTY_PRESETS,
+    onTogglePreset: vi.fn(),
+    weeklyCount: 0,
+    onReset: vi.fn(),
+    ...overrides,
+  }
+  return {
+    ...render(<MatrixToolbar {...props} />),
+    props,
+  }
+}
+
+describe('MatrixToolbar', () => {
+  it('renders three cadence buttons labelled All, Weekly, Daily', () => {
+    renderToolbar()
+    expect(screen.getByRole('button', { name: /^all$/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /^weekly$/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /^daily$/i })).toBeTruthy()
+  })
+
+  it('wraps the cadence buttons in a .d-c-toggle container', () => {
+    const { container } = renderToolbar()
+    const toggle = container.querySelector('.d-c-toggle')
+    expect(toggle).toBeTruthy()
+    expect(toggle?.querySelectorAll('button')).toHaveLength(3)
+  })
+
+  it('applies the .on class to the active cadence button (All by default)', () => {
+    renderToolbar({ filter: 'All' })
+    const allBtn = screen.getByRole('button', { name: /^all$/i })
+    const weeklyBtn = screen.getByRole('button', { name: /^weekly$/i })
+    const dailyBtn = screen.getByRole('button', { name: /^daily$/i })
+    expect(allBtn.classList.contains('on')).toBe(true)
+    expect(weeklyBtn.classList.contains('on')).toBe(false)
+    expect(dailyBtn.classList.contains('on')).toBe(false)
+  })
+
+  it('moves the .on class when filter=Weekly', () => {
+    renderToolbar({ filter: 'Weekly' })
+    expect(
+      screen.getByRole('button', { name: /^weekly$/i }).classList.contains('on'),
+    ).toBe(true)
+    expect(
+      screen.getByRole('button', { name: /^all$/i }).classList.contains('on'),
+    ).toBe(false)
+  })
+
+  it('moves the .on class when filter=Daily', () => {
+    renderToolbar({ filter: 'Daily' })
+    expect(
+      screen.getByRole('button', { name: /^daily$/i }).classList.contains('on'),
+    ).toBe(true)
+  })
+
+  it('calls onFilterChange with "Weekly" when the Weekly button is clicked', () => {
+    const onFilterChange = vi.fn()
+    renderToolbar({ onFilterChange })
+    fireEvent.click(screen.getByRole('button', { name: /^weekly$/i }))
+    expect(onFilterChange).toHaveBeenCalledWith('Weekly')
+  })
+
+  it('calls onFilterChange with "Daily" when the Daily button is clicked', () => {
+    const onFilterChange = vi.fn()
+    renderToolbar({ onFilterChange })
+    fireEvent.click(screen.getByRole('button', { name: /^daily$/i }))
+    expect(onFilterChange).toHaveBeenCalledWith('Daily')
+  })
+
+  it('calls onFilterChange with "All" when the All button is clicked', () => {
+    const onFilterChange = vi.fn()
+    renderToolbar({ filter: 'Weekly', onFilterChange })
+    fireEvent.click(screen.getByRole('button', { name: /^all$/i }))
+    expect(onFilterChange).toHaveBeenCalledWith('All')
+  })
+
+  it('renders a calendar SVG inside the Weekly button', () => {
+    renderToolbar()
+    const weeklyBtn = screen.getByRole('button', { name: /^weekly$/i })
+    const svg = weeklyBtn.querySelector('svg')
+    expect(svg).toBeTruthy()
+    // Calendar shape: rect + 2 lines for tabs + 1 horizontal line
+    expect(svg?.querySelector('rect')).toBeTruthy()
+    expect(svg?.querySelectorAll('line').length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('renders a clock SVG inside the Daily button', () => {
+    renderToolbar()
+    const dailyBtn = screen.getByRole('button', { name: /^daily$/i })
+    const svg = dailyBtn.querySelector('svg')
+    expect(svg).toBeTruthy()
+    // Clock shape: circle + polyline for the hands
+    expect(svg?.querySelector('circle')).toBeTruthy()
+    expect(svg?.querySelector('polyline')).toBeTruthy()
+  })
+
+  it('does not render an icon inside the All button', () => {
+    renderToolbar()
+    const allBtn = screen.getByRole('button', { name: /^all$/i })
+    expect(allBtn.querySelector('svg')).toBeNull()
+  })
+
+  it('accepts the unused preset / count / reset props without crashing', () => {
+    // Smoke test: full prop surface is declared up front so future slices
+    // can add right-side controls without churning the API.
+    renderToolbar({
+      activePresets: new Set(['CRA']),
+      onTogglePreset: noop,
+      weeklyCount: 5,
+      onReset: noop,
+    })
+    expect(screen.getByRole('button', { name: /^all$/i })).toBeTruthy()
+  })
+})

--- a/src/components/__tests__/MuleDetailDrawer.test.tsx
+++ b/src/components/__tests__/MuleDetailDrawer.test.tsx
@@ -16,6 +16,9 @@ const NORMAL_LUCID = makeKey(LUCID, 'normal', 'weekly')
 
 const VELLUM_BOSS = bosses.find((b) => b.family === 'vellum')!
 const CRIMSON_QUEEN_BOSS = bosses.find((b) => b.family === 'crimson-queen')!
+const BLACK_MAGE_BOSS = bosses.find((b) => b.family === 'black-mage')!
+const HORNTAIL_BOSS = bosses.find((b) => b.family === 'horntail')!
+const MORI_BOSS = bosses.find((b) => b.family === 'mori-ranmaru')!
 
 const baseMule: Mule = {
   id: 'test-mule-1',
@@ -371,6 +374,99 @@ describe('MuleDetailDrawer', () => {
       renderDrawer()
       expect(getSearchInput().value).toBe('')
       expect(screen.getAllByRole('rowheader')).toHaveLength(bosses.length)
+    })
+  })
+
+  describe('MatrixToolbar + Cadence Filter integration', () => {
+    function getSearchInput() {
+      return screen.getByPlaceholderText('Search bosses\u2026') as HTMLInputElement
+    }
+
+    it('renders the MatrixToolbar above the fused BossSearch', () => {
+      renderDrawer()
+      const toolbar = document.querySelector('.d-c-toggle') as HTMLElement
+      expect(toolbar).toBeTruthy()
+      const search = document.querySelector('.d-search') as HTMLElement
+      expect(search).toBeTruthy()
+      // Toolbar must appear before the search bar in document order.
+      const position = toolbar.compareDocumentPosition(search)
+      expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+
+    it('defaults the cadence filter to All (All button has .on)', () => {
+      renderDrawer()
+      const allBtn = screen.getByRole('button', { name: /^all$/i })
+      expect(allBtn.classList.contains('on')).toBe(true)
+    })
+
+    it('clicking Weekly hides daily-only families (Horntail, Mori Ranmaru)', () => {
+      renderDrawer()
+      const weeklyBtn = screen.getByRole('button', { name: /^weekly$/i })
+      fireEvent.click(weeklyBtn)
+      const rowHeaderText = screen.getAllByRole('rowheader').map((r) => r.textContent ?? '')
+      expect(rowHeaderText.some((t) => t.includes(HORNTAIL_BOSS.name))).toBe(false)
+      expect(rowHeaderText.some((t) => t.includes(MORI_BOSS.name))).toBe(false)
+      // Weekly-only family (Black Mage) still visible.
+      expect(rowHeaderText.some((t) => t.includes(BLACK_MAGE_BOSS.name))).toBe(true)
+      // Mixed family (Vellum: daily + weekly) still visible.
+      expect(rowHeaderText.some((t) => t.includes(VELLUM_BOSS.name))).toBe(true)
+    })
+
+    it('clicking Daily hides weekly-only families (Black Mage)', () => {
+      renderDrawer()
+      const dailyBtn = screen.getByRole('button', { name: /^daily$/i })
+      fireEvent.click(dailyBtn)
+      const rowHeaderText = screen.getAllByRole('rowheader').map((r) => r.textContent ?? '')
+      expect(rowHeaderText.some((t) => t.includes(BLACK_MAGE_BOSS.name))).toBe(false)
+      // Daily-only families still visible.
+      expect(rowHeaderText.some((t) => t.includes(HORNTAIL_BOSS.name))).toBe(true)
+      // Mixed family (Vellum) still visible.
+      expect(rowHeaderText.some((t) => t.includes(VELLUM_BOSS.name))).toBe(true)
+    })
+
+    it('clicking All after a filter restores every family', () => {
+      renderDrawer()
+      fireEvent.click(screen.getByRole('button', { name: /^weekly$/i }))
+      fireEvent.click(screen.getByRole('button', { name: /^all$/i }))
+      expect(screen.getAllByRole('rowheader')).toHaveLength(bosses.length)
+    })
+
+    it('cadence filter composes with the search box', () => {
+      renderDrawer()
+      // Weekly filter + "vell" search → only Vellum remains.
+      fireEvent.click(screen.getByRole('button', { name: /^weekly$/i }))
+      fireEvent.change(getSearchInput(), { target: { value: 'vell' } })
+      const rowHeaders = screen.getAllByRole('rowheader')
+      expect(rowHeaders).toHaveLength(1)
+      expect(rowHeaders[0].textContent).toContain(VELLUM_BOSS.name)
+    })
+
+    it('resets the cadence filter to All when the drawer opens for a different mule', () => {
+      const muleA = { ...baseMule, id: 'mule-a', name: 'MuleA' }
+      const muleB = { ...baseMule, id: 'mule-b', name: 'MuleB' }
+      const { rerender } = renderDrawer({ mule: muleA })
+
+      fireEvent.click(screen.getByRole('button', { name: /^weekly$/i }))
+      expect(
+        screen.getByRole('button', { name: /^weekly$/i }).classList.contains('on'),
+      ).toBe(true)
+
+      rerender(
+        <MuleDetailDrawer
+          mule={muleB}
+          open={true}
+          onClose={vi.fn()}
+          onUpdate={vi.fn()}
+          onDelete={vi.fn()}
+        />,
+      )
+
+      expect(
+        screen.getByRole('button', { name: /^all$/i }).classList.contains('on'),
+      ).toBe(true)
+      expect(
+        screen.getByRole('button', { name: /^weekly$/i }).classList.contains('on'),
+      ).toBe(false)
     })
   })
 })

--- a/src/data/__tests__/bossSelection.test.ts
+++ b/src/data/__tests__/bossSelection.test.ts
@@ -6,6 +6,8 @@ import {
   makeKey,
   parseKey,
   TIER_ORDER,
+  hardestDifficulty,
+  cadencesForBoss,
 } from '../bossSelection'
 import { bosses, getBossById } from '../bosses'
 import type { BossTier } from '../../types'
@@ -474,5 +476,53 @@ describe('cross-reference sanity', () => {
       tier: 'normal',
       cadence: 'weekly',
     })
+  })
+})
+
+describe('hardestDifficulty', () => {
+  it('returns the entry with the max crystalValue (Lucid → Hard)', () => {
+    const lucid = getBossById(LUCID)!
+    const entry = hardestDifficulty(lucid)
+    expect(entry.tier).toBe('hard')
+    expect(entry.crystalValue).toBe(
+      Math.max(...lucid.difficulty.map((d) => d.crystalValue)),
+    )
+  })
+
+  it('picks the weekly chaos tier for Vellum over the daily normal tier', () => {
+    const vellum = getBossById(VELLUM)!
+    const entry = hardestDifficulty(vellum)
+    expect(entry.tier).toBe('chaos')
+    expect(entry.cadence).toBe('weekly')
+  })
+
+  it('picks Extreme Black Mage (all weekly) as hardest', () => {
+    const bm = getBossById(BLACK_MAGE)!
+    const entry = hardestDifficulty(bm)
+    expect(entry.tier).toBe('extreme')
+  })
+
+  it('picks the Hard daily tier for Mori Ranmaru (all daily)', () => {
+    const mori = bosses.find((b) => b.family === 'mori-ranmaru')!
+    const entry = hardestDifficulty(mori)
+    expect(entry.tier).toBe('hard')
+    expect(entry.cadence).toBe('daily')
+  })
+})
+
+describe('cadencesForBoss', () => {
+  it('returns {weekly} for an all-weekly family (Black Mage)', () => {
+    const bm = getBossById(BLACK_MAGE)!
+    expect(cadencesForBoss(bm)).toEqual(new Set(['weekly']))
+  })
+
+  it('returns {daily} for an all-daily family (Horntail)', () => {
+    const horntail = getBossById(HORNTAIL)!
+    expect(cadencesForBoss(horntail)).toEqual(new Set(['daily']))
+  })
+
+  it('returns {daily, weekly} for a mixed family (Vellum)', () => {
+    const vellum = getBossById(VELLUM)!
+    expect(cadencesForBoss(vellum)).toEqual(new Set(['daily', 'weekly']))
   })
 })

--- a/src/data/bossSelection.ts
+++ b/src/data/bossSelection.ts
@@ -166,6 +166,27 @@ export const bossesByTopCrystalDesc: readonly Boss[] = bosses
   .sort((a, b) => familyTopCrystal.get(b.family)! - familyTopCrystal.get(a.family)!);
 
 /**
+ * Return the difficulty entry with the highest crystalValue for this boss.
+ * Used by the Matrix Toolbar preset row (and similar headline lookups) where
+ * "hardest" means "biggest numeric reward", irrespective of tier name or
+ * cadence — e.g. Vellum's weekly chaos beats its daily normal.
+ */
+export function hardestDifficulty(boss: Boss): BossDifficulty {
+  return boss.difficulty.reduce((best, d) =>
+    d.crystalValue > best.crystalValue ? d : best,
+  );
+}
+
+/**
+ * Convenience predicate: the set of cadences this boss offers across its
+ * difficulty entries. A mixed family (e.g. Vellum) returns both; an
+ * all-weekly family (e.g. Black Mage) returns just `{weekly}`.
+ */
+export function cadencesForBoss(boss: Boss): Set<BossCadence> {
+  return new Set(boss.difficulty.map((d) => d.cadence));
+}
+
+/**
  * Filter a boss list by a case-insensitive substring match against both the
  * display name and the family slug. An empty query returns the list
  * unchanged so callers can feed a search box value directly.

--- a/src/index.css
+++ b/src/index.css
@@ -345,4 +345,42 @@
     border-radius: 0 0 10px 10px !important;
     margin-top: 0 !important;
   }
+
+  /* Matrix Toolbar — segmented cadence toggle on the left, slots reserved
+   * on the right for later slices (preset toggles, weekly count, reset). */
+  .d-c-toggle {
+    display: flex;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .d-c-toggle button {
+    background: transparent; border: none;
+    border-right: 1px solid var(--border);
+    color: var(--muted-foreground);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px; letter-spacing: 0.06em;
+    padding: 5px 10px;
+    cursor: pointer;
+    display: flex; align-items: center;
+    transition: all 0.1s;
+  }
+  .d-c-toggle button:last-child { border-right: none; }
+  .d-c-toggle button.on {
+    background: var(--accent-soft);
+    color: var(--accent);
+  }
+  .d-c-toggle button:hover:not(.on) {
+    background: var(--surface);
+    color: var(--foreground);
+  }
+
+  .d-toolbar-sep {
+    width: 1px;
+    height: 18px;
+    background: var(--border);
+    margin: 0 4px;
+    flex-shrink: 0;
+  }
 }


### PR DESCRIPTION
## Summary
- Added `MatrixToolbar` presentational component with the full stable prop surface (cadence filter wired, preset / count / reset slots declared but unused in this slice).
- Exported `hardestDifficulty` and `cadencesForBoss` helpers from `src/data/bossSelection.ts`.
- Wired cadence filter state + `filterByCadence` pipeline into `MuleDetailDrawer`, resets to `All` on mule-id change, composes with existing search.

## Test plan
- [x] npm test — all green (378 passing, +24 new)
- [x] npm run build — passes
- [x] Acceptance criteria verified against issue

Closes #131