### PR TITLE
feat: weekly count + matrix reset in toolbar

### DIFF
--- a/src/components/MatrixToolbar.tsx
+++ b/src/components/MatrixToolbar.tsx
@@ -8,11 +8,14 @@ interface MatrixToolbarProps {
   activePresets: ReadonlySet<PresetKey>;
   /** Slice 4+: unused here. Declared now so the API is stable. */
   onTogglePreset: (preset: PresetKey) => void;
-  /** Slice 4+: unused here. Declared now so the API is stable. */
+  /** Count of `weekly`-cadence selections; displayed as `{weeklyCount}/14`. */
   weeklyCount: number;
-  /** Slice 4+: unused here. Declared now so the API is stable. */
+  /** Invoked when the Matrix Reset button is clicked. */
   onReset: () => void;
 }
+
+/** Weekly Crystal Cap reference — displayed, not enforced. */
+const WEEKLY_CRYSTAL_CAP = 14;
 
 function CadenceIcon({ children }: { children: React.ReactNode }) {
   return (
@@ -55,7 +58,14 @@ const CADENCES: ReadonlyArray<{ value: CadenceFilter; icon: React.ReactNode }> =
   },
 ];
 
-export function MatrixToolbar({ filter, onFilterChange }: MatrixToolbarProps) {
+export function MatrixToolbar({
+  filter,
+  onFilterChange,
+  weeklyCount,
+  onReset,
+}: MatrixToolbarProps) {
+  const countColor =
+    weeklyCount > 0 ? 'var(--accent)' : 'var(--muted-foreground)';
   return (
     <div className="flex items-center justify-between gap-2">
       <div className="d-c-toggle" role="group" aria-label="Cadence filter">
@@ -71,9 +81,27 @@ export function MatrixToolbar({ filter, onFilterChange }: MatrixToolbarProps) {
           </button>
         ))}
       </div>
-      {/* Right-side slot reserved for preset toggles, count, and reset in
-          later slices — intentionally empty in this slice. */}
-      <div aria-hidden />
+      <div className="flex items-center">
+        <span
+          aria-label="Weekly boss selections"
+          className="font-mono-nums"
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: '11px',
+            color: countColor,
+          }}
+        >
+          {weeklyCount}/{WEEKLY_CRYSTAL_CAP}
+        </span>
+        <span className="d-toolbar-sep" aria-hidden />
+        <button
+          type="button"
+          onClick={onReset}
+          className="d-toolbar-reset"
+        >
+          Reset
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/MuleDetailDrawer.tsx
+++ b/src/components/MuleDetailDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Trash2, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -17,6 +17,7 @@ import { MatrixToolbar, type CadenceFilter } from './MatrixToolbar';
 import type { Boss } from '../types';
 import {
   bossesByTopCrystalDesc,
+  countWeeklySelections,
   filterBySearch,
   parseKey,
   toggleBoss,
@@ -57,6 +58,11 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
   const visibleBosses = filterBySearch(
     filterByCadence(bossesByTopCrystalDesc, filter),
     search,
+  );
+
+  const weeklyCount = useMemo(
+    () => countWeeklySelections(mule?.selectedBosses ?? []),
+    [mule?.selectedBosses],
   );
 
   function handleClose() {
@@ -218,8 +224,8 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
                 onFilterChange={setFilter}
                 activePresets={EMPTY_PRESETS}
                 onTogglePreset={() => {}}
-                weeklyCount={0}
-                onReset={() => {}}
+                weeklyCount={weeklyCount}
+                onReset={() => onUpdate(mule.id, { selectedBosses: [] })}
               />
               <div className="mt-2">
                 <BossSearch fused value={search} onChange={setSearch} />

--- a/src/components/__tests__/MatrixToolbar.test.tsx
+++ b/src/components/__tests__/MatrixToolbar.test.tsx
@@ -124,4 +124,82 @@ describe('MatrixToolbar', () => {
     })
     expect(screen.getByRole('button', { name: /^all$/i })).toBeTruthy()
   })
