### PR TITLE
Slice 3: Add Active Toggle pill to drawer and default new mules inactive

### DIFF
--- a/src/components/MuleDetailDrawer.tsx
+++ b/src/components/MuleDetailDrawer.tsx
@@ -153,6 +153,39 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
                 <span className="font-mono-nums text-base text-[var(--accent-numeric)]">{potentialIncome}</span>
                 <span className="font-display italic text-xs text-muted-foreground">mesos</span>
               </div>
+              <div className="mt-2">
+                <button
+                  type="button"
+                  data-testid="active-toggle"
+                  aria-pressed={mule.active}
+                  onClick={() => onUpdate(mule.id, { active: !mule.active })}
+                  className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-sans uppercase tracking-[0.18em] transition-colors"
+                  style={{
+                    background: 'var(--surface-2)',
+                    border: `1px solid ${mule.active ? 'var(--accent-soft, var(--border))' : 'var(--border)'}`,
+                    color: mule.active
+                      ? 'var(--accent-raw, var(--accent))'
+                      : 'var(--muted-foreground)',
+                    minWidth: 96,
+                    justifyContent: 'center',
+                  }}
+                >
+                  {mule.active && (
+                    <span
+                      data-active-dot
+                      aria-hidden
+                      style={{
+                        display: 'inline-block',
+                        width: 8,
+                        height: 8,
+                        borderRadius: '50%',
+                        background: 'var(--accent-raw, var(--accent))',
+                      }}
+                    />
+                  )}
+                  <span>{mule.active ? 'Active' : 'Inactive'}</span>
+                </button>
+              </div>
             </div>
 
             {confirmDelete ? (

--- a/src/components/__tests__/MuleDetailDrawer.test.tsx
+++ b/src/components/__tests__/MuleDetailDrawer.test.tsx
@@ -690,4 +690,97 @@ describe('MuleDetailDrawer', () => {
       ).toBe(true)
     })
   })
+
+  describe('Active Toggle pill', () => {
+    function getToggle() {
+      return screen.getByTestId('active-toggle')
+    }
+
+    it('renders the Active Toggle after the weekly-mesos pill in DOM order', () => {
+      renderDrawer({ mule: { ...baseMule, active: true } })
+      // The weekly-mesos pill is the div with --surface-2 background that
+      // contains the "Weekly" uppercase label.
+      const weeklyLabel = screen
+        .getAllByText('Weekly')
+        .find((el) => el.className.includes('uppercase')) as HTMLElement
+      const weeklyPill = weeklyLabel.closest('div') as HTMLElement
+      const toggle = getToggle()
+      expect(weeklyPill).toBeTruthy()
+      expect(toggle).toBeTruthy()
+      const position = weeklyPill.compareDocumentPosition(toggle)
+      expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+
+    it('renders "Active" with a dot when mule.active is true', () => {
+      renderDrawer({ mule: { ...baseMule, active: true } })
+      const toggle = getToggle()
+      expect(toggle.textContent).toContain('Active')
+      expect(toggle.textContent).not.toContain('Inactive')
+      expect(toggle.querySelector('[data-active-dot]')).toBeTruthy()
+    })
+
+    it('renders "Inactive" with no dot when mule.active is false', () => {
+      renderDrawer({ mule: { ...baseMule, active: false } })
+      const toggle = getToggle()
+      expect(toggle.textContent).toContain('Inactive')
+      expect(toggle.querySelector('[data-active-dot]')).toBeNull()
+    })
+
+    it('clicking the toggle calls onUpdate with { active: !current }', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({ mule: { ...baseMule, active: true }, onUpdate })
+      fireEvent.click(getToggle())
+      expect(onUpdate).toHaveBeenCalledWith('test-mule-1', { active: false })
+    })
+
+    it('clicking twice calls onUpdate with both states (sanity check)', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({ mule: { ...baseMule, active: false }, onUpdate })
+      fireEvent.click(getToggle())
+      expect(onUpdate).toHaveBeenLastCalledWith('test-mule-1', { active: true })
+      fireEvent.click(getToggle())
+      // mule.active is still false (parent hasn't re-rendered with updated prop),
+      // so the second click also flips from false → true.
+      expect(onUpdate).toHaveBeenCalledTimes(2)
+      expect(onUpdate.mock.calls[1][1]).toEqual({ active: true })
+    })
+
+    it('has aria-pressed reflecting current state', () => {
+      const { rerender } = renderDrawer({ mule: { ...baseMule, active: true } })
+      expect(getToggle().getAttribute('aria-pressed')).toBe('true')
+      rerender(
+        <MuleDetailDrawer
+          mule={{ ...baseMule, active: false }}
+          open={true}
+          onClose={vi.fn()}
+          onUpdate={vi.fn()}
+          onDelete={vi.fn()}
+        />,
+      )
+      expect(getToggle().getAttribute('aria-pressed')).toBe('false')
+    })
+
+    it('is a real <button type="button">', () => {
+      renderDrawer({ mule: { ...baseMule, active: true } })
+      const toggle = getToggle()
+      expect(toggle.tagName).toBe('BUTTON')
+      expect(toggle.getAttribute('type')).toBe('button')
+    })
+  })
+
+  describe('Weekly-mesos pill regression', () => {
+    it('renders the weekly-mesos pill in accent color even when mule.active is false', () => {
+      renderDrawer({
+        mule: { ...baseMule, active: false, selectedBosses: [HARD_LUCID] },
+      })
+      // KPI pill's income span uses var(--accent-numeric). It must stay in
+      // accent regardless of active flag — the drawer is the editor and
+      // needs legibility (decision #6).
+      const kpi = document.querySelector(
+        '.font-mono-nums.text-base.text-\\[var\\(--accent-numeric\\)\\]',
+      )
+      expect(kpi).toBeTruthy()
+      expect(kpi?.textContent).toBe('504M')
+    })
+  })
 })

