### PR TITLE
Slice 2: Dim inactive mule cards in the roster

### DIFF
--- a/src/components/MuleCharacterCard.tsx
+++ b/src/components/MuleCharacterCard.tsx
@@ -20,6 +20,9 @@ const MuleCardInner = memo(function MuleCardInner({ mule }: { mule: Mule }) {
   const { abbreviated } = useFormatPreference()
   const abbreviatedIncome = formatMeso(rawIncome, true)
   const hasBosses = mule.selectedBosses.length > 0
+  const incomeColor = mule.active && hasBosses
+    ? 'var(--accent-raw, var(--accent))'
+    : 'var(--dim, var(--surface-dim))'
 
   return (
     <>
@@ -77,14 +80,14 @@ const MuleCardInner = memo(function MuleCardInner({ mule }: { mule: Mule }) {
         <span
           className="md:hidden"
           style={{
-            color: hasBosses ? 'var(--accent-raw, var(--accent))' : 'var(--dim, var(--surface-dim))',
+            color: incomeColor,
             fontFamily: 'JetBrains Mono, monospace', fontSize: 13, fontWeight: 600,
           }}
         >{abbreviatedIncome}</span>
         <span
           className="hidden md:inline"
           style={{
-            color: hasBosses ? 'var(--accent-raw, var(--accent))' : 'var(--dim, var(--surface-dim))',
+            color: incomeColor,
             fontFamily: 'JetBrains Mono, monospace', fontSize: 13, fontWeight: 600,
           }}
         >{potentialIncome}</span>
@@ -121,7 +124,7 @@ export function MuleCharacterCard({ mule, onClick, onDelete }: MuleCharacterCard
     : {
         transform: CSS.Transform.toString(transform),
         transition,
-        opacity: 1,
+        opacity: mule.active ? 1 : 0.55,
       }
 
   function stopPropagation(e: React.SyntheticEvent) { e.stopPropagation() }

--- a/src/components/__tests__/MuleCharacterCard.test.tsx
+++ b/src/components/__tests__/MuleCharacterCard.test.tsx
@@ -122,8 +122,8 @@ describe('MuleCharacterCard', () => {
     expect(screen.getByText('504,000,000')).toBeTruthy()
   })
 
-  it('keeps card opacity at 1 when not dragging', () => {
-    const { container } = renderCard()
+  it('keeps an active mule card at opacity 1 when not dragging', () => {
+    const { container } = renderCard({ active: true })
     const cardWrapper = container.querySelector('[data-mule-card]') as HTMLElement
     // Opacity stays at 1 regardless of hover; only drop during active drag.
     expect(cardWrapper.style.opacity).toBe('1')
@@ -131,6 +131,40 @@ describe('MuleCharacterCard', () => {
     expect(cardWrapper.style.opacity).toBe('1')
     fireEvent.mouseLeave(cardWrapper)
     expect(cardWrapper.style.opacity).toBe('1')
+  })
+
+  it('renders an inactive mule card at 0.55 opacity', () => {
+    const { container } = renderCard({ active: false })
+    const cardWrapper = container.querySelector('[data-mule-card]') as HTMLElement
+    expect(cardWrapper.style.opacity).toBe('0.55')
+  })
+
+  it('keeps an inactive mule card at 0.55 opacity on hover', () => {
+    const { container } = renderCard({ active: false })
+    const cardWrapper = container.querySelector('[data-mule-card]') as HTMLElement
+    const panel = cardWrapper.querySelector('.panel') as HTMLElement
+    expect(cardWrapper.style.opacity).toBe('0.55')
+    fireEvent.mouseEnter(panel)
+    expect(cardWrapper.style.opacity).toBe('0.55')
+    fireEvent.mouseLeave(panel)
+    expect(cardWrapper.style.opacity).toBe('0.55')
+  })
+
+  it('renders inactive mule income line in the dim color even when bosses are selected', () => {
+    renderCard({ active: false, selectedBosses: [HARD_LUCID] })
+    const incomeSpans = screen.getAllByText('504M')
+    for (const span of incomeSpans) {
+      expect(span.style.color).not.toContain('accent')
+      expect(span.style.color).toContain('dim')
+    }
+  })
+
+  it('renders active mule income line in the accent color when bosses are selected', () => {
+    renderCard({ active: true, selectedBosses: [HARD_LUCID] })
+    const incomeSpans = screen.getAllByText('504M')
+    for (const span of incomeSpans) {
+      expect(span.style.color).toContain('accent')
+    }
   })
 
   describe('trash icon and delete popover', () => {


### PR DESCRIPTION
## Summary

- Apply the Dim State (0.55 opacity) to a Character Card whose Mule is inactive; drag and hover states leave it dim.
- Extend the card's income-color predicate to `(mule.active && hasBosses)` so an Inactive Mule's income renders in the dim color even when bosses are selected.
- Tests updated: existing "opacity stays at 1" renamed to explicitly exercise the active case; added four new tests covering inactive opacity, inactive hover stability, inactive dim income, and an active+bosses accent regression guard.

Part of PRD #145. Follows Slice 1 (#146) which added the `active` field to `Mule`.

## Test plan

- [x] `npm test -- --run src/components/__tests__/MuleCharacterCard.test.tsx` — all 5 active/inactive tests green; the 3 pre-existing `/weekly/i` failures on `main` are unchanged.
- [x] Full suite: `npm test -- --run` — only pre-existing failures remain (unrelated App DnD opacity tests and a pre-existing IncomePieChart type error).
- [ ] Manual QA: after merge, app looks identical (`active: true` default from Slice 1). Edit localStorage to set one mule's `active: false`, reload — card renders at 0.55 opacity and stays dim on hover.

Closes #147