+
+  describe('weekly count display', () => {
+    it('renders "{weeklyCount}/14" with the Weekly-selections aria-label', () => {
+      renderToolbar({ weeklyCount: 5 })
+      const count = screen.getByLabelText(/weekly boss selections/i)
+      expect(count.textContent).toBe('5/14')
+    })
+
+    it('shows "0/14" when weeklyCount is 0', () => {
+      renderToolbar({ weeklyCount: 0 })
+      const count = screen.getByLabelText(/weekly boss selections/i)
+      expect(count.textContent).toBe('0/14')
+    })
+
+    it('does not clamp and can display values greater than 14', () => {
+      renderToolbar({ weeklyCount: 16 })
+      const count = screen.getByLabelText(/weekly boss selections/i)
+      expect(count.textContent).toBe('16/14')
+    })
+
+    it('uses var(--muted-foreground) color when weeklyCount is 0', () => {
+      renderToolbar({ weeklyCount: 0 })
+      const count = screen.getByLabelText(/weekly boss selections/i) as HTMLElement
+      expect(count.style.color).toContain('var(--muted-foreground)')
+    })
+
+    it('uses var(--accent) color when weeklyCount > 0', () => {
+      renderToolbar({ weeklyCount: 1 })
+      const count = screen.getByLabelText(/weekly boss selections/i) as HTMLElement
+      expect(count.style.color).toContain('var(--accent)')
+    })
+
+    it('uses JetBrains Mono at 11px for the count text', () => {
+      renderToolbar({ weeklyCount: 3 })
+      const count = screen.getByLabelText(/weekly boss selections/i) as HTMLElement
+      // Either inline font-family or font-mono-nums class satisfies monospaced
+      // numerics; inline font-size must be 11px per the design spec.
+      const hasMonoClass = count.classList.contains('font-mono-nums')
+      const hasMonoInline = /JetBrains Mono/i.test(count.style.fontFamily ?? '')
+      expect(hasMonoClass || hasMonoInline).toBe(true)
+      expect(count.style.fontSize).toBe('11px')
+    })
+  })
+
+  describe('Reset button', () => {
+    it('renders a button labelled "Reset"', () => {
+      renderToolbar()
+      expect(screen.getByRole('button', { name: /^reset$/i })).toBeTruthy()
+    })
+
+    it('calls onReset when clicked', () => {
+      const onReset = vi.fn()
+      renderToolbar({ onReset })
+      fireEvent.click(screen.getByRole('button', { name: /^reset$/i }))
+      expect(onReset).toHaveBeenCalledTimes(1)
+    })
+
+    it('renders no icon (flat text button)', () => {
+      renderToolbar()
+      const resetBtn = screen.getByRole('button', { name: /^reset$/i })
+      expect(resetBtn.querySelector('svg')).toBeNull()
+    })
+  })
+
+  describe('toolbar separator', () => {
+    it('renders a .d-toolbar-sep element between the count and the reset button', () => {
+      const { container } = renderToolbar()
+      const sep = container.querySelector('.d-toolbar-sep')
+      expect(sep).toBeTruthy()
+      const count = screen.getByLabelText(/weekly boss selections/i)
+      const resetBtn = screen.getByRole('button', { name: /^reset$/i })
+      // Count comes before separator which comes before Reset, in document order.
+      const countVsSep = count.compareDocumentPosition(sep!)
+      const sepVsReset = sep!.compareDocumentPosition(resetBtn)
+      expect(countVsSep & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+      expect(sepVsReset & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+  })
 })

--- a/src/components/__tests__/MuleDetailDrawer.test.tsx
+++ b/src/components/__tests__/MuleDetailDrawer.test.tsx
@@ -469,4 +469,76 @@ describe('MuleDetailDrawer', () => {
       ).toBe(false)
     })
   })
