### PR TITLE
Slice 4: CRA + CTENE Boss Presets

### DIFF
--- a/src/components/MatrixToolbar.tsx
+++ b/src/components/MatrixToolbar.tsx
@@ -4,9 +4,7 @@ export type PresetKey = 'CRA' | 'CTENE';
 interface MatrixToolbarProps {
   filter: CadenceFilter;
   onFilterChange: (next: CadenceFilter) => void;
-  /** Slice 4+: unused here. Declared now so the API is stable. */
   activePresets: ReadonlySet<PresetKey>;
-  /** Slice 4+: unused here. Declared now so the API is stable. */
   onTogglePreset: (preset: PresetKey) => void;
   /** Count of `weekly`-cadence selections; displayed as `{weeklyCount}/14`. */
   weeklyCount: number;
@@ -58,9 +56,13 @@ const CADENCES: ReadonlyArray<{ value: CadenceFilter; icon: React.ReactNode }> =
   },
 ];
 
+const PRESETS: readonly PresetKey[] = ['CRA', 'CTENE'];
+
 export function MatrixToolbar({
   filter,
   onFilterChange,
+  activePresets,
+  onTogglePreset,
   weeklyCount,
   onReset,
 }: MatrixToolbarProps) {
@@ -68,18 +70,33 @@ export function MatrixToolbar({
     weeklyCount > 0 ? 'var(--accent)' : 'var(--muted-foreground)';
   return (
     <div className="flex items-center justify-between gap-2">
-      <div className="d-c-toggle" role="group" aria-label="Cadence filter">
-        {CADENCES.map(({ value, icon }) => (
-          <button
-            key={value}
-            type="button"
-            className={filter === value ? 'on' : ''}
-            onClick={() => onFilterChange(value)}
-          >
-            {icon}
-            {value}
-          </button>
-        ))}
+      <div className="flex items-center">
+        <div className="d-c-toggle" role="group" aria-label="Cadence filter">
+          {CADENCES.map(({ value, icon }) => (
+            <button
+              key={value}
+              type="button"
+              className={filter === value ? 'on' : ''}
+              onClick={() => onFilterChange(value)}
+            >
+              {icon}
+              {value}
+            </button>
+          ))}
+        </div>
+        <span className="d-toolbar-sep" aria-hidden />
+        <div className="d-c-toggle" role="group" aria-label="Boss presets">
+          {PRESETS.map((preset) => (
+            <button
+              key={preset}
+              type="button"
+              className={activePresets.has(preset) ? 'on' : ''}
+              onClick={() => onTogglePreset(preset)}
+            >
+              {preset}
+            </button>
+          ))}
+        </div>
       </div>
       <div className="flex items-center">
         <span

--- a/src/components/MuleDetailDrawer.tsx
+++ b/src/components/MuleDetailDrawer.tsx
@@ -13,7 +13,7 @@ import type { Mule } from '../types';
 import { useMuleIncome } from '../modules/income-hooks';
 import { BossMatrix } from './BossMatrix';
 import { BossSearch } from './BossSearch';
-import { MatrixToolbar, type CadenceFilter } from './MatrixToolbar';
+import { MatrixToolbar, type CadenceFilter, type PresetKey } from './MatrixToolbar';
 import type { Boss } from '../types';
 import {
   bossesByTopCrystalDesc,
@@ -22,9 +22,15 @@ import {
   parseKey,
   toggleBoss,
 } from '../data/bossSelection';
+import {
+  PRESET_FAMILIES,
+  applyPreset,
+  isPresetActive,
+  removePreset,
+} from '../data/bossPresets';
 import placeholderPng from '../assets/placeholder.png';
 
-const EMPTY_PRESETS: ReadonlySet<'CRA' | 'CTENE'> = new Set();
+const PRESET_KEYS: readonly PresetKey[] = ['CRA', 'CTENE'];
 
 function filterByCadence(
   list: readonly Boss[],
@@ -64,6 +70,21 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
     () => countWeeklySelections(mule?.selectedBosses ?? []),
     [mule?.selectedBosses],
   );
+
+  const selectedBosses = mule?.selectedBosses ?? [];
+  const activePresets = useMemo(
+    () => new Set(PRESET_KEYS.filter((p) => isPresetActive(p, selectedBosses))),
+    [selectedBosses],
+  );
+
+  function handleTogglePreset(preset: PresetKey) {
+    if (!mule) return;
+    const families = PRESET_FAMILIES[preset];
+    const next = activePresets.has(preset)
+      ? removePreset(mule.selectedBosses, families)
+      : applyPreset(mule.selectedBosses, families);
+    onUpdate(mule.id, { selectedBosses: next });
+  }
 
   function handleClose() {
     setConfirmDelete(false);
@@ -222,8 +243,8 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
               <MatrixToolbar
                 filter={filter}
                 onFilterChange={setFilter}
-                activePresets={EMPTY_PRESETS}
-                onTogglePreset={() => {}}
+                activePresets={activePresets}
+                onTogglePreset={handleTogglePreset}
                 weeklyCount={weeklyCount}
                 onReset={() => onUpdate(mule.id, { selectedBosses: [] })}
               />

--- a/src/components/__tests__/MatrixToolbar.test.tsx
+++ b/src/components/__tests__/MatrixToolbar.test.tsx
@@ -191,15 +191,101 @@ describe('MatrixToolbar', () => {
   describe('toolbar separator', () => {
     it('renders a .d-toolbar-sep element between the count and the reset button', () => {
       const { container } = renderToolbar()
-      const sep = container.querySelector('.d-toolbar-sep')
-      expect(sep).toBeTruthy()
+      const seps = container.querySelectorAll('.d-toolbar-sep')
+      expect(seps.length).toBeGreaterThanOrEqual(1)
       const count = screen.getByLabelText(/weekly boss selections/i)
       const resetBtn = screen.getByRole('button', { name: /^reset$/i })
-      // Count comes before separator which comes before Reset, in document order.
-      const countVsSep = count.compareDocumentPosition(sep!)
-      const sepVsReset = sep!.compareDocumentPosition(resetBtn)
-      expect(countVsSep & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
-      expect(sepVsReset & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+      // Find the separator that sits between the count and the reset button.
+      // After Slice 4, an earlier .d-toolbar-sep also separates the cadence
+      // filter from the Boss Presets control; that one is not the subject here.
+      const sep = Array.from(seps).find((s) => {
+        const countVsSep = count.compareDocumentPosition(s)
+        const sepVsReset = s.compareDocumentPosition(resetBtn)
+        return (
+          (countVsSep & Node.DOCUMENT_POSITION_FOLLOWING) !== 0 &&
+          (sepVsReset & Node.DOCUMENT_POSITION_FOLLOWING) !== 0
+        )
+      })
+      expect(sep).toBeTruthy()
+    })
+  })
+
+  describe('Boss Presets segmented control', () => {
+    it('renders CRA and CTENE buttons after the Cadence Filter', () => {
+      renderToolbar()
+      expect(screen.getByRole('button', { name: /^cra$/i })).toBeTruthy()
+      expect(screen.getByRole('button', { name: /^ctene$/i })).toBeTruthy()
+    })
+
+    it('wraps the preset buttons in their own .d-c-toggle container', () => {
+      const { container } = renderToolbar()
+      // Two .d-c-toggle groups: cadence filter (3 buttons) + preset row (2 buttons).
+      const groups = container.querySelectorAll('.d-c-toggle')
+      expect(groups.length).toBeGreaterThanOrEqual(2)
+      const presetGroup = Array.from(groups).find(
+        (g) => g.querySelectorAll('button').length === 2,
+      )
+      expect(presetGroup).toBeTruthy()
+      const buttonNames = Array.from(
+        presetGroup!.querySelectorAll('button'),
+      ).map((b) => b.textContent?.trim())
+      expect(buttonNames).toEqual(['CRA', 'CTENE'])
+    })
+
+    it('separates the preset control from the cadence filter with a .d-toolbar-sep', () => {
+      const { container } = renderToolbar()
+      const sep = container.querySelector('.d-toolbar-sep')
+      expect(sep).toBeTruthy()
+    })
+
+    it('renders the Cadence Filter before the Boss Presets in document order', () => {
+      renderToolbar()
+      const allBtn = screen.getByRole('button', { name: /^all$/i })
+      const craBtn = screen.getByRole('button', { name: /^cra$/i })
+      const position = allBtn.compareDocumentPosition(craBtn)
+      expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+
+    it('applies the .on class to active preset pills only', () => {
+      renderToolbar({ activePresets: new Set(['CRA']) })
+      const craBtn = screen.getByRole('button', { name: /^cra$/i })
+      const cteneBtn = screen.getByRole('button', { name: /^ctene$/i })
+      expect(craBtn.classList.contains('on')).toBe(true)
+      expect(cteneBtn.classList.contains('on')).toBe(false)
+    })
+
+    it('marks both pills active when activePresets holds CRA and CTENE', () => {
+      renderToolbar({ activePresets: new Set(['CRA', 'CTENE']) })
+      expect(
+        screen.getByRole('button', { name: /^cra$/i }).classList.contains('on'),
+      ).toBe(true)
+      expect(
+        screen.getByRole('button', { name: /^ctene$/i }).classList.contains('on'),
+      ).toBe(true)
+    })
+
+    it('calls onTogglePreset with "CRA" when CRA is clicked', () => {
+      const onTogglePreset = vi.fn()
+      renderToolbar({ onTogglePreset })
+      fireEvent.click(screen.getByRole('button', { name: /^cra$/i }))
+      expect(onTogglePreset).toHaveBeenCalledWith('CRA')
+    })
+
+    it('calls onTogglePreset with "CTENE" when CTENE is clicked', () => {
+      const onTogglePreset = vi.fn()
+      renderToolbar({ onTogglePreset })
+      fireEvent.click(screen.getByRole('button', { name: /^ctene$/i }))
+      expect(onTogglePreset).toHaveBeenCalledWith('CTENE')
+    })
+
+    it('preset buttons render no SVG icons', () => {
+      renderToolbar()
+      expect(
+        screen.getByRole('button', { name: /^cra$/i }).querySelector('svg'),
+      ).toBeNull()
+      expect(
+        screen.getByRole('button', { name: /^ctene$/i }).querySelector('svg'),
+      ).toBeNull()
     })
   })
 })

--- a/src/components/__tests__/MuleDetailDrawer.test.tsx
+++ b/src/components/__tests__/MuleDetailDrawer.test.tsx
@@ -3,8 +3,9 @@ import { render, screen, fireEvent, waitFor } from '@/test/test-utils'
 
 import { MuleDetailDrawer } from '../MuleDetailDrawer'
 import type { Mule } from '../../types'
-import { bosses } from '../../data/bosses'
-import { makeKey } from '../../data/bossSelection'
+import { bosses, getBossByFamily } from '../../data/bosses'
+import { hardestDifficulty, makeKey } from '../../data/bossSelection'
+import { PRESET_FAMILIES } from '../../data/bossPresets'
 import { formatMeso } from '../../utils/meso'
 
 const LUCID_BOSS = bosses.find((b) => b.family === 'lucid')!
@@ -539,6 +540,140 @@ describe('MuleDetailDrawer', () => {
       expect(onUpdate).toHaveBeenCalledTimes(1)
       const [, updates] = onUpdate.mock.calls[0]
       expect(Object.keys(updates)).toEqual(['selectedBosses'])
+    })
+  })
+
+  describe('Boss Presets integration', () => {
+    /** Hardest-tier key for a family slug, computed off the real boss data. */
+    function hardestKey(family: string): string {
+      const boss = getBossByFamily(family)!
+      const diff = hardestDifficulty(boss)
+      return makeKey(boss.id, diff.tier, diff.cadence)
+    }
+
+    const CRA_KEYS = PRESET_FAMILIES.CRA.map(hardestKey)
+    const CTENE_KEYS = PRESET_FAMILIES.CTENE.map(hardestKey)
+
+    it('renders CRA and CTENE preset pills in the toolbar', () => {
+      renderDrawer()
+      expect(screen.getByRole('button', { name: /^cra$/i })).toBeTruthy()
+      expect(screen.getByRole('button', { name: /^ctene$/i })).toBeTruthy()
+    })
+
+    it('clicking CRA on an empty selection calls onUpdate with all 10 CRA hardest keys', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({ onUpdate })
+      fireEvent.click(screen.getByRole('button', { name: /^cra$/i }))
+      expect(onUpdate).toHaveBeenCalledTimes(1)
+      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] }
+      expect(new Set(update.selectedBosses)).toEqual(new Set(CRA_KEYS))
+    })
+
+    it('clicking CRA preserves pre-existing non-CRA keys', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: [HARD_LUCID] },
+        onUpdate,
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^cra$/i }))
+      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] }
+      expect(update.selectedBosses).toContain(HARD_LUCID)
+      for (const k of CRA_KEYS) {
+        expect(update.selectedBosses).toContain(k)
+      }
+    })
+
+    it('CRA pill is active when all 10 CRA hardest keys are selected', () => {
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: CRA_KEYS },
+      })
+      expect(
+        screen.getByRole('button', { name: /^cra$/i }).classList.contains('on'),
+      ).toBe(true)
+    })
+
+    it('CRA pill is not active when even one hardest key is missing', () => {
+      const missingOne = CRA_KEYS.slice(0, -1)
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: missingOne },
+      })
+      expect(
+        screen.getByRole('button', { name: /^cra$/i }).classList.contains('on'),
+      ).toBe(false)
+    })
+
+    it('clicking CRA while active calls onUpdate with CRA keys removed', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: CRA_KEYS },
+        onUpdate,
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^cra$/i }))
+      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] }
+      expect(update.selectedBosses).toEqual([])
+    })
+
+    it('clicking CRA while active preserves non-CRA keys', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: [...CRA_KEYS, HARD_LUCID] },
+        onUpdate,
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^cra$/i }))
+      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] }
+      expect(update.selectedBosses).toEqual([HARD_LUCID])
+    })
+
+    it('toggling CRA off with both presets active removes the 10 CRA families (including overlap)', () => {
+      // Helper-level contract: removePreset drops ALL families in the list,
+      // including CRA ∩ CTENE. Higher-level overlap persistence (re-selecting
+      // CTENE after) is an issue for the caller, not this wiring.
+      const onUpdate = vi.fn()
+      const both = Array.from(new Set([...CRA_KEYS, ...CTENE_KEYS]))
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: both },
+        onUpdate,
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^cra$/i }))
+      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] }
+      const craSet: ReadonlySet<string> = new Set(PRESET_FAMILIES.CRA)
+      const cteneOnlyFamilies = PRESET_FAMILIES.CTENE.filter((f) => !craSet.has(f))
+      for (const f of cteneOnlyFamilies) {
+        expect(update.selectedBosses).toContain(hardestKey(f))
+      }
+      for (const f of PRESET_FAMILIES.CRA) {
+        expect(update.selectedBosses).not.toContain(hardestKey(f))
+      }
+    })
+
+    it('clicking CTENE on empty selection calls onUpdate with 14 CTENE hardest keys', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({ onUpdate })
+      fireEvent.click(screen.getByRole('button', { name: /^ctene$/i }))
+      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] }
+      expect(new Set(update.selectedBosses)).toEqual(new Set(CTENE_KEYS))
+    })
+
+    it('CTENE pill is active when all 14 CTENE hardest keys are selected', () => {
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: CTENE_KEYS },
+      })
+      expect(
+        screen.getByRole('button', { name: /^ctene$/i }).classList.contains('on'),
+      ).toBe(true)
+    })
+
+    it('both pills are active when CRA+CTENE union is present', () => {
+      const both = Array.from(new Set([...CRA_KEYS, ...CTENE_KEYS]))
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: both },
+      })
+      expect(
+        screen.getByRole('button', { name: /^cra$/i }).classList.contains('on'),
+      ).toBe(true)
+      expect(
+        screen.getByRole('button', { name: /^ctene$/i }).classList.contains('on'),
+      ).toBe(true)
     })
   })
 })

