### PR TITLE
Slice 1: AddCard height parity with mule cards in roster grid

### DIFF
--- a/Design.md
+++ b/Design.md
@@ -112,6 +112,7 @@ Set on `<html>` via `DensityProvider` (`comfy` default, `compact` alt). Controls
 | `--roster-cols` | 6 | 8 |
 | `--sil-size` | 72px | 56px |
 | `--mule-name-size` | 14px | 13px |
+| `--roster-card-min-height` | 260px | 220px |
 
 The roster grid reads `grid-template-columns: repeat(var(--roster-cols), minmax(0, 1fr))`. `DensityToggle` is a two-option segmented control in the Roster heading.
 
@@ -146,7 +147,7 @@ Plain `panel` wrapping a 260px Recharts donut. Inner radius 66, outer 100, 2° p
 Card is also a dnd-kit sortable handle; the full card is the drag surface (pointer sensor with 5px activation distance).
 
 ### [AddCard](src/components/AddCard.tsx)
-Dashed 2px border tile in the roster grid. On hover: border and `+` icon flip to accent; background fills with `--accent-soft`. 160px min-height keeps it flush with mule cards.
+Dashed 2px border tile in the roster grid. On hover: border and `+` icon flip to accent; background fills with `--accent-soft`. Reads the shared `--roster-card-min-height` token (also consumed by `MuleCharacterCard`), and the roster grid pins every implicit row to that same floor via `grid-auto-rows: minmax(var(--roster-card-min-height), auto)` — so the AddCard stays flush with mule cards whether it shares a row, wraps alone onto a new row at the density boundary, or renders on an empty roster. The token is density-scoped (260px comfy, 220px compact) to track the smaller silhouette in compact.
 
 ### [MuleDetailDrawer](src/components/MuleDetailDrawer.tsx)
 Right-side shadcn `Sheet`. Full viewport below `md`, 640px at `md+`. Surface: `var(--surface)` with a 1px `--border` left rail. A 1px horizontal accent gradient lines the top edge, and a `-24px` blurred accent radial sits in the top-right corner.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -134,7 +134,11 @@ function AppContent() {
               <div style={isDragging ? dragBoundaryActiveStyle : dragBoundaryBaseStyle} className="transition-[border-color] duration-200" data-drag-boundary>
                 <div
                   className="grid gap-4"
-                  style={{ gridTemplateColumns: 'repeat(var(--roster-cols, 6), minmax(0, 1fr))' }}
+                  style={{
+                    gridTemplateColumns: 'repeat(var(--roster-cols, 6), minmax(0, 1fr))',
+                    // Prevents a lone AddCard row from collapsing below the mule-card floor.
+                    gridAutoRows: 'minmax(var(--roster-card-min-height, 260px), auto)',
+                  }}
                 >
                   {mules.map((mule) => (
                     <MuleCharacterCard

--- a/src/components/AddCard.tsx
+++ b/src/components/AddCard.tsx
@@ -28,7 +28,10 @@ export function AddCard({ onClick }: AddCardProps) {
         display: 'grid',
         placeItems: 'center',
         transition: 'border-color 150ms, background 150ms',
-        minHeight: 260,
+        // Reads the shared roster-card height contract (see index.css) so
+        // AddCard can't drift from the mule-card floor — and a lone AddCard
+        // row still renders at the same height thanks to grid-auto-rows.
+        minHeight: 'var(--roster-card-min-height, 260px)',
       }}
     >
       <div style={{ display: 'grid', placeItems: 'center', gap: 10 }}>

--- a/src/components/MuleCharacterCard.tsx
+++ b/src/components/MuleCharacterCard.tsx
@@ -99,7 +99,7 @@ export const MuleCharacterCardOverlay = memo(function MuleCharacterCardOverlay({
       className="panel cursor-grabbing"
       style={{
         padding: 'var(--card-pad, 16px)',
-        minHeight: 260,
+        minHeight: 'var(--roster-card-min-height, 260px)',
         display: 'flex',
         flexDirection: 'column',
         transform: 'translateY(-2px)',
@@ -144,7 +144,7 @@ export function MuleCharacterCard({ mule, onClick, onDelete }: MuleCharacterCard
         className="panel cursor-pointer"
         style={{
           padding: 'var(--card-pad, 16px)',
-          minHeight: 260,
+          minHeight: 'var(--roster-card-min-height, 260px)',
           display: 'flex',
           flexDirection: 'column',
           transform: isHovered ? 'translateY(-2px)' : undefined,

--- a/src/components/__tests__/RosterCardHeightParity.test.tsx
+++ b/src/components/__tests__/RosterCardHeightParity.test.tsx
@@ -1,0 +1,174 @@
+/// <reference types="node" />
+/**
+ * Slice 1 parent #141 / issue #142: pins the height contract that keeps AddCard
+ * flush with mule cards in the roster grid regardless of row position.
+ *
+ * jsdom has no layout engine, so we can't measure pixel heights. Instead these
+ * tests pin the *contract*:
+ *   1. AddCard and MuleCharacterCard read the same min-height token, so their
+ *      floors can never drift from each other.
+ *   2. The roster grid applies `grid-auto-rows` with that same min, so an
+ *      AddCard wrapping alone to a new row still gets the floor (density-boundary
+ *      parity — the case that failed before, in both comfy and compact).
+ *   3. Within any row, CSS grid's default stretch alignment pulls every cell
+ *      (including AddCard) to the tallest card — we don't set `align-items`
+ *      away from stretch, so the non-uniform-content parity falls out for free.
+ *      The test here just pins that we're not accidentally opting out.
+ *   4. Empty-roster fallback: even with zero mules, the AddCard still renders
+ *      at the shared floor.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it, beforeEach } from 'vitest'
+import { DndContext } from '@dnd-kit/core'
+import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable'
+import { render } from '../../test/test-utils'
+import App from '../../App'
+import { AddCard } from '../AddCard'
+import { MuleCharacterCard } from '../MuleCharacterCard'
+import type { Mule } from '../../types'
+
+// Read index.css once at module load. Node env is available under vitest.
+const indexCssRaw = readFileSync(resolve(process.cwd(), 'src/index.css'), 'utf-8')
+
+const STORAGE_KEY = 'maplestory-mule-tracker'
+
+function persistedRoot(mules: Mule[]) {
+  return { schemaVersion: 2, mules }
+}
+
+function seedMules(mules: Mule[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(persistedRoot(mules)))
+}
+
+let muleCounter = 0
+function makeMule(overrides: Partial<Mule> = {}): Mule {
+  muleCounter += 1
+  return {
+    id: `mule-${muleCounter}`,
+    name: 'Mule',
+    level: 200,
+    muleClass: 'Hero',
+    selectedBosses: [],
+    ...overrides,
+  }
+}
+
+
+beforeEach(() => {
+  localStorage.clear()
+  document.documentElement.removeAttribute('data-density')
+})
+
+describe('Roster card height parity contract', () => {
+  it('MuleCharacterCard inner panel min-height reads the shared roster-card-min-height variable', () => {
+    const onClick = () => {}
+    const onDelete = () => {}
+    const mule = makeMule()
+    const { container } = render(
+      <DndContext>
+        <SortableContext items={[mule.id]} strategy={rectSortingStrategy}>
+          <MuleCharacterCard mule={mule} onClick={onClick} onDelete={onDelete} />
+        </SortableContext>
+      </DndContext>,
+    )
+    const panel = container.querySelector('[data-mule-card] .panel') as HTMLElement
+    expect(panel).toBeTruthy()
+    // The inline min-height must reference the shared CSS variable — not a hard number.
+    expect(panel.style.minHeight).toContain('var(--roster-card-min-height')
+  })
+
+  it('AddCard min-height reads the same shared roster-card-min-height variable', () => {
+    const { container } = render(<AddCard onClick={() => {}} />)
+    const addCard = container.querySelector('[data-add-card]') as HTMLElement
+    expect(addCard).toBeTruthy()
+    expect(addCard.style.minHeight).toContain('var(--roster-card-min-height')
+  })
+
+  it('AddCard and MuleCharacterCard reference the exact same min-height variable (no drift)', () => {
+    const mule = makeMule()
+    const { container: muleContainer } = render(
+      <DndContext>
+        <SortableContext items={[mule.id]} strategy={rectSortingStrategy}>
+          <MuleCharacterCard mule={mule} onClick={() => {}} onDelete={() => {}} />
+        </SortableContext>
+      </DndContext>,
+    )
+    const { container: addContainer } = render(<AddCard onClick={() => {}} />)
+    const panel = muleContainer.querySelector('[data-mule-card] .panel') as HTMLElement
+    const addCard = addContainer.querySelector('[data-add-card]') as HTMLElement
+    expect(panel.style.minHeight).toBe(addCard.style.minHeight)
+  })
+
+  it('the shared min-height token is declared in both density scopes and above the stale 160px floor', () => {
+    // jsdom doesn't parse Tailwind/@import CSS, so getComputedStyle on :root
+    // won't see tokens from index.css. Inspect the stylesheet source directly.
+    // Variable exists at the comfy and compact density scopes (those are the
+    // only two scopes the roster grid actually renders under).
+    const comfyMatch = indexCssRaw.match(/\[data-density="comfy"\]\s*\{[^}]*--roster-card-min-height:\s*(\d+)px/)
+    const compactMatch = indexCssRaw.match(/\[data-density="compact"\]\s*\{[^}]*--roster-card-min-height:\s*(\d+)px/)
+    expect(comfyMatch).not.toBeNull()
+    expect(compactMatch).not.toBeNull()
+    // Must be taller than the stale 160px floor the parent PRD called out,
+    // otherwise AddCard would still collapse below the mule-card intrinsic height.
+    expect(parseInt(comfyMatch![1], 10)).toBeGreaterThanOrEqual(240)
+    // Compact cards are shorter (56px silhouette vs 72px) so the floor can be
+    // smaller, but it must still clear the stale 160px floor.
+    expect(parseInt(compactMatch![1], 10)).toBeGreaterThan(160)
+  })
+
+  it('roster grid pins every implicit row to the shared min via grid-auto-rows (density-boundary parity)', () => {
+    // Seed enough mules to hit the comfy column boundary (6 mules → AddCard wraps alone).
+    const mules = Array.from({ length: 6 }, (_, i) =>
+      makeMule({ id: `mule-${i}`, name: `M${i}` }),
+    )
+    seedMules(mules)
+    const { container } = render(<App />)
+    const grid = container.querySelector('[data-drag-boundary] .grid') as HTMLElement
+    expect(grid).toBeTruthy()
+    // grid-auto-rows (or a grid-template-rows) must reference the shared variable
+    // so the AddCard-alone row gets the same floor as mule rows.
+    const gridAutoRows = grid.style.gridAutoRows
+    expect(gridAutoRows).toContain('var(--roster-card-min-height')
+  })
+
+  it('parity holds at the compact-density boundary (8 mules → AddCard wraps alone in compact)', () => {
+    document.documentElement.setAttribute('data-density', 'compact')
+    const mules = Array.from({ length: 8 }, (_, i) =>
+      makeMule({ id: `mule-${i}`, name: `M${i}` }),
+    )
+    seedMules(mules)
+    const { container } = render(<App />)
+    const grid = container.querySelector('[data-drag-boundary] .grid') as HTMLElement
+    // Same contract on the grid regardless of density — the variable resolves at
+    // the density's :root scope, but the grid rule stays density-agnostic.
+    expect(grid.style.gridAutoRows).toContain('var(--roster-card-min-height')
+  })
+
+  it('roster grid does not override align-items (cells stretch to tallest in-row card for non-uniform content parity)', () => {
+    const mules = [
+      makeMule({ id: 'short', name: 'A' }),
+      // A very long name would wrap and grow this card; the AddCard sharing the row
+      // stretches with it via CSS grid's default align-items: stretch.
+      makeMule({ id: 'long', name: 'A'.repeat(80), muleClass: '' }),
+    ]
+    seedMules(mules)
+    const { container } = render(<App />)
+    const grid = container.querySelector('[data-drag-boundary] .grid') as HTMLElement
+    // Don't opt out of stretch — that's how in-row parity works.
+    expect(grid.style.alignItems === '' || grid.style.alignItems === 'stretch').toBe(true)
+  })
+
+  it('empty roster still renders AddCard at the shared min (no collapse to content-only)', () => {
+    // No seeded mules → roster contains only the AddCard.
+    const { container } = render(<App />)
+    const addCard = container.querySelector('[data-add-card]') as HTMLElement
+    expect(addCard).toBeTruthy()
+    // The AddCard itself still carries the shared min on its own inline style,
+    // so an empty roster doesn't collapse to the +-and-label intrinsic height.
+    expect(addCard.style.minHeight).toContain('var(--roster-card-min-height')
+    // And the grid rule still applies, so the lone row also has the floor.
+    const grid = container.querySelector('[data-drag-boundary] .grid') as HTMLElement
+    expect(grid.style.gridAutoRows).toContain('var(--roster-card-min-height')
+  })
+})

--- a/src/index.css
+++ b/src/index.css
@@ -136,6 +136,10 @@
   --roster-cols: 6;
   --sil-size: 72px;
   --mule-name-size: 14px;
+  /* Shared floor read by both MuleCharacterCard and AddCard so their heights
+   * can't drift; also fed into the roster grid's grid-auto-rows so a lone
+   * AddCard row keeps the same floor. */
+  --roster-card-min-height: 260px;
 }
 
 .dark {
@@ -197,12 +201,14 @@
   --roster-cols: 6;
   --sil-size: 72px;
   --mule-name-size: 14px;
+  --roster-card-min-height: 260px;
 }
 [data-density="compact"] {
   --card-pad: 12px;
   --roster-cols: 8;
   --sil-size: 56px;
   --mule-name-size: 13px;
+  --roster-card-min-height: 220px;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary

- Introduces density-scoped `--roster-card-min-height` CSS variable (260px comfy, 220px compact). Both `MuleCharacterCard` and `AddCard` read it, and the roster grid pins every implicit row to the same floor via `grid-auto-rows: minmax(var(--roster-card-min-height), auto)`.
- Fixes the AddCard collapse that happened when the mule count was an exact multiple of the column count and the AddCard wrapped alone onto a new row.
- 8 new contract tests in `RosterCardHeightParity.test.tsx` pin the height contract (jsdom-friendly — asserts CSS var usage and grid rules rather than measured pixel heights). Existing tests untouched.
- Design.md updated: "160px min-height" language replaced with the shared-token contract description, and the density table now includes the new variable.

## Test plan

- [x] `npm test` — 8 new tests pass; 5 pre-existing failures (unrelated: stale "WEEKLY" text assertions in MuleCharacterCard tests and two DnD timing tests) remain the same as before this change.
- [x] `npx tsc -b` — typecheck passes.
- [x] `npm run lint` — no new lint errors in changed files.
- [ ] Manual QA: seed 6 mules in comfy density, confirm AddCard wraps alone onto row 2 and matches row 1 height.
- [ ] Manual QA: switch to compact density with 8 mules, confirm same parity.
- [ ] Manual QA: empty roster — AddCard renders at the 260px floor, not collapsed to content.
- [ ] Manual QA: mule with an extra-long name — AddCard in the same row stretches to match.

Closes #142