+
+  describe('Weekly Count + Matrix Reset integration', () => {
+    function getSearchInput() {
+      return screen.getByPlaceholderText('Search bosses\u2026') as HTMLInputElement
+    }
+
+    it('renders the weekly count reflecting mule.selectedBosses', () => {
+      // Two weekly selections: Hard Lucid + Normal Lucid would collide on same
+      // boss — use two different families instead.
+      const WILL_BOSS = bosses.find((b) => b.family === 'will')!
+      const HARD_WILL = makeKey(WILL_BOSS.id, 'hard', 'weekly')
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: [HARD_LUCID, HARD_WILL] },
+      })
+      const count = screen.getByLabelText(/weekly boss selections/i)
+      expect(count.textContent).toBe('2/14')
+    })
+
+    it('renders 0/14 when there are no selections', () => {
+      renderDrawer()
+      const count = screen.getByLabelText(/weekly boss selections/i)
+      expect(count.textContent).toBe('0/14')
+    })
+
+    it('clicking Reset calls onUpdate with { selectedBosses: [] }', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: [HARD_LUCID] },
+        onUpdate,
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^reset$/i }))
+      expect(onUpdate).toHaveBeenCalledWith('test-mule-1', { selectedBosses: [] })
+    })
+
+    it('Reset leaves the Cadence Filter selection intact', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: [HARD_LUCID] },
+        onUpdate,
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^weekly$/i }))
+      fireEvent.click(screen.getByRole('button', { name: /^reset$/i }))
+      expect(
+        screen.getByRole('button', { name: /^weekly$/i }).classList.contains('on'),
+      ).toBe(true)
+    })
+
+    it('Reset leaves the Boss Search query intact', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: [HARD_LUCID] },
+        onUpdate,
+      })
+      fireEvent.change(getSearchInput(), { target: { value: 'vell' } })
+      expect(getSearchInput().value).toBe('vell')
+      fireEvent.click(screen.getByRole('button', { name: /^reset$/i }))
+      expect(getSearchInput().value).toBe('vell')
+    })
+
+    it('Reset onUpdate payload does not include filter/search/presets keys', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: [HARD_LUCID] },
+        onUpdate,
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^reset$/i }))
+      // Only selectedBosses should be updated — verify the payload shape.
+      expect(onUpdate).toHaveBeenCalledTimes(1)
+      const [, updates] = onUpdate.mock.calls[0]
+      expect(Object.keys(updates)).toEqual(['selectedBosses'])
+    })
+  })
 })

--- a/src/data/__tests__/bossSelection.test.ts
+++ b/src/data/__tests__/bossSelection.test.ts
@@ -8,6 +8,7 @@ import {
   TIER_ORDER,
   hardestDifficulty,
   cadencesForBoss,
+  countWeeklySelections,
 } from '../bossSelection'
 import { bosses, getBossById } from '../bosses'
 import type { BossTier } from '../../types'
