### PR TITLE
fix: make boss presets mutually exclusive (slice 1)

### DIFF
--- a/Design.md
+++ b/Design.md
@@ -176,7 +176,7 @@ One-click bulk-selection behind the toolbar's `CRA` / `CTENE` pills. A preset en
 
 - **CRA (10 families)** — `cygnus · pink-bean · vellum · crimson-queen · von-bon · pierre · papulatus · hilla · magnus · zakum`. All resolve to their hardest tier.
 - **CTENE (14 families)** — `akechi-mitsuhide · princess-no · darknell · verus-hilla · gloom · will · lucid · guardian-angel-slime · damien · {lotus, hard} · vellum · crimson-queen · papulatus · magnus`. Lotus is pinned to **Hard** (the weekly that most mules can realistically clear) instead of the Extreme default.
-- **Overlap** — CRA ∩ CTENE shares Vellum / Crimson Queen / Papulatus / Magnus. Toggling one preset off drops those four; they return as soon as the other preset is re-applied. The drawer uses `isPresetActive` to pick between `applyPreset` and `removePreset` per pill.
+- **Single-select swap** — at most one preset pill is active at any time. Clicking an inactive preset while another is active swaps: the drawer handler first calls `removePreset` for every currently-active preset, then `applyPreset` for the clicked one. Clicking the currently active pill deselects it. The CRA ∩ CTENE overlap (Vellum / Crimson Queen / Papulatus / Magnus) is a trivial consequence of apply-after-remove — the clicked preset re-selects its overlap families at its own resolved tiers, so no special persistence logic is needed in the helpers. Hand-picked selections outside both preset family lists survive every swap or deselect because `removePreset` is family-scoped.
 
 `applyPreset` uses `toggleBoss` semantics (same-cadence siblings get swapped, opposite-cadence selections are preserved); `removePreset` drops every key whose bossId matches a family in the list regardless of tier.
 

--- a/src/components/MuleDetailDrawer.tsx
+++ b/src/components/MuleDetailDrawer.tsx
@@ -81,9 +81,20 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
   function handleTogglePreset(preset: PresetKey) {
     if (!mule) return;
     const families = PRESET_FAMILIES[preset];
-    const next = activePresets.has(preset)
-      ? removePreset(mule.selectedBosses, families)
-      : applyPreset(mule.selectedBosses, families);
+    let next: string[];
+    if (activePresets.has(preset)) {
+      // Clicking the active pill deselects it.
+      next = removePreset(mule.selectedBosses, families);
+    } else {
+      // Swap semantics: strip every OTHER active preset's families first,
+      // then apply this one. Keeps at most one preset active at a time while
+      // preserving hand-picked selections outside any preset family.
+      let cleared = mule.selectedBosses;
+      for (const other of activePresets) {
+        cleared = removePreset(cleared, PRESET_FAMILIES[other]);
+      }
+      next = applyPreset(cleared, families);
+    }
     onUpdate(mule.id, { selectedBosses: next });
   }
 

--- a/src/components/__tests__/MuleDetailDrawer.test.tsx
+++ b/src/components/__tests__/MuleDetailDrawer.test.tsx
@@ -676,17 +676,129 @@ describe('MuleDetailDrawer', () => {
       ).toBe(true)
     })
 
-    it('both pills are active when CRA+CTENE union is present', () => {
-      const both = Array.from(new Set([...CRA_KEYS, ...CTENE_KEYS]))
+    it('clicking CTENE while CRA is active swaps to exactly CTENE (CRA-only families cleared)', () => {
+      const onUpdate = vi.fn()
       renderDrawer({
-        mule: { ...baseMule, selectedBosses: both },
+        mule: { ...baseMule, selectedBosses: CRA_KEYS },
+        onUpdate,
       })
-      expect(
-        screen.getByRole('button', { name: /^cra$/i }).classList.contains('on'),
-      ).toBe(true)
-      expect(
-        screen.getByRole('button', { name: /^ctene$/i }).classList.contains('on'),
-      ).toBe(true)
+      fireEvent.click(screen.getByRole('button', { name: /^ctene$/i }))
+      expect(onUpdate).toHaveBeenCalledTimes(1)
+      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] }
+      // Every CTENE resolved key is present.
+      for (const k of CTENE_KEYS) {
+        expect(update.selectedBosses).toContain(k)
+      }
+      // CRA-only families (those in CRA but not in CTENE) are gone.
+      const cteneFamilies = new Set(
+        PRESET_FAMILIES.CTENE.map(presetEntryFamily),
+      )
+      for (const f of PRESET_FAMILIES.CRA) {
+        if (cteneFamilies.has(f)) continue
+        expect(update.selectedBosses).not.toContain(hardestKey(f))
+      }
+    })
+
+    it('clicking CRA while CTENE is active swaps to exactly CRA (CTENE-only families cleared)', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: CTENE_KEYS },
+        onUpdate,
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^cra$/i }))
+      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] }
+      for (const k of CRA_KEYS) {
+        expect(update.selectedBosses).toContain(k)
+      }
+      const craFamilies = new Set(PRESET_FAMILIES.CRA)
+      for (const entry of PRESET_FAMILIES.CTENE) {
+        const family = presetEntryFamily(entry)
+        if (craFamilies.has(family)) continue
+        expect(update.selectedBosses).not.toContain(presetEntryKey(entry)!)
+      }
+    })
+
+    it('clicking the currently active preset deselects it (no pill active)', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: CRA_KEYS },
+        onUpdate,
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^cra$/i }))
+      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] }
+      // No CRA family key survives.
+      for (const f of PRESET_FAMILIES.CRA) {
+        expect(update.selectedBosses).not.toContain(hardestKey(f))
+      }
+      // No CTENE family key is spuriously added.
+      for (const k of CTENE_KEYS) {
+        expect(update.selectedBosses).not.toContain(k)
+      }
+    })
+
+    it('hand-picked non-preset keys survive a CRA→CTENE swap', () => {
+      const onUpdate = vi.fn()
+      // HARD_LUCID's family (lucid) is in CTENE, so pick a non-preset family
+      // instead — Horntail is in neither CRA nor CTENE.
+      const HARD_HORNTAIL = makeKey(HORNTAIL_BOSS.id, 'chaos', 'daily')
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: [...CRA_KEYS, HARD_HORNTAIL] },
+        onUpdate,
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^ctene$/i }))
+      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] }
+      expect(update.selectedBosses).toContain(HARD_HORNTAIL)
+    })
+
+    it('hand-picked non-preset keys survive a CTENE→deselect click', () => {
+      const onUpdate = vi.fn()
+      const HARD_HORNTAIL = makeKey(HORNTAIL_BOSS.id, 'chaos', 'daily')
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: [...CTENE_KEYS, HARD_HORNTAIL] },
+        onUpdate,
+      })
+      fireEvent.click(screen.getByRole('button', { name: /^ctene$/i }))
+      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] }
+      expect(update.selectedBosses).toContain(HARD_HORNTAIL)
+    })
+
+    it('the union state is unreachable via the pill-click flow (no sequence produces two active pills)', () => {
+      // Simulate the real drawer pipeline: each click's onUpdate payload
+      // becomes the next render's selectedBosses. Exercise both orderings
+      // (CRA→CTENE and CTENE→CRA) and assert the resulting state is never
+      // a union where both pills light up.
+      for (const order of [
+        ['cra', 'ctene'],
+        ['ctene', 'cra'],
+      ] as const) {
+        let selectedBosses: string[] = []
+        const onUpdate = vi.fn((_id: string, upd: { selectedBosses?: string[] }) => {
+          if (upd.selectedBosses !== undefined) selectedBosses = upd.selectedBosses
+        })
+        const { rerender } = renderDrawer({
+          mule: { ...baseMule, selectedBosses },
+          onUpdate,
+        })
+        for (const which of order) {
+          fireEvent.click(screen.getByRole('button', { name: new RegExp(`^${which}$`, 'i') }))
+          rerender(
+            <MuleDetailDrawer
+              mule={{ ...baseMule, selectedBosses }}
+              open={true}
+              onClose={vi.fn()}
+              onUpdate={onUpdate}
+              onDelete={vi.fn()}
+            />,
+          )
+        }
+        const craActive = screen
+          .getByRole('button', { name: /^cra$/i })
+          .classList.contains('on')
+        const cteneActive = screen
+          .getByRole('button', { name: /^ctene$/i })
+          .classList.contains('on')
+        expect(craActive && cteneActive).toBe(false)
+      }
     })
   })
 })

