### PR TITLE
feat: deleteMules(ids) batch API on useMules

### DIFF
--- a/src/hooks/__tests__/useMules.test.ts
+++ b/src/hooks/__tests__/useMules.test.ts
@@ -661,6 +661,78 @@ describe('useMules', () => {
     })
   })
 
+  describe('deleteMules (batch)', () => {
+    const seed = (ids: string[]) => {
+      const payload = {
+        schemaVersion: 4,
+        mules: ids.map((id) => ({
+          id,
+          name: id.toUpperCase(),
+          level: 200,
+          muleClass: 'Hero',
+          selectedBosses: [],
+          partySizes: {},
+          active: true,
+        })),
+      }
+      localStorageStore['maplestory-mule-tracker'] = JSON.stringify(payload)
+    }
+
+    it('deletes N mules in a single state update', () => {
+      seed(['a', 'b', 'c', 'd'])
+      const { result } = renderHook(() => useMules())
+      const before = result.current.mules
+      act(() => {
+        result.current.deleteMules(['a', 'b', 'c'])
+      })
+      expect(result.current.mules.map((m) => m.id)).toEqual(['d'])
+      // Single pass: the array reference must have changed exactly once (not
+      // three filter round-trips through setState).
+      expect(result.current.mules).not.toBe(before)
+    })
+
+    it('is a no-op on an empty ids array (same array reference)', () => {
+      seed(['a', 'b'])
+      const { result } = renderHook(() => useMules())
+      const before = result.current.mules
+      act(() => {
+        result.current.deleteMules([])
+      })
+      // No state change — array reference is preserved.
+      expect(result.current.mules).toBe(before)
+      expect(result.current.mules.map((m) => m.id)).toEqual(['a', 'b'])
+    })
+
+    it('is a no-op when every id is unknown', () => {
+      seed(['a', 'b'])
+      const { result } = renderHook(() => useMules())
+      act(() => {
+        result.current.deleteMules(['x', 'y', 'z'])
+      })
+      expect(result.current.mules.map((m) => m.id)).toEqual(['a', 'b'])
+    })
+
+    it('removes only the known ids when the list mixes known + unknown', () => {
+      seed(['a', 'b', 'c'])
+      const { result } = renderHook(() => useMules())
+      act(() => {
+        result.current.deleteMules(['a', 'unknown', 'c'])
+      })
+      expect(result.current.mules.map((m) => m.id)).toEqual(['b'])
+    })
+
+    it('persists the remaining mules to localStorage after debounce flush', () => {
+      seed(['a', 'b', 'c'])
+      const { result } = renderHook(() => useMules())
+      act(() => {
+        result.current.deleteMules(['a', 'c'])
+      })
+      flushPersist()
+      const saved = JSON.parse(localStorageStore['maplestory-mule-tracker'])
+      expect(saved.mules.map((m: { id: string }) => m.id)).toEqual(['b'])
+    })
+  })
+
   describe('reorderMules', () => {
     it('reorders mules', () => {
       const payload = {
@@ -864,11 +936,11 @@ describe('useMules', () => {
   })
 
   describe('outward API unchanged', () => {
-    it('returns { mules, addMule, updateMule, deleteMule, reorderMules }', () => {
+    it('returns { mules, addMule, updateMule, deleteMule, deleteMules, reorderMules }', () => {
       const { result } = renderHook(() => useMules())
       const keys = Object.keys(result.current).sort()
       expect(keys).toEqual(
-        ['addMule', 'deleteMule', 'mules', 'reorderMules', 'updateMule'],
+        ['addMule', 'deleteMule', 'deleteMules', 'mules', 'reorderMules', 'updateMule'],
       )
     })
 

--- a/src/hooks/useMules.ts
+++ b/src/hooks/useMules.ts
@@ -243,9 +243,25 @@ export function useMules() {
     setMules((prev) => prev.filter((m) => m.id !== id));
   }, []);
 
+  /**
+   * Batch delete. Removes every mule whose id is in `ids` in a single
+   * `setMules` pass so React re-renders once and the debounced persistence
+   * pipeline schedules one write (not N). Unknown ids are silently ignored
+   * and an empty `ids` array is a no-op — we preserve the prior array
+   * reference so downstream `useMemo`/`useEffect` consumers don't re-run.
+   */
+  const deleteMules = useCallback((ids: string[]) => {
+    if (ids.length === 0) return;
+    const idSet = new Set(ids);
+    setMules((prev) => {
+      const next = prev.filter((m) => !idSet.has(m.id));
+      return next.length === prev.length ? prev : next;
+    });
+  }, []);
+
   const reorderMules = useCallback((oldIndex: number, newIndex: number) => {
     setMules((prev) => arrayMove(prev, oldIndex, newIndex));
   }, []);
 
-  return { mules, addMule, updateMule, deleteMule, reorderMules };
+  return { mules, addMule, updateMule, deleteMule, deleteMules, reorderMules };
 }


### PR DESCRIPTION
## Summary
- Adds `deleteMules(ids: string[])` alongside `deleteMule(id)` on the `useMules` hook. Uses a `Set` for O(1) id lookup and a single `setMules` pass so React re-renders once and the 200ms debounced localStorage pipeline schedules one persist (not N).
- Empty `ids` array and all-unknown-ids are no-ops that preserve the prior array reference, so downstream `useMemo`/`useEffect` consumers don't re-run on a zero-change "delete".
- Pure data-layer primitive — no UI consumers land in this slice; slice 2 will call it from the Bulk Action Bar's Bulk Confirm.

## Test plan
- [x] `npm test -- useMules` — all 47 green (5 new tests: N-in-one-pass, empty-is-noop, unknown-is-noop, mixed known+unknown, persists after debounce flush)
- [x] `deleteMule(id)` regression test stays green
- [x] Outward-API surface test updated to include `deleteMules`
- [x] TS clean for `src/hooks/useMules.ts`

## Notes
- `npm run build` surfaces pre-existing TS errors in `IncomePieChart.test.tsx`, `MuleDetailDrawer.test.tsx`, and `RosterCardHeightParity.test.tsx` (seed fixtures omit the required `active: boolean` field introduced by #149). Those are unrelated to this slice and already red on `main`.
- The `App.test.tsx > renders weekly income section` test is also red on `main` (searches for copy "TOTAL WEEKLY INCOME" that no component renders). Not touched by this slice.

Closes #156