@@ -524,5 +525,63 @@ describe('cadencesForBoss', () => {
   it('returns {daily, weekly} for a mixed family (Vellum)', () => {
     const vellum = getBossById(VELLUM)!
     expect(cadencesForBoss(vellum)).toEqual(new Set(['daily', 'weekly']))
+  })
+})
+
+describe('countWeeklySelections', () => {
+  it('returns 0 for an empty array', () => {
+    expect(countWeeklySelections([])).toBe(0)
+  })
+
+  it('returns 0 when only daily selections are present', () => {
+    // Horntail is all-daily; Normal Vellum is daily.
+    const keys = [key(HORNTAIL, 'chaos'), key(VELLUM, 'normal')]
+    expect(countWeeklySelections(keys)).toBe(0)
+  })
+
+  it('counts weekly selections only, ignoring daily siblings', () => {
+    const keys = [
+      key(LUCID, 'hard'),      // weekly
+      key(WILL, 'hard'),       // weekly
+      key(VELLUM, 'normal'),   // daily
+      key(HORNTAIL, 'chaos'),  // daily
+    ]
+    expect(countWeeklySelections(keys)).toBe(2)
+  })
+
+  it('counts every weekly key when all are weekly', () => {
+    const keys = [
+      key(LUCID, 'hard'),
+      key(WILL, 'hard'),
+      key(LOTUS, 'hard'),
+      key(DAMIEN, 'hard'),
+    ]
+    expect(countWeeklySelections(keys)).toBe(4)
+  })
+
+  it('ignores malformed keys that parseKey rejects', () => {
+    const keys = [
+      key(LUCID, 'hard'),        // weekly, valid
+      'not-a-real-key',          // invalid
+      `${LUCID}:mythic:weekly`,  // invalid tier
+    ]
+    expect(countWeeklySelections(keys)).toBe(1)
+  })
+
+  it('can exceed 14 (no clamp)', () => {
+    // 16 distinct weekly selections — synthesized from every weekly difficulty
+    // entry we can find until we have 16.
+    const weeklyKeys: string[] = []
+    for (const b of bosses) {
+      for (const d of b.difficulty) {
+        if (d.cadence === 'weekly') {
+          weeklyKeys.push(makeKey(b.id, d.tier, 'weekly'))
+          if (weeklyKeys.length === 16) break
+        }
+      }
+      if (weeklyKeys.length === 16) break
+    }
+    expect(weeklyKeys.length).toBe(16)
+    expect(countWeeklySelections(weeklyKeys)).toBe(16)
   })
 })

--- a/src/data/bossSelection.ts
+++ b/src/data/bossSelection.ts
@@ -187,6 +187,20 @@ export function cadencesForBoss(boss: Boss): Set<BossCadence> {
 }
 
 /**
+ * Count the `weekly`-cadence selections inside `keys`. Malformed or stale keys
+ * are ignored (via `parseKey`). No clamp: callers that show `X/14` against the
+ * Weekly Crystal Cap display the raw count even when `X > 14`.
+ */
+export function countWeeklySelections(keys: string[]): number {
+  let count = 0;
+  for (const key of keys) {
+    const parsed = parseKey(key);
+    if (parsed?.cadence === 'weekly') count++;
+  }
+  return count;
+}
+
+/**
  * Filter a boss list by a case-insensitive substring match against both the
  * display name and the family slug. An empty query returns the list
  * unchanged so callers can feed a search box value directly.

--- a/src/index.css
+++ b/src/index.css
@@ -383,4 +383,20 @@
     margin: 0 4px;
     flex-shrink: 0;
   }
+
+  /* Matrix Reset — flat muted text button; hovers to the destructive red. */
+  .d-toolbar-reset {
+    background: transparent;
+    border: none;
+    color: var(--muted-foreground);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    padding: 4px 8px;
+    cursor: pointer;
+    transition: color 0.1s;
+  }
+  .d-toolbar-reset:hover {
+    color: #e05040;
+  }
 }


### PR DESCRIPTION
## Summary
- Add `countWeeklySelections(keys)` helper in `src/data/bossSelection.ts` that parses each key and counts `cadence === 'weekly'`.
- Fill in the right side of `MatrixToolbar`: `{weeklyCount}/14` span (accent color when > 0, muted-foreground at 0; JetBrains Mono, 11px), a `.d-toolbar-sep`, and a flat "Reset" button (muted text, no border, no icon, hovers to #e05040 via a new `.d-toolbar-reset` class).
- Wire the drawer: memoized `weeklyCount` from `mule.selectedBosses`; Reset calls `onUpdate(mule.id, { selectedBosses: [] })`, leaving Cadence Filter / Boss Search / preset state untouched (they're local drawer state).

## Test plan
- [x] npm test — 400/400 green (added 6 cases for `countWeeklySelections`, 10 cases for MatrixToolbar right-side, 5 drawer integration cases covering filter/search preservation)
- [x] npm run build — passes
- [x] Acceptance criteria verified against issue

Closes #133