--- a/src/hooks/__tests__/useMules.test.ts
+++ b/src/hooks/__tests__/useMules.test.ts
@@ -508,12 +508,12 @@ describe('useMules', () => {
       expect(result.current.mules[0].selectedBosses).toEqual([])
     })
 
-    it('defaults active to true (Slice 1; flipped to false in Slice 3)', () => {
+    it('defaults active to false (Slice 3: new mules are inactive until toggled)', () => {
       const { result } = renderHook(() => useMules())
       act(() => {
         result.current.addMule()
       })
-      expect(result.current.mules[0].active).toBe(true)
+      expect(result.current.mules[0].active).toBe(false)
     })
   })
 

--- a/src/hooks/useMules.ts
+++ b/src/hooks/useMules.ts
@@ -171,9 +171,10 @@ export function useMules() {
       muleClass: '',
       selectedBosses: [],
       partySizes: {},
-      // Slice 1: new mules land as active so KPI and income match today's
-      // behaviour. Slice 3 flips this to `false` when the drawer toggle ships.
-      active: true,
+      // Slice 3: new mules land inactive so brand-new cards match the design's
+      // dim empty-slot treatment. The user flips the Active Toggle in the
+      // drawer to opt in to KPI + weekly-income contribution.
+      active: false,
     };
     setMules((prev) => [newMule, ...prev]);
     return newMule.id;


### PR DESCRIPTION
## Summary

- Adds the Active Toggle pill to the drawer's Identity Section on its own row below the weekly-mesos pill.
- Flips `addMule` default from `active: true` to `active: false` — new mules land as Inactive Mules, matching the design's dim empty-slot treatment.
- Toggle renders `[ dot Active ]` in accent color when active, and `[Inactive]` in muted color when inactive. `min-width: 96` keeps the pill width stable across toggles.
- Drawer's weekly-mesos pill stays in accent color regardless of active state (decision #6: the drawer is the editor and must stay legible).

Together with Slice 1 (active field + KPI/income gating) and Slice 2 (card dim), this completes the feature: declare a Mule inactive, the card dims, the KPI and Total Weekly Income update, and new mules appear dim on creation.

## Test plan

- [x] New unit tests cover: render order after weekly-mesos pill, Active/Inactive labels + dot visibility, click fires `onUpdate({ active: !current })`, `aria-pressed` mirrors state, real `<button type="button">`, and regression that the weekly-mesos pill stays accent for inactive mules.
- [x] Updated `useMules` test to assert `addMule` now defaults `active: false`.
- [x] `npm test` on drawer + hooks tests all green (101/101). Full suite: 473 pre-existing pass; 5 pre-existing failures on `MuleCharacterCard` and `App` DnD tests are unrelated to this slice and were present on main before this change.
- [ ] Manual QA per the issue's 8-step checklist (add mule → opens dim, toggle flips to Active with dot + card un-dims, KPI ACTIVE count and Total Weekly Income track the toggle, etc.).

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)