### PR TITLE
Slice 1: Stable per-mule slice colors in the income pie chart

### DIFF
--- a/src/components/IncomePieChart.tsx
+++ b/src/components/IncomePieChart.tsx
@@ -3,15 +3,8 @@ import { PieChart, Pie, Cell } from 'recharts';
 import type { Mule } from '../types';
 import { computeMuleIncome } from '../modules/income';
 import { useFormatPreference } from '../modules/income-hooks';
+import { colorForMuleId } from '../utils/muleColor';
 import { ChartContainer, type ChartConfig } from './ui/chart';
-
-const CHART_VARS = [
-  'var(--c1)',
-  'var(--c2)',
-  'var(--c3)',
-  'var(--c4)',
-  'var(--c5)',
-];
 
 interface ChartDataItem {
   name: string;
@@ -30,16 +23,20 @@ export function IncomePieChart({ mules, onSliceClick }: IncomePieChartProps) {
   const { abbreviated } = useFormatPreference();
   const [activeIndex, setActiveIndex] = useState<number | undefined>(undefined);
 
+  // Slice color is a function of mule identity, not array position. Drag
+  // reorders the roster in place, so anything derived from the array index
+  // would flicker on every drop; the stable per-id mapping is what keeps
+  // "the amber one is my Bishop" true across reorders and insertions.
   const data: ChartDataItem[] = mules
     .filter((m) => m.selectedBosses.length > 0)
-    .map((m, i) => {
+    .map((m) => {
       const { raw, formatted } = computeMuleIncome(m.selectedBosses, abbreviated);
       return {
         name: m.name || 'Unnamed Mule',
         value: raw,
         formatted,
         muleId: m.id,
-        fill: CHART_VARS[i % CHART_VARS.length],
+        fill: colorForMuleId(m.id),
       };
     });
 

--- a/src/components/__tests__/IncomePieChart.test.tsx
+++ b/src/components/__tests__/IncomePieChart.test.tsx
@@ -4,6 +4,7 @@ import { IncomePieChart, describeArc, formatCompact } from '../IncomePieChart'
 import type { Mule } from '../../types'
 import { bosses } from '../../data/bosses'
 import { makeKey } from '../../data/bossSelection'
+import { MULE_PALETTE } from '../../utils/muleColor'
 
 const HILLA = bosses.find((b) => b.family === 'hilla')!.id
 // Normal Hilla is a daily tier (slice 2, per the PRD daily classification).
@@ -23,6 +24,41 @@ const muleNoBosses: Mule = {
   level: 150,
   muleClass: 'Paladin',
   selectedBosses: [],
+}
+
+/**
+ * Build a mule whose id is meaningful and who has at least one boss so it
+ * shows up in the pie.
+ */
+function makeMule(id: string, overrides: Partial<Mule> = {}): Mule {
+  return {
+    id,
+    name: id,
+    level: 200,
+    muleClass: 'Hero',
+    selectedBosses: [NORMAL_HILLA],
+    ...overrides,
+  }
+}
+
+/**
+ * Read the ChartContainer's inlined `<style>` block and return a map from
+ * mule id → CSS color token. The ChartContainer emits `--color-<id>: <token>`
+ * for every entry in `chartConfig`, which our IncomePieChart keys by mule id.
+ * That makes the style text a clean, test-stable view of the name↔color
+ * pairing the legend and tooltip both derive from.
+ */
+function readMuleColors(container: HTMLElement): Record<string, string> {
+  const styleEl = container.querySelector('style')
+  const css = styleEl?.textContent ?? ''
+  const map: Record<string, string> = {}
+  // Match `--color-<id>: <value>;` — ids come from mule uuids / test ids.
+  const re = /--color-([^:\s]+):\s*([^;]+);/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(css)) !== null) {
+    map[m[1]] = m[2].trim()
+  }
+  return map
 }
 
 describe('IncomePieChart', () => {
@@ -82,5 +118,116 @@ describe('IncomePieChart', () => {
       fireEvent.click(paths[0])
       expect(onSliceClick).toHaveBeenCalledWith('mule-1')
     }
+  })
+
+  describe('per-mule stable slice colors', () => {
+    it('keeps each mule\'s slice color unchanged when the roster is reordered', () => {
+      const mules = [makeMule('A'), makeMule('B'), makeMule('C')]
+
+      const first = render(<IncomePieChart mules={mules} />)
+      const before = readMuleColors(first.container)
+      first.unmount()
+
+      const reordered = [mules[2], mules[0], mules[1]] // C, A, B
+      const second = render(<IncomePieChart mules={reordered} />)
+      const after = readMuleColors(second.container)
+
+      expect(after.A).toBe(before.A)
+      expect(after.B).toBe(before.B)
+      expect(after.C).toBe(before.C)
+    })
+
+    it('does not change existing slice colors when a new mule is prepended', () => {
+      const existing = [makeMule('A'), makeMule('B'), makeMule('C')]
+
+      const first = render(<IncomePieChart mules={existing} />)
+      const before = readMuleColors(first.container)
+      first.unmount()
+
+      const withNew = [makeMule('NEW'), ...existing]
+      const second = render(<IncomePieChart mules={withNew} />)
+      const after = readMuleColors(second.container)
+
+      expect(after.A).toBe(before.A)
+      expect(after.B).toBe(before.B)
+      expect(after.C).toBe(before.C)
+      // And the new mule has a defined color as well.
+      expect(after.NEW).toBeDefined()
+    })
+
+    it('does not change existing slice colors when an unrelated mule is removed', () => {
+      const mules = [makeMule('A'), makeMule('B'), makeMule('C')]
+
+      const first = render(<IncomePieChart mules={mules} />)
+      const before = readMuleColors(first.container)
+      first.unmount()
+
+      // Drop B from the middle.
+      const shrunken = [mules[0], mules[2]]
+      const second = render(<IncomePieChart mules={shrunken} />)
+      const after = readMuleColors(second.container)
+
+      expect(after.A).toBe(before.A)
+      expect(after.C).toBe(before.C)
+    })
+
+    it('keeps name↔color pairing intact so legend/tooltip stay correct after reorder', () => {
+      const mules = [makeMule('alpha'), makeMule('bravo'), makeMule('charlie')]
+
+      const first = render(<IncomePieChart mules={mules} />)
+      const before = readMuleColors(first.container)
+      first.unmount()
+
+      // Rotate: [bravo, charlie, alpha]
+      const rotated = [mules[1], mules[2], mules[0]]
+      const second = render(<IncomePieChart mules={rotated} />)
+      const after = readMuleColors(second.container)
+
+      // The legend derives entries from chartConfig keyed by mule id, so a
+      // stable per-id color automatically keeps each name paired with the
+      // same color after any reorder.
+      for (const id of ['alpha', 'bravo', 'charlie']) {
+        expect(after[id]).toBe(before[id])
+      }
+    })
+
+    it('with more mules than palette slots, color mapping is stable across reorders', () => {
+      const N = MULE_PALETTE.length + 3
+      const mules = Array.from({ length: N }, (_, i) => makeMule(`mule-${i}`))
+
+      const first = render(<IncomePieChart mules={mules} />)
+      const before = readMuleColors(first.container)
+      first.unmount()
+
+      // Every mule has a defined color.
+      for (let i = 0; i < N; i++) {
+        expect(before[`mule-${i}`]).toBeDefined()
+      }
+      // Collisions exist (pigeonhole), and two colliding mules share a color.
+      const values = Object.values(before)
+      const unique = new Set(values)
+      expect(unique.size).toBeLessThan(values.length)
+
+      // Reorder — reverse the whole roster, which moves every mule past
+      // whichever sibling it may be color-sharing with.
+      const reversed = [...mules].reverse()
+      const second = render(<IncomePieChart mules={reversed} />)
+      const after = readMuleColors(second.container)
+
+      // Each mule keeps its color.
+      for (let i = 0; i < N; i++) {
+        expect(after[`mule-${i}`]).toBe(before[`mule-${i}`])
+      }
+
+      // And any two mules that shared a color before still share one after,
+      // and any two that differed still differ.
+      for (let i = 0; i < N; i++) {
+        for (let j = i + 1; j < N; j++) {
+          const sharedBefore = before[`mule-${i}`] === before[`mule-${j}`]
+          const sharedAfter = after[`mule-${i}`] === after[`mule-${j}`]
+          expect(sharedAfter).toBe(sharedBefore)
+        }
+      }
+    })
   })
 })

--- a/src/utils/__tests__/muleColor.test.ts
+++ b/src/utils/__tests__/muleColor.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MULE_PALETTE,
+  colorForMuleId,
+  colorIndexForMuleId,
+} from '../muleColor'
+
+describe('muleColor', () => {
+  it('returns a palette slot in bounds for any id', () => {
+    const ids = ['a', 'b', 'c', 'long-uuid-like-string', '']
+    for (const id of ids) {
+      const idx = colorIndexForMuleId(id)
+      expect(idx).toBeGreaterThanOrEqual(0)
+      expect(idx).toBeLessThan(MULE_PALETTE.length)
+    }
+  })
+
+  it('is deterministic — same id → same index across calls', () => {
+    expect(colorIndexForMuleId('mule-1')).toBe(colorIndexForMuleId('mule-1'))
+    expect(colorForMuleId('mule-1')).toBe(colorForMuleId('mule-1'))
+  })
+
+  it('is pure in the id: other ids never change an id\'s slot', () => {
+    const before = colorIndexForMuleId('target')
+    // Touch many other ids; the hash must not accumulate state.
+    for (let i = 0; i < 50; i++) colorIndexForMuleId(`noise-${i}`)
+    expect(colorIndexForMuleId('target')).toBe(before)
+  })
+
+  it('colorForMuleId returns the palette token at the computed index', () => {
+    const id = 'mule-xyz'
+    expect(colorForMuleId(id)).toBe(MULE_PALETTE[colorIndexForMuleId(id)])
+  })
+})