--- a/src/data/__tests__/bossPresets.test.ts
+++ b/src/data/__tests__/bossPresets.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PRESET_FAMILIES,
+  applyPreset,
+  removePreset,
+  isPresetActive,
+} from '../bossPresets'
+import { bosses, getBossByFamily } from '../bosses'
+import {
+  hardestDifficulty,
+  makeKey,
+  parseKey,
+} from '../bossSelection'
+
+const CRA_FAMILIES = [
+  'cygnus',
+  'pink-bean',
+  'vellum',
+  'crimson-queen',
+  'von-bon',
+  'pierre',
+  'papulatus',
+  'hilla',
+  'magnus',
+  'zakum',
+] as const
+
+const CTENE_FAMILIES = [
+  'akechi-mitsuhide',
+  'princess-no',
+  'darknell',
+  'verus-hilla',
+  'gloom',
+  'will',
+  'lucid',
+  'guardian-angel-slime',
+  'damien',
+  'lotus',
+  'vellum',
+  'crimson-queen',
+  'papulatus',
+  'magnus',
+] as const
+
+const CTENE_OVERLAP = ['vellum', 'crimson-queen', 'papulatus', 'magnus'] as const
+
+/** Hardest-tier selection key for a family slug. */
+function hardestKey(family: string): string {
+  const boss = getBossByFamily(family)!
+  const diff = hardestDifficulty(boss)
+  return makeKey(boss.id, diff.tier, diff.cadence)
+}
+
+describe('PRESET_FAMILIES membership', () => {
+  it('contains exactly the 10 CRA families in spec order', () => {
+    expect(PRESET_FAMILIES.CRA).toEqual(CRA_FAMILIES)
+  })
+
+  it('contains exactly the 14 CTENE families in spec order', () => {
+    expect(PRESET_FAMILIES.CTENE).toEqual(CTENE_FAMILIES)
+  })
+
+  it('every CRA family resolves to a known boss', () => {
+    for (const f of PRESET_FAMILIES.CRA) {
+      expect(bosses.find((b) => b.family === f)).toBeDefined()
+    }
+  })
+
+  it('every CTENE family resolves to a known boss', () => {
+    for (const f of PRESET_FAMILIES.CTENE) {
+      expect(bosses.find((b) => b.family === f)).toBeDefined()
+    }
+  })
+
+  it('CRA ∩ CTENE shares Vellum, Crimson Queen, Papulatus, Magnus', () => {
+    const craSet: ReadonlySet<string> = new Set(PRESET_FAMILIES.CRA)
+    const overlap = PRESET_FAMILIES.CTENE.filter((f) => craSet.has(f))
+    expect(new Set(overlap)).toEqual(new Set(CTENE_OVERLAP))
+  })
+})
+
+describe('applyPreset', () => {
+  it('selects the hardest-tier key for each preset family from an empty selection', () => {
+    const result = applyPreset([], PRESET_FAMILIES.CRA)
+    const expected = CRA_FAMILIES.map(hardestKey)
+    expect(new Set(result)).toEqual(new Set(expected))
+    expect(result).toHaveLength(CRA_FAMILIES.length)
+  })
+
+  it('preserves pre-existing non-preset keys', () => {
+    const lucid = hardestKey('lucid')
+    const result = applyPreset([lucid], PRESET_FAMILIES.CRA)
+    expect(result).toContain(lucid)
+    for (const f of PRESET_FAMILIES.CRA) {
+      expect(result).toContain(hardestKey(f))
+    }
+  })
+
+  it('is idempotent: applying twice yields the same set', () => {
+    const once = applyPreset([], PRESET_FAMILIES.CRA)
+    const twice = applyPreset(once, PRESET_FAMILIES.CRA)
+    expect(new Set(twice)).toEqual(new Set(once))
+  })
+
+  it('swaps a lower-tier same-cadence selection up to the hardest tier', () => {
+    // Start with a lower-tier Vellum daily selection (Normal Vellum daily).
+    const vellum = getBossByFamily('vellum')!
+    const lowDailyKey = makeKey(vellum.id, 'normal', 'daily')
+    const result = applyPreset([lowDailyKey], ['vellum'])
+    // Hardest Vellum is chaos weekly; the daily entry is on a different
+    // cadence bucket so both selections coexist.
+    const hardestWeekly = hardestKey('vellum')
+    expect(result).toContain(hardestWeekly)
+    // Daily selection is preserved — applyPreset uses toggleBoss semantics,
+    // which only swaps *same-cadence* siblings.
+    expect(result).toContain(lowDailyKey)
+  })
+
+  it('keeps CRA and CTENE overlap intact when both are applied', () => {
+    const withCra = applyPreset([], PRESET_FAMILIES.CRA)
+    const withBoth = applyPreset(withCra, PRESET_FAMILIES.CTENE)
+    for (const f of CTENE_OVERLAP) {
+      expect(withBoth).toContain(hardestKey(f))
+    }
+    // All CRA and all CTENE hardest keys present.
+    for (const f of PRESET_FAMILIES.CRA) {
+      expect(withBoth).toContain(hardestKey(f))
+    }
+    for (const f of PRESET_FAMILIES.CTENE) {
+      expect(withBoth).toContain(hardestKey(f))
+    }
+  })
+})
+
+describe('removePreset', () => {
+  it('drops every key whose boss family is in the list', () => {
+    const withCra = applyPreset([], PRESET_FAMILIES.CRA)
+    const result = removePreset(withCra, PRESET_FAMILIES.CRA)
+    expect(result).toEqual([])
+  })
+
+  it('preserves non-preset keys', () => {
+    const lucid = hardestKey('lucid')
+    const withCra = applyPreset([lucid], PRESET_FAMILIES.CRA)
+    const result = removePreset(withCra, PRESET_FAMILIES.CRA)
+    expect(result).toEqual([lucid])
+  })
+
+  it('drops ALL keys for a family in the list, regardless of tier/cadence', () => {
+    const vellum = getBossByFamily('vellum')!
+    const normalDaily = makeKey(vellum.id, 'normal', 'daily')
+    const chaosWeekly = makeKey(vellum.id, 'chaos', 'weekly')
+    const result = removePreset([normalDaily, chaosWeekly], ['vellum'])
+    expect(result).toEqual([])
+  })
+
+  it('leaves CTENE overlap intact when only CRA is removed while CTENE is still active', () => {
+    // Apply CRA and CTENE; then remove CRA. The 4 overlap families
+    // (Vellum, CQ, Papulatus, Magnus) must come back because CTENE still
+    // holds them — but under the spec, removePreset drops those families
+    // outright. The invariant is that the CALLER (MuleDetailDrawer) uses
+    // isPresetActive to choose whether to call applyPreset or removePreset,
+    // and the overlap persistence is realized by re-applying CTENE after
+    // CRA-remove. At the helper level: removePreset(CRA) drops all 10 CRA
+    // families including the overlap.
+    const withBoth = applyPreset(
+      applyPreset([], PRESET_FAMILIES.CRA),
+      PRESET_FAMILIES.CTENE,
+    )
+    const afterCraRemoved = removePreset(withBoth, PRESET_FAMILIES.CRA)
+    // Non-overlap CTENE families survive.
+    const craSet: ReadonlySet<string> = new Set(CRA_FAMILIES)
+    for (const f of PRESET_FAMILIES.CTENE) {
+      if (craSet.has(f)) continue
+      expect(afterCraRemoved).toContain(hardestKey(f))
+    }
+    // Overlap dropped (not re-added by this helper).
+    for (const f of CTENE_OVERLAP) {
+      expect(afterCraRemoved).not.toContain(hardestKey(f))
+    }
+  })
+
+  it('ignores malformed keys in the input (no crash)', () => {
+    const result = removePreset(['stale-key'], PRESET_FAMILIES.CRA)
+    // Malformed keys have no parseable bossId; they are preserved since
+    // they do not match any family in the drop list.
+    expect(result).toEqual(['stale-key'])
+  })
+
+  it('returns empty input unchanged', () => {
+    expect(removePreset([], PRESET_FAMILIES.CRA)).toEqual([])
+  })
+})
+
+describe('isPresetActive', () => {
+  it('returns false for an empty selection', () => {
+    expect(isPresetActive('CRA', [])).toBe(false)
+    expect(isPresetActive('CTENE', [])).toBe(false)
+  })
+
+  it('returns true iff every preset family has its hardest-tier key present', () => {
+    const withCra = applyPreset([], PRESET_FAMILIES.CRA)
+    expect(isPresetActive('CRA', withCra)).toBe(true)
+    expect(isPresetActive('CTENE', withCra)).toBe(false)
+  })
+
+  it('returns false when one CRA family is missing', () => {
+    const withCra = applyPreset([], PRESET_FAMILIES.CRA)
+    // Drop just Magnus's hardest key.
+    const magnusHard = hardestKey('magnus')
+    const missingOne = withCra.filter((k) => k !== magnusHard)
+    expect(isPresetActive('CRA', missingOne)).toBe(false)
+  })
+
+  it('returns false when a family has only a lower-tier key', () => {
+    // Replace the hardest Vellum key with Normal (daily) — lower tier.
+    const withCra = applyPreset([], PRESET_FAMILIES.CRA)
+    const vellum = getBossByFamily('vellum')!
+    const hardestVellum = hardestKey('vellum')
+    const normalDaily = makeKey(vellum.id, 'normal', 'daily')
+    const downgraded = withCra
+      .filter((k) => k !== hardestVellum)
+      .concat(normalDaily)
+    expect(isPresetActive('CRA', downgraded)).toBe(false)
+  })
+
+  it('returns true for CTENE iff all 14 hardest-tier keys are present', () => {
+    const withCtene = applyPreset([], PRESET_FAMILIES.CTENE)
+    expect(isPresetActive('CTENE', withCtene)).toBe(true)
+  })
+
+  it('both presets read active when both have been applied', () => {
+    const withBoth = applyPreset(
+      applyPreset([], PRESET_FAMILIES.CRA),
+      PRESET_FAMILIES.CTENE,
+    )
+    expect(isPresetActive('CRA', withBoth)).toBe(true)
+    expect(isPresetActive('CTENE', withBoth)).toBe(true)
+  })
+})
+
+describe('cross-helper sanity', () => {
+  it('applyPreset output has parseable keys for every family', () => {
+    const keys = applyPreset([], PRESET_FAMILIES.CRA)
+    for (const k of keys) {
+      expect(parseKey(k)).not.toBeNull()
+    }
+  })
+
+  it('removePreset output has parseable keys (or malformed pass-through)', () => {
+    const withCra = applyPreset([], PRESET_FAMILIES.CRA)
+    const lucid = hardestKey('lucid')
+    const partial = removePreset([...withCra, lucid], PRESET_FAMILIES.CRA)
+    expect(partial).toEqual([lucid])
+    expect(parseKey(partial[0])).not.toBeNull()
+  })
+})