--- a/src/data/__tests__/bossPresets.test.ts
+++ b/src/data/__tests__/bossPresets.test.ts
@@ -248,15 +248,6 @@ describe('isPresetActive', () => {
     const withCtene = applyPreset([], PRESET_FAMILIES.CTENE)
     expect(isPresetActive('CTENE', withCtene)).toBe(true)
   })
-
-  it('both presets read active when both have been applied', () => {
-    const withBoth = applyPreset(
-      applyPreset([], PRESET_FAMILIES.CRA),
-      PRESET_FAMILIES.CTENE,
-    )
-    expect(isPresetActive('CRA', withBoth)).toBe(true)
-    expect(isPresetActive('CTENE', withBoth)).toBe(true)
-  })
 })
 
 describe('cross-helper sanity', () => {

--- a/src/data/bossPresets.ts
+++ b/src/data/bossPresets.ts
@@ -9,11 +9,15 @@ import { hardestDifficulty, makeKey, parseKey, toggleBoss } from './bossSelectio
  * key; an `{ family, tier }` entry pins a specific tier (e.g. CTENE's Hard
  * Lotus, chosen over the Extreme tier most mules can't clear).
  *
- * Overlap-persistent by design: CRA ∩ CTENE share Vellum / Crimson Queen /
- * Papulatus / Magnus. Toggling one preset off leaves those four families
- * selected iff the OTHER preset is still active — the caller decides which
- * branch of (applyPreset | removePreset) to take based on `isPresetActive`,
- * and re-applying the overlap preset re-inserts the shared families.
+ * Single-select swap semantics: at most one preset pill is ever active.
+ * Clicking an inactive preset while another is active first removes the
+ * previously active preset's families from the selection, then applies the
+ * clicked preset — so the CRA ∩ CTENE overlap (Vellum / Crimson Queen /
+ * Papulatus / Magnus) is just re-added by the apply step with the clicked
+ * preset's resolved tiers, no special-casing needed. Clicking the currently
+ * active preset deselects it. The drawer-level handler owns this policy;
+ * the helpers below (`applyPreset` / `removePreset` / `isPresetActive`) stay
+ * single-purpose and family-scoped.
  */
 
 export type PresetKey = 'CRA' | 'CTENE';


### PR DESCRIPTION
## Summary

- Drawer-level preset handler now swaps instead of unions when clicking an inactive preset while another is active: it first removes every currently-active preset's families from the selection, then applies the clicked preset. The previously-active preset's exclusive families are cleared; the CRA ∩ CTENE overlap is re-added by the apply step with the clicked preset's resolved tiers, so no special-casing is needed.
- Clicking the currently active preset still deselects it. Hand-picked keys outside both preset family lists survive every transition because `removePreset` is family-scoped.
- Updates the preset-module JSDoc and the Design.md "Boss Presets" section to describe single-select swap semantics (the "overlap-persistent by design" framing is dropped).

## Test plan

- [x] New drawer tests: CRA→CTENE swap clears CRA-only families, CTENE→CRA swap clears CTENE-only families, clicking an active preset deselects it, hand-picked keys survive a swap and a deselect.
- [x] Union-state-unreachable invariant test exercises CRA→CTENE and CTENE→CRA pill-click sequences through the real drawer pipeline and asserts both pills never light up simultaneously.
- [x] Retired the `bossPresets.test.ts` "both presets read active when both have been applied" helper-level assertion per the parent PRD's Step 4 plan.
- [x] All drawer and preset-data tests pass (83/83). Full `npm test` is green on the files touched by this slice; the only remaining failures (5 in `MuleCharacterCard.test.tsx` + `App.test.tsx`) exist on `main` without these changes and are unrelated to presets.

Closes #140