--- a/src/utils/muleColor.ts
+++ b/src/utils/muleColor.ts
@@ -1,0 +1,44 @@
+/**
+ * Palette of CSS custom-property references used for pie-chart slice fills.
+ * The order is significant: indexes here align with `colorIndexForMuleId`'s
+ * output so that a given mule id consistently maps to the same palette slot.
+ *
+ * When the roster exceeds the palette size, mule ids hash modulo the palette
+ * length; collisions are expected and stable — the same two mules share a
+ * color before and after any reorder.
+ */
+export const MULE_PALETTE: readonly string[] = [
+  'var(--c1)',
+  'var(--c2)',
+  'var(--c3)',
+  'var(--c4)',
+  'var(--c5)',
+];
+
+/**
+ * Deterministic, stateless string hash (FNV-1a 32-bit). Identical across
+ * renders, independent of roster membership or order — which is exactly the
+ * property the pie chart's slice colors need.
+ */
+function hashString(input: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    // Multiply by the FNV 32-bit prime and fold to 32 bits.
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/**
+ * Map a mule id to a palette slot. Pure function of the id alone — no
+ * dependence on current roster order, size, or any other mule's presence.
+ */
+export function colorIndexForMuleId(muleId: string): number {
+  return hashString(muleId) % MULE_PALETTE.length;
+}
+
+/** Convenience wrapper that returns the CSS color token directly. */
+export function colorForMuleId(muleId: string): string {
+  return MULE_PALETTE[colorIndexForMuleId(muleId)];
+}


### PR DESCRIPTION
## Summary

- Derive pie-chart slice `fill` from a deterministic FNV-1a hash of the mule id instead of the roster index, so drag-reordering no longer reshuffles slice colors.
- New `src/utils/muleColor.ts` owns the pure `colorForMuleId` function and the 5-slot palette; `IncomePieChart` drops the inline `CHART_VARS` constant and its index-based lookup.
- Collisions past the palette size are tolerated by design — the same two mules share a color before and after any reorder.

No schema change is needed: the hash is stateless, so existing persisted rosters "just work" without a migration.

## Test plan

- [x] `npm test` — new tests pass; no tests that were green on `main` have regressed.
- [x] New behavior tests under `IncomePieChart > per-mule stable slice colors`:
  - reorder-invariance (swap, rotate)
  - insertion-invariance (prepend new mule; delete middle mule)
  - legend name↔color pairing after reorder
  - palette overflow: 8 mules → every mule has a color, collisions are stable across a full reverse
- [x] New unit tests for `colorForMuleId` / `colorIndexForMuleId` pin determinism, purity, and palette-bounds.
- [x] Empty-roster / single-mule-no-bosses empty states still render.

Closes #144