--- a/src/data/bossPresets.ts
+++ b/src/data/bossPresets.ts
@@ -1,0 +1,98 @@
+import { getBossByFamily } from './bosses';
+import { hardestDifficulty, makeKey, parseKey, toggleBoss } from './bossSelection';
+
+/**
+ * Boss Preset shortcuts for the Matrix Toolbar. Each preset is a fixed list
+ * of boss families; clicking a preset pill swaps in (or drops) the
+ * Hardest-Tier selection key for every family in the list.
+ *
+ * Overlap-persistent by design: CRA ∩ CTENE share Vellum / Crimson Queen /
+ * Papulatus / Magnus. Toggling one preset off leaves those four families
+ * selected iff the OTHER preset is still active — the caller decides which
+ * branch of (applyPreset | removePreset) to take based on `isPresetActive`,
+ * and re-applying the overlap preset re-inserts the shared families.
+ */
+
+export type PresetKey = 'CRA' | 'CTENE';
+
+export const PRESET_FAMILIES = {
+  CRA: [
+    'cygnus',
+    'pink-bean',
+    'vellum',
+    'crimson-queen',
+    'von-bon',
+    'pierre',
+    'papulatus',
+    'hilla',
+    'magnus',
+    'zakum',
+  ],
+  CTENE: [
+    'akechi-mitsuhide',
+    'princess-no',
+    'darknell',
+    'verus-hilla',
+    'gloom',
+    'will',
+    'lucid',
+    'guardian-angel-slime',
+    'damien',
+    'lotus',
+    'vellum',
+    'crimson-queen',
+    'papulatus',
+    'magnus',
+  ],
+} as const satisfies Record<PresetKey, readonly string[]>;
+
+/**
+ * Swap each family's Hardest-Tier selection key into `keys`, using
+ * `toggleBoss` semantics so any prior same-cadence sibling on that boss is
+ * replaced (and opposite-cadence selections are preserved).
+ */
+export function applyPreset(keys: string[], families: readonly string[]): string[] {
+  let next = keys;
+  for (const family of families) {
+    const boss = getBossByFamily(family);
+    if (!boss) continue;
+    const diff = hardestDifficulty(boss);
+    const target = makeKey(boss.id, diff.tier, diff.cadence);
+    if (next.includes(target)) continue; // idempotent
+    next = toggleBoss(next, boss.id, diff.tier);
+  }
+  return next;
+}
+
+/**
+ * Drop every key whose bossId resolves to a family in `families`. Malformed
+ * keys (unparseable) pass through untouched.
+ */
+export function removePreset(keys: string[], families: readonly string[]): string[] {
+  const dropFamilyIds = new Set<string>();
+  for (const family of families) {
+    const boss = getBossByFamily(family);
+    if (boss) dropFamilyIds.add(boss.id);
+  }
+  return keys.filter((k) => {
+    const parsed = parseKey(k);
+    if (!parsed) return true;
+    return !dropFamilyIds.has(parsed.bossId);
+  });
+}
+
+/**
+ * Active iff every family in the preset has its Hardest-Tier key present
+ * in `keys`. Mirrors the visual: pill highlights iff the selection state
+ * fully matches what `applyPreset` would have produced.
+ */
+export function isPresetActive(preset: PresetKey, keys: string[]): boolean {
+  const keySet = new Set(keys);
+  for (const family of PRESET_FAMILIES[preset]) {
+    const boss = getBossByFamily(family);
+    if (!boss) return false;
+    const diff = hardestDifficulty(boss);
+    if (!keySet.has(makeKey(boss.id, diff.tier, diff.cadence))) return false;
+  }
+  return true;
+}

--- a/src/data/bosses.ts
+++ b/src/data/bosses.ts
@@ -323,7 +323,12 @@ export const TIER_LESS_FAMILIES: ReadonlySet<string> = new Set([
 ]);
 
 const bossById = new Map<string, Boss>(bosses.map((b) => [b.id, b]));
+const bossByFamily = new Map<string, Boss>(bosses.map((b) => [b.family, b]));
 
 export function getBossById(id: string): Boss | undefined {
   return bossById.get(id);
+}
+
+export function getBossByFamily(family: string): Boss | undefined {
+  return bossByFamily.get(family);
 }


### PR DESCRIPTION
## Summary

- New `src/data/bossPresets.ts` with `PRESET_FAMILIES`, `applyPreset`, `removePreset`, `isPresetActive`.
- `MatrixToolbar` renders `[CRA · CTENE]` segmented control next to the Cadence Filter with a `.d-toolbar-sep` between them.
- `MuleDetailDrawer` derives `activePresets` from `mule.selectedBosses` and wires `onTogglePreset` to apply/remove preset families.
- `src/data/bosses.ts` gains a `getBossByFamily` lookup helper used by the preset helpers.

## Test plan

- [x] npm test — 422/422 passing
- [x] Acceptance criteria verified against issue

Closes #132