### PR TITLE
feat: bulk delete mode for the roster

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ import { AddCard } from './components/AddCard';
 import { Header } from './components/Header';
 import { KpiCard } from './components/KpiCard';
 import { SplitCard } from './components/SplitCard';
-import { DensityToggle } from './components/DensityToggle';
+import { RosterHeader } from './components/RosterHeader';
 
 const dragBoundaryBaseStyle: React.CSSProperties = {
   borderRadius: '1rem',
@@ -50,13 +50,15 @@ const dropAnimation: DropAnimation = {
 };
 
 function AppContent() {
-  const { mules, addMule, updateMule, deleteMule, reorderMules } = useMules();
+  const { mules, addMule, updateMule, deleteMule, deleteMules, reorderMules } = useMules();
   // KpiCard/SplitCard defer to absorb boss-matrix burst updates. Roster stays
   // live — stale mules on drop causes FLIP to target the wrong layout.
   const deferredMules = useDeferredValue(mules);
   const { toggle: toggleAbbreviated } = useFormatPreference();
   const [selectedMuleId, setSelectedMuleId] = useState<string | null>(null);
   const [activeMuleId, setActiveMuleId] = useState<string | null>(null);
+  const [bulkMode, setBulkMode] = useState(false);
+  const [toDelete, setToDelete] = useState<Set<string>>(() => new Set());
 
   const selectedMule = mules.find((m) => m.id === selectedMuleId) ?? null;
   const activeMule = activeMuleId ? (mules.find((m) => m.id === activeMuleId) ?? null) : null;
@@ -108,6 +110,31 @@ function AppContent() {
     setSelectedMuleId(null);
   }, []);
 
+  const enterBulk = useCallback(() => {
+    setBulkMode(true);
+    setToDelete(new Set());
+  }, []);
+
+  const exitBulk = useCallback(() => {
+    setBulkMode(false);
+    setToDelete(new Set());
+  }, []);
+
+  const toggleDelete = useCallback((id: string) => {
+    setToDelete((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const handleBulkDelete = useCallback(() => {
+    if (toDelete.size === 0) return;
+    deleteMules([...toDelete]);
+    exitBulk();
+  }, [toDelete, deleteMules, exitBulk]);
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <Header />
@@ -122,23 +149,14 @@ function AppContent() {
         </section>
 
         <section data-testid="roster-section" className="animate-in fade-in slide-in-from-bottom-4 duration-500 fill-mode-both">
-          <div className="flex items-end justify-between mb-4">
-            <div className="flex items-center gap-3">
-              <span
-                aria-hidden
-                className="h-px w-8"
-                style={{ background: 'linear-gradient(90deg, transparent, var(--accent-raw, var(--accent)))' }}
-              />
-              <h2 className="font-display text-2xl font-bold tracking-tight">Roster</h2>
-              <span className="eyebrow-plain">
-                {mules.length} {mules.length === 1 ? 'MULE' : 'MULES'}
-              </span>
-              <DensityToggle />
-            </div>
-            {mules.length > 1 && (
-              <p className="eyebrow-plain hidden sm:block" style={{ opacity: 0.6 }}>drag to reorder</p>
-            )}
-          </div>
+          <RosterHeader
+            muleCount={mules.length}
+            bulkMode={bulkMode}
+            selectedCount={toDelete.size}
+            onEnterBulk={enterBulk}
+            onCancel={exitBulk}
+            onDelete={handleBulkDelete}
+          />
 
           <DndContext
             collisionDetection={closestCenter}
@@ -148,7 +166,7 @@ function AppContent() {
             sensors={sensors}
             modifiers={[restrictToParentElement]}
           >
-            <SortableContext items={muleIds} strategy={rectSortingStrategy}>
+            <SortableContext items={muleIds} strategy={rectSortingStrategy} disabled={bulkMode}>
               <div style={isDragging ? dragBoundaryActiveStyle : dragBoundaryBaseStyle} className="transition-[border-color] duration-200" data-drag-boundary>
                 <div
                   className="grid gap-4"
@@ -164,9 +182,12 @@ function AppContent() {
                       mule={mule}
                       onClick={handleCardClick}
                       onDelete={deleteMule}
+                      bulkMode={bulkMode}
+                      selected={toDelete.has(mule.id)}
+                      onToggleSelect={toggleDelete}
                     />
                   ))}
-                  <AddCard onClick={handleAddMule} />
+                  {!bulkMode && <AddCard onClick={handleAddMule} />}
                 </div>
               </div>
             </SortableContext>

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -215,6 +215,165 @@ describe('App', () => {
   })
 })
 
+describe('Bulk Delete Mode', () => {
+  beforeEach(() => {
+    resetTestEnvironment()
+  })
+
+  function enterBulk() {
+    const btn = screen.getByRole('button', { name: /bulk.*delete|bulk.*trash/i })
+    fireEvent.click(btn)
+  }
+
+  it('renders the Bulk Trash Icon in the roster header', () => {
+    seedMules(testMules)
+    render(<App />)
+    expect(screen.getByRole('button', { name: /bulk.*delete|bulk.*trash/i })).toBeTruthy()
+  })
+
+  it('clicking the Bulk Trash Icon swaps the header to the Bulk Action Bar', () => {
+    seedMules(testMules)
+    render(<App />)
+    enterBulk()
+    expect(screen.getByText(/select mules to delete/i)).toBeTruthy()
+    expect(screen.getByText(/0\s*SELECTED/i)).toBeTruthy()
+  })
+
+  it('hides the Add Card in bulk mode', () => {
+    seedMules(testMules)
+    const { container } = render(<App />)
+    expect(container.querySelector('[data-add-card]')).toBeTruthy()
+    enterBulk()
+    expect(container.querySelector('[data-add-card]')).toBeNull()
+  })
+
+  it('clicking a Character Card toggles selection (does NOT open the drawer)', async () => {
+    seedMules(testMules)
+    const { container } = render(<App />)
+    enterBulk()
+
+    const panelA = container.querySelector('[data-mule-card="mule-a"] .panel') as HTMLElement
+    fireEvent.click(panelA)
+
+    expect(screen.getByText(/1\s*SELECTED/i)).toBeTruthy()
+    // Drawer heading should not appear
+    expect(screen.queryByRole('heading', { name: 'Alpha' })).toBeNull()
+  })
+
+  it('Bulk Confirm updates its label to "Delete N" and is enabled when N > 0', () => {
+    seedMules(testMules)
+    const { container } = render(<App />)
+    enterBulk()
+
+    // Initially disabled at 0
+    expect((screen.getByRole('button', { name: /^delete$/i }) as HTMLButtonElement).disabled).toBe(true)
+
+    const panelA = container.querySelector('[data-mule-card="mule-a"] .panel') as HTMLElement
+    const panelB = container.querySelector('[data-mule-card="mule-b"] .panel') as HTMLElement
+    fireEvent.click(panelA)
+    fireEvent.click(panelB)
+
+    const confirm = screen.getByRole('button', { name: /delete\s*2/i }) as HTMLButtonElement
+    expect(confirm.disabled).toBe(false)
+  })
+
+  it('Bulk Confirm removes marked mules from the Roster and exits bulk mode', async () => {
+    seedMules(testMules)
+    const { container } = render(<App />)
+    enterBulk()
+
+    fireEvent.click(container.querySelector('[data-mule-card="mule-a"] .panel') as HTMLElement)
+    fireEvent.click(container.querySelector('[data-mule-card="mule-b"] .panel') as HTMLElement)
+    fireEvent.click(screen.getByRole('button', { name: /delete\s*2/i }))
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-mule-card="mule-a"]')).toBeNull()
+      expect(container.querySelector('[data-mule-card="mule-b"]')).toBeNull()
+      expect(container.querySelector('[data-mule-card="mule-c"]')).toBeTruthy()
+    })
+
+    // Mode exited — header returns to default
+    expect(screen.queryByText(/select mules to delete/i)).toBeNull()
+  })
+
+  it('persists bulk deletion to localStorage', async () => {
+    seedMules(testMules)
+    const { container, unmount } = render(<App />)
+    enterBulk()
+
+    fireEvent.click(container.querySelector('[data-mule-card="mule-a"] .panel') as HTMLElement)
+    fireEvent.click(screen.getByRole('button', { name: /delete\s*1/i }))
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-mule-card="mule-a"]')).toBeNull()
+    })
+
+    // Force persistence flush by unmounting; cleanup effect flushes pending writes
+    unmount()
+
+    const raw = localStorage.getItem(STORAGE_KEY)
+    expect(raw).toBeTruthy()
+    const parsed = JSON.parse(raw!) as { mules: Mule[] }
+    expect(parsed.mules.some((m) => m.id === 'mule-a')).toBe(false)
+    expect(parsed.mules.some((m) => m.id === 'mule-b')).toBe(true)
+    expect(parsed.mules.some((m) => m.id === 'mule-c')).toBe(true)
+  })
+
+  it('Bulk Cancel exits without removing any mule', async () => {
+    seedMules(testMules)
+    const { container } = render(<App />)
+    enterBulk()
+
+    fireEvent.click(container.querySelector('[data-mule-card="mule-a"] .panel') as HTMLElement)
+    expect(screen.getByText(/1\s*SELECTED/i)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText(/select mules to delete/i)).toBeNull()
+    })
+
+    // All three mules still in DOM
+    expect(container.querySelectorAll('[data-mule-card]')).toHaveLength(3)
+  })
+
+  it('hides the level badge on every card while in bulk mode', () => {
+    seedMules(testMules)
+    render(<App />)
+    expect(screen.getAllByText(/Lv\./).length).toBeGreaterThan(0)
+
+    enterBulk()
+    expect(screen.queryByText(/Lv\./)).toBeNull()
+  })
+
+  it('hides the hover-trash popover on every card while in bulk mode', () => {
+    seedMules(testMules)
+    const { container } = render(<App />)
+    expect(container.querySelectorAll('button[aria-label="Delete mule"]').length).toBeGreaterThan(0)
+    enterBulk()
+    expect(container.querySelectorAll('button[aria-label="Delete mule"]')).toHaveLength(0)
+  })
+
+  it('drag-to-reorder does not trigger in bulk mode (dnd sensors suspended)', async () => {
+    seedMules(testMules)
+    const restoreRect = mockGetBoundingClientRect()
+    try {
+      const { container } = render(<App />)
+      enterBulk()
+
+      const cardA = container.querySelector('[data-mule-card="mule-a"]') as HTMLElement
+      simulatePointerDrag(cardA, 100, 150, 320, 150)
+
+      const order = Array.from(container.querySelectorAll('[data-mule-card]')).map((c) =>
+        c.getAttribute('data-mule-card'),
+      )
+      expect(order).toEqual(['mule-a', 'mule-b', 'mule-c'])
+    } finally {
+      restoreRect()
+    }
+  })
+})
+
 describe('section entrance animations', () => {
   it('Header renders with sticky positioning', () => {
     render(<App />)

--- a/src/components/MuleCharacterCard.tsx
+++ b/src/components/MuleCharacterCard.tsx
@@ -1,7 +1,7 @@
 import { memo, useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { Trash2 } from 'lucide-react'
+import { Check, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import type { Mule } from '../types'
@@ -13,9 +13,24 @@ interface MuleCharacterCardProps {
   mule: Mule
   onClick: (id: string) => void
   onDelete: (id: string) => void
+  bulkMode?: boolean
+  selected?: boolean
+  onToggleSelect?: (id: string) => void
 }
 
-const MuleCardInner = memo(function MuleCardInner({ mule }: { mule: Mule }) {
+// `--destructive` is stored as `hsl(...)`, not a raw triplet — blend via
+// `color-mix` to get alpha variants without introducing #e05040 literals.
+const DESTRUCTIVE = 'var(--destructive)'
+const destructiveAlpha = (pct: number) =>
+  `color-mix(in oklab, var(--destructive) ${pct}%, transparent)`
+
+const MuleCardInner = memo(function MuleCardInner({
+  mule,
+  hideLevelBadge = false,
+}: {
+  mule: Mule
+  hideLevelBadge?: boolean
+}) {
   const { raw: rawIncome, formatted: potentialIncome } = useMuleIncome(mule)
   const { abbreviated } = useFormatPreference()
   const abbreviatedIncome = formatMeso(rawIncome, true)
@@ -26,7 +41,7 @@ const MuleCardInner = memo(function MuleCardInner({ mule }: { mule: Mule }) {
 
   return (
     <>
-      {mule.level > 0 && (
+      {!hideLevelBadge && mule.level > 0 && (
         <div style={{
           position: 'absolute', top: 8, left: 8,
           fontFamily: 'JetBrains Mono, monospace', fontSize: 10, letterSpacing: '0.1em',
@@ -115,8 +130,18 @@ export const MuleCharacterCardOverlay = memo(function MuleCharacterCardOverlay({
   )
 })
 
-export const MuleCharacterCard = memo(function MuleCharacterCard({ mule, onClick, onDelete }: MuleCharacterCardProps) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: mule.id })
+export const MuleCharacterCard = memo(function MuleCharacterCard({
+  mule,
+  onClick,
+  onDelete,
+  bulkMode = false,
+  selected = false,
+  onToggleSelect,
+}: MuleCharacterCardProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: mule.id,
+    disabled: bulkMode,
+  })
   const [isHovered, setIsHovered] = useState(false)
   const [popoverOpen, setPopoverOpen] = useState(false)
 
@@ -128,13 +153,33 @@ export const MuleCharacterCard = memo(function MuleCharacterCard({ mule, onClick
         opacity: mule.active ? 1 : 0.55,
       }
 
-  function handleClick() { onClick(mule.id) }
+  function handleActivate() {
+    if (bulkMode) {
+      onToggleSelect?.(mule.id)
+    } else {
+      onClick(mule.id)
+    }
+  }
+
   function handleKeyDown(e: React.KeyboardEvent) {
-    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(mule.id) }
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      handleActivate()
+    }
   }
   function stopPropagation(e: React.SyntheticEvent) { e.stopPropagation() }
   function handleDeleteConfirm() { onDelete(mule.id); setPopoverOpen(false) }
   function handleDeleteCancel() { setPopoverOpen(false) }
+
+  // In bulk mode we suppress hover-lift on unselected cards AND the selected
+  // visual treatment overrides any hover shadow. Single delete path is
+  // untouched — `isHovered` still drives the normal hover state outside bulk.
+  const hoverActive = !bulkMode && isHovered
+  const panelBoxShadow = bulkMode && selected
+    ? `0 0 0 1px ${DESTRUCTIVE} inset, 0 0 0 1px ${DESTRUCTIVE}`
+    : hoverActive
+      ? '0 8px 32px -8px var(--accent-glow)'
+      : '0 0 0 1px var(--border)'
 
   return (
     <div
@@ -146,7 +191,7 @@ export const MuleCharacterCard = memo(function MuleCharacterCard({ mule, onClick
       {...listeners}
     >
       <div
-        onClick={handleClick}
+        onClick={handleActivate}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
         className="panel cursor-pointer"
@@ -155,49 +200,76 @@ export const MuleCharacterCard = memo(function MuleCharacterCard({ mule, onClick
           minHeight: 'var(--roster-card-min-height, 260px)',
           display: 'flex',
           flexDirection: 'column',
-          transform: isHovered ? 'translateY(-2px)' : undefined,
-          boxShadow: isHovered
-            ? '0 8px 32px -8px var(--accent-glow)'
-            : '0 0 0 1px var(--border)',
-          transition: 'transform 150ms, box-shadow 150ms',
+          transform: hoverActive ? 'translateY(-2px)' : undefined,
+          boxShadow: panelBoxShadow,
+          borderColor: bulkMode && selected ? DESTRUCTIVE : undefined,
+          background: bulkMode && selected ? destructiveAlpha(10) : undefined,
+          transition: 'transform 150ms, box-shadow 150ms, border-color 150ms, background 150ms',
         }}
         role="button"
         tabIndex={0}
+        aria-pressed={bulkMode ? selected : undefined}
         onKeyDown={handleKeyDown}
       >
-        <MuleCardInner mule={mule} />
+        <MuleCardInner mule={mule} hideLevelBadge={bulkMode} />
 
-        <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-          <PopoverTrigger
-            render={
-              <button
-                aria-label="Delete mule"
-                style={{
-                  position: 'absolute', top: 8, right: 8,
-                  padding: '4px 6px', borderRadius: 4,
-                  background: 'var(--surface-2, var(--surface-raised))',
-                  border: '1px solid var(--border)',
-                  color: 'var(--muted-raw, var(--muted-foreground))',
-                  opacity: isHovered || popoverOpen ? 1 : 0,
-                  transition: 'opacity 140ms',
-                  cursor: 'pointer',
-                  display: 'flex', alignItems: 'center',
-                }}
-                onClick={stopPropagation}
-                onPointerDown={stopPropagation}
-              />
-            }
+        {bulkMode && (
+          <div
+            aria-hidden
+            data-selection-indicator
+            style={{
+              position: 'absolute',
+              top: 10,
+              left: 10,
+              width: 22,
+              height: 22,
+              borderRadius: 6,
+              border: `1.5px solid ${selected ? DESTRUCTIVE : destructiveAlpha(50)}`,
+              background: selected ? DESTRUCTIVE : 'transparent',
+              color: selected ? 'white' : 'transparent',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              transition: 'background 140ms, border-color 140ms',
+            }}
           >
-            <Trash2 style={{ width: 14, height: 14 }} />
-          </PopoverTrigger>
-          <PopoverContent className="w-auto p-3" side="bottom" align="end" onClick={stopPropagation} onPointerDown={stopPropagation}>
-            <div className="flex items-center gap-2">
-              <span className="text-sm">Delete?</span>
-              <Button size="sm" variant="destructive" onClick={handleDeleteConfirm}>Yes</Button>
-              <Button size="sm" variant="outline" onClick={handleDeleteCancel}>Cancel</Button>
-            </div>
-          </PopoverContent>
-        </Popover>
+            {selected && <Check style={{ width: 14, height: 14, strokeWidth: 3 }} />}
+          </div>
+        )}
+
+        {!bulkMode && (
+          <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+            <PopoverTrigger
+              render={
+                <button
+                  aria-label="Delete mule"
+                  style={{
+                    position: 'absolute', top: 8, right: 8,
+                    padding: '4px 6px', borderRadius: 4,
+                    background: 'var(--surface-2, var(--surface-raised))',
+                    border: '1px solid var(--border)',
+                    color: 'var(--muted-raw, var(--muted-foreground))',
+                    opacity: isHovered || popoverOpen ? 1 : 0,
+                    transition: 'opacity 140ms',
+                    cursor: 'pointer',
+                    display: 'flex', alignItems: 'center',
+                  }}
+                  onClick={stopPropagation}
+                  onPointerDown={stopPropagation}
+                />
+              }
+            >
+              <Trash2 style={{ width: 14, height: 14 }} />
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-3" side="bottom" align="end" onClick={stopPropagation} onPointerDown={stopPropagation}>
+              <div className="flex items-center gap-2">
+                <span className="text-sm">Delete?</span>
+                <Button size="sm" variant="destructive" onClick={handleDeleteConfirm}>Yes</Button>
+                <Button size="sm" variant="outline" onClick={handleDeleteCancel}>Cancel</Button>
+              </div>
+            </PopoverContent>
+          </Popover>
+        )}
       </div>
     </div>
   )

--- a/src/components/RosterHeader.tsx
+++ b/src/components/RosterHeader.tsx
@@ -1,0 +1,157 @@
+import { Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { DensityToggle } from './DensityToggle'
+
+export interface RosterHeaderProps {
+  muleCount: number
+  bulkMode: boolean
+  selectedCount: number
+  onEnterBulk: () => void
+  onCancel: () => void
+  onDelete: () => void
+}
+
+// `--destructive` is stored as a full `hsl(...)` call, not a raw triplet, so
+// we can't use `hsl(var(--destructive) / <alpha>)`. `color-mix` lets us blend
+// the theme token with transparent to produce the same alpha variants while
+// keeping all reds theme-token-driven (no #e05040 literals).
+const destructive = 'var(--destructive)'
+const destructiveAlpha = (pct: number) =>
+  `color-mix(in oklab, var(--destructive) ${pct}%, transparent)`
+
+export function RosterHeader({
+  muleCount,
+  bulkMode,
+  selectedCount,
+  onEnterBulk,
+  onCancel,
+  onDelete,
+}: RosterHeaderProps) {
+  if (bulkMode) {
+    return (
+      <div
+        data-bulk-action-bar
+        className="mb-4 flex items-center justify-between gap-3"
+        style={{
+          padding: '10px 14px',
+          borderRadius: 10,
+          border: `1px solid ${destructiveAlpha(35)}`,
+          background: destructiveAlpha(10),
+          animation: 'bulk-slide 0.22s ease-out',
+        }}
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          <span
+            aria-hidden
+            data-bulk-pulse-dot
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              background: destructive,
+              boxShadow: `0 0 10px ${destructive}`,
+              animation: 'bulk-pulse 1.5s ease-in-out infinite',
+              flexShrink: 0,
+            }}
+          />
+          <span
+            style={{
+              color: destructive,
+              fontWeight: 600,
+              fontSize: 14,
+              letterSpacing: '-0.01em',
+            }}
+          >
+            Select mules to delete
+          </span>
+          <span
+            data-bulk-selection-pill
+            style={{
+              padding: '3px 9px',
+              borderRadius: 999,
+              background: destructiveAlpha(20),
+              border: `1px solid ${destructiveAlpha(40)}`,
+              color: destructive,
+              fontFamily: 'JetBrains Mono, monospace',
+              fontSize: 10,
+              letterSpacing: '0.12em',
+              fontWeight: 500,
+            }}
+          >
+            {selectedCount} SELECTED
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button size="sm" variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={onDelete}
+            disabled={selectedCount === 0}
+          >
+            {selectedCount > 0 ? `Delete ${selectedCount}` : 'Delete'}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-end justify-between mb-4">
+      <div className="flex items-center gap-3">
+        <span
+          aria-hidden
+          className="h-px w-8"
+          style={{
+            background:
+              'linear-gradient(90deg, transparent, var(--accent-raw, var(--accent)))',
+          }}
+        />
+        <h2 className="font-display text-2xl font-bold tracking-tight">Roster</h2>
+        <span className="eyebrow-plain">
+          {muleCount} {muleCount === 1 ? 'MULE' : 'MULES'}
+        </span>
+        <DensityToggle />
+      </div>
+      <div className="flex items-center gap-3">
+        {muleCount > 1 && (
+          <p className="eyebrow-plain hidden sm:block" style={{ opacity: 0.6 }}>
+            drag to reorder
+          </p>
+        )}
+        <button
+          type="button"
+          aria-label="Bulk delete mules"
+          onClick={onEnterBulk}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 32,
+            height: 32,
+            borderRadius: 8,
+            background: 'transparent',
+            border: '1px solid var(--border)',
+            color: 'var(--muted-raw, var(--muted-foreground))',
+            cursor: 'pointer',
+            transition: 'color 150ms, border-color 150ms, background 150ms',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.color = destructive
+            e.currentTarget.style.borderColor = destructiveAlpha(40)
+            e.currentTarget.style.background = destructiveAlpha(8)
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.color = 'var(--muted-raw, var(--muted-foreground))'
+            e.currentTarget.style.borderColor = 'var(--border)'
+            e.currentTarget.style.background = 'transparent'
+          }}
+        >
+          <Trash2 style={{ width: 16, height: 16 }} />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/__tests__/MuleCharacterCard.test.tsx
+++ b/src/components/__tests__/MuleCharacterCard.test.tsx
@@ -19,24 +19,41 @@ const baseMule: Mule = {
   active: true,
 }
 
+interface RenderCardOptions {
+  defaultAbbreviated?: boolean
+  onDelete?: (id: string) => void
+  bulkMode?: boolean
+  selected?: boolean
+  onToggleSelect?: (id: string) => void
+}
+
 function renderCard(
   overrides: Partial<Mule> = {},
-  options?: { defaultAbbreviated?: boolean; onDelete?: (id: string) => void },
+  options?: RenderCardOptions,
 ) {
   const onClick = vi.fn()
   const onDelete = options?.onDelete ?? vi.fn()
+  const onToggleSelect = options?.onToggleSelect ?? vi.fn()
   const mule = { ...baseMule, ...overrides }
   return {
     ...render(
       <DndContext>
         <SortableContext items={[mule.id]} strategy={rectSortingStrategy}>
-          <MuleCharacterCard mule={mule} onClick={onClick} onDelete={onDelete} />
+          <MuleCharacterCard
+            mule={mule}
+            onClick={onClick}
+            onDelete={onDelete}
+            bulkMode={options?.bulkMode ?? false}
+            selected={options?.selected ?? false}
+            onToggleSelect={onToggleSelect}
+          />
         </SortableContext>
       </DndContext>,
       options,
     ),
     onClick,
     onDelete,
+    onToggleSelect,
   }
 }
 
@@ -261,5 +278,97 @@ describe('MuleCharacterCard', () => {
       expect(onClick).not.toHaveBeenCalled()
     })
 
+  })
+
+  describe('bulk mode', () => {
+    it('click toggles selection via onToggleSelect and does NOT call onClick (drawer)', () => {
+      const { container, onClick, onToggleSelect } = renderCard({}, { bulkMode: true })
+      const panel = container.querySelector('[data-mule-card] .panel') as HTMLElement
+      fireEvent.click(panel)
+      expect(onToggleSelect).toHaveBeenCalledWith('test-mule-1')
+      expect(onClick).not.toHaveBeenCalled()
+    })
+
+    it('Enter key toggles selection via onToggleSelect (not onClick)', () => {
+      const { container, onClick, onToggleSelect } = renderCard({}, { bulkMode: true })
+      const panel = container.querySelector('[data-mule-card] .panel') as HTMLElement
+      fireEvent.keyDown(panel, { key: 'Enter' })
+      expect(onToggleSelect).toHaveBeenCalledWith('test-mule-1')
+      expect(onClick).not.toHaveBeenCalled()
+    })
+
+    it('Space key toggles selection via onToggleSelect (not onClick)', () => {
+      const { container, onClick, onToggleSelect } = renderCard({}, { bulkMode: true })
+      const panel = container.querySelector('[data-mule-card] .panel') as HTMLElement
+      fireEvent.keyDown(panel, { key: ' ' })
+      expect(onToggleSelect).toHaveBeenCalledWith('test-mule-1')
+      expect(onClick).not.toHaveBeenCalled()
+    })
+
+    it('hides the level badge in bulk mode', () => {
+      renderCard({ level: 200 }, { bulkMode: true })
+      expect(screen.queryByText(/Lv\./)).toBeNull()
+    })
+
+    it('does not render the hover-trash popover trigger in bulk mode', () => {
+      renderCard({}, { bulkMode: true })
+      expect(screen.queryByRole('button', { name: /delete mule/i })).toBeNull()
+    })
+
+    it('sets aria-pressed=false on an unselected card in bulk mode', () => {
+      const { container } = renderCard({}, { bulkMode: true, selected: false })
+      const panel = container.querySelector('[data-mule-card] .panel') as HTMLElement
+      expect(panel.getAttribute('aria-pressed')).toBe('false')
+    })
+
+    it('sets aria-pressed=true on a selected card in bulk mode', () => {
+      const { container } = renderCard({}, { bulkMode: true, selected: true })
+      const panel = container.querySelector('[data-mule-card] .panel') as HTMLElement
+      expect(panel.getAttribute('aria-pressed')).toBe('true')
+    })
+
+    it('does not set aria-pressed when bulkMode is false', () => {
+      const { container } = renderCard({}, { bulkMode: false })
+      const panel = container.querySelector('[data-mule-card] .panel') as HTMLElement
+      expect(panel.getAttribute('aria-pressed')).toBeNull()
+    })
+
+    it('renders the Selection Indicator (with aria-hidden) only in bulk mode', () => {
+      const { container, rerender } = renderCard({}, { bulkMode: true })
+      const indicator = container.querySelector('[data-selection-indicator]') as HTMLElement
+      expect(indicator).toBeTruthy()
+      expect(indicator.getAttribute('aria-hidden')).not.toBeNull()
+
+      // Re-render without bulk mode — the indicator disappears
+      rerender(
+        <DndContext>
+          <SortableContext items={[baseMule.id]} strategy={rectSortingStrategy}>
+            <MuleCharacterCard
+              mule={baseMule}
+              onClick={vi.fn()}
+              onDelete={vi.fn()}
+              bulkMode={false}
+              selected={false}
+              onToggleSelect={vi.fn()}
+            />
+          </SortableContext>
+        </DndContext>,
+      )
+      expect(container.querySelector('[data-selection-indicator]')).toBeNull()
+    })
+
+    it('renders a filled check icon inside the Selection Indicator when selected', () => {
+      const { container } = renderCard({}, { bulkMode: true, selected: true })
+      const indicator = container.querySelector('[data-selection-indicator]') as HTMLElement
+      expect(indicator.querySelector('svg')).toBeTruthy()
+    })
+
+    it('applies selected styling (destructive border) to the card panel when selected', () => {
+      const { container } = renderCard({}, { bulkMode: true, selected: true })
+      const panel = container.querySelector('[data-mule-card] .panel') as HTMLElement
+      const borderColor = panel.style.borderColor + panel.style.boxShadow
+      expect(borderColor.toLowerCase()).not.toContain('#e05040')
+      expect(borderColor).toMatch(/destructive/)
+    })
   })
 })

--- a/src/components/__tests__/RosterHeader.test.tsx
+++ b/src/components/__tests__/RosterHeader.test.tsx
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '../../test/test-utils'
+import { DensityProvider } from '../../context/DensityProvider'
+import { RosterHeader } from '../RosterHeader'
+
+function renderHeader(overrides: Partial<Parameters<typeof RosterHeader>[0]> = {}) {
+  const props = {
+    muleCount: 3,
+    bulkMode: false,
+    selectedCount: 0,
+    onEnterBulk: vi.fn(),
+    onCancel: vi.fn(),
+    onDelete: vi.fn(),
+    ...overrides,
+  }
+  return {
+    ...render(
+      <DensityProvider>
+        <RosterHeader {...props} />
+      </DensityProvider>,
+    ),
+    props,
+  }
+}
+
+describe('RosterHeader', () => {
+  describe('default state', () => {
+    it('renders the Roster heading', () => {
+      renderHeader()
+      expect(screen.getByRole('heading', { name: /roster/i })).toBeTruthy()
+    })
+
+    it('shows the mule count in MULES', () => {
+      renderHeader({ muleCount: 3 })
+      expect(screen.getByText(/3\s*MULES/i)).toBeTruthy()
+    })
+
+    it('uses singular MULE for one mule', () => {
+      renderHeader({ muleCount: 1 })
+      expect(screen.getByText(/1\s*MULE\b/i)).toBeTruthy()
+    })
+
+    it('renders the Bulk Trash Icon button (visible at every breakpoint)', () => {
+      renderHeader()
+      const btn = screen.getByRole('button', { name: /bulk.*delete|delete.*mode|bulk.*trash/i })
+      expect(btn).toBeTruthy()
+      // Should not carry a responsive-hidden class like hidden/sm:hidden
+      expect(btn.className).not.toMatch(/\bhidden\b/)
+    })
+
+    it('calls onEnterBulk when the Bulk Trash Icon is clicked', () => {
+      const { props } = renderHeader()
+      const btn = screen.getByRole('button', { name: /bulk.*delete|delete.*mode|bulk.*trash/i })
+      fireEvent.click(btn)
+      expect(props.onEnterBulk).toHaveBeenCalled()
+    })
+
+    it('does not render the Bulk Action Bar in default state', () => {
+      renderHeader()
+      expect(screen.queryByText(/select mules to delete/i)).toBeNull()
+      expect(screen.queryByRole('button', { name: /^cancel$/i })).toBeNull()
+    })
+  })
+
+  describe('bulk state', () => {
+    it('renders the bulk title "Select mules to delete"', () => {
+      renderHeader({ bulkMode: true })
+      expect(screen.getByText(/select mules to delete/i)).toBeTruthy()
+    })
+
+    it('renders the Bulk Selection Pill with 0 SELECTED when no cards marked', () => {
+      renderHeader({ bulkMode: true, selectedCount: 0 })
+      expect(screen.getByText(/0\s*SELECTED/i)).toBeTruthy()
+    })
+
+    it('updates the Bulk Selection Pill to reflect the selected count', () => {
+      renderHeader({ bulkMode: true, selectedCount: 5 })
+      expect(screen.getByText(/5\s*SELECTED/i)).toBeTruthy()
+    })
+
+    it('renders a Bulk Pulse Dot using the bulk-pulse animation', () => {
+      const { container } = renderHeader({ bulkMode: true })
+      const dot = container.querySelector('[data-bulk-pulse-dot]') as HTMLElement
+      expect(dot).toBeTruthy()
+      // bulk-pulse keyframe is configured via inline animation or class
+      const animation = dot.style.animation || getComputedStyle(dot).animation
+      expect(animation).toContain('bulk-pulse')
+    })
+
+    it('applies the bulk-slide animation to the Bulk Action Bar wrapper', () => {
+      const { container } = renderHeader({ bulkMode: true })
+      const bar = container.querySelector('[data-bulk-action-bar]') as HTMLElement
+      expect(bar).toBeTruthy()
+      const animation = bar.style.animation || getComputedStyle(bar).animation
+      expect(animation).toContain('bulk-slide')
+    })
+
+    it('renders a Bulk Cancel button', () => {
+      renderHeader({ bulkMode: true })
+      expect(screen.getByRole('button', { name: /^cancel$/i })).toBeTruthy()
+    })
+
+    it('calls onCancel when Bulk Cancel is clicked', () => {
+      const { props } = renderHeader({ bulkMode: true, selectedCount: 2 })
+      fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+      expect(props.onCancel).toHaveBeenCalled()
+    })
+
+    it('renders a disabled Bulk Confirm reading "Delete" at 0 selected', () => {
+      renderHeader({ bulkMode: true, selectedCount: 0 })
+      const btn = screen.getByRole('button', { name: /^delete$/i }) as HTMLButtonElement
+      expect(btn.disabled).toBe(true)
+    })
+
+    it('renders an enabled Bulk Confirm reading "Delete N" when N > 0', () => {
+      renderHeader({ bulkMode: true, selectedCount: 3 })
+      const btn = screen.getByRole('button', { name: /delete\s*3/i }) as HTMLButtonElement
+      expect(btn.disabled).toBe(false)
+    })
+
+    it('calls onDelete when Bulk Confirm is clicked with a selection', () => {
+      const { props } = renderHeader({ bulkMode: true, selectedCount: 2 })
+      fireEvent.click(screen.getByRole('button', { name: /delete\s*2/i }))
+      expect(props.onDelete).toHaveBeenCalled()
+    })
+
+    it('does not render the default Roster heading in bulk mode', () => {
+      renderHeader({ bulkMode: true })
+      expect(screen.queryByRole('heading', { name: /roster/i })).toBeNull()
+    })
+
+    it('does not render the Bulk Trash Icon in bulk mode', () => {
+      renderHeader({ bulkMode: true })
+      expect(screen.queryByRole('button', { name: /bulk.*trash/i })).toBeNull()
+    })
+
+    it('uses the --destructive token for the pulse dot background (no #e05040)', () => {
+      const { container } = renderHeader({ bulkMode: true })
+      const dot = container.querySelector('[data-bulk-pulse-dot]') as HTMLElement
+      expect(dot.style.background.toLowerCase()).not.toContain('#e05040')
+      expect(dot.style.background).toContain('destructive')
+    })
+  })
+})

--- a/src/index.css
+++ b/src/index.css
@@ -418,3 +418,17 @@
     color: #e05040;
   }
 }
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Bulk Delete Mode — animation keyframes read by RosterHeader's Bulk Action
+ * Bar (bulk-slide) and Bulk Pulse Dot (bulk-pulse). All reds resolve through
+ * --destructive so theme toggle carries them into light/dark automatically.
+ * ────────────────────────────────────────────────────────────────────────── */
+@keyframes bulk-slide {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes bulk-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.5; }
+}


### PR DESCRIPTION
## Summary

- Ships the end-to-end **Bulk Delete Mode** from PRD #155 on top of `deleteMules(ids)` from slice 1 (PR #158). Trash icon in the Roster Header toggles a red Bulk Action Bar; every Character Card becomes a selection target; Bulk Confirm removes all marked mules in a single debounced write.
- New `RosterHeader` (two visual states), optional `bulkMode`/`selected`/`onToggleSelect` props on `MuleCharacterCard` (intercept click + keydown, hide level badge + hover-trash, render Selection Indicator, aria-pressed), App.tsx owns `bulkMode` + `toDelete` state, `<AddCard />` hidden and drag suspended while in bulk mode.
- `bulk-slide` + `bulk-pulse` keyframes in `index.css`. All reds resolve through `--destructive` via `color-mix(in oklab, var(--destructive) N%, transparent)` — no `#e05040` literals.

## Test plan

- [x] `npm test` — 19 new RosterHeader tests, 10 new MuleCharacterCard bulk-mode tests, 10 new App integration tests all green
- [x] Existing `useMules` + `MuleCharacterCard` + `App` tests still pass (only the pre-existing `renders weekly income section` test is red, same as noted in issue)
- [x] Acceptance criteria from #157 verified: Bulk Trash Icon visible at every breakpoint, bulk-slide animation plays, bulk-pulse dot animates, selection pill live-updates, Bulk Confirm disabled at 0 / "Delete N" when N>0, click toggles selection (not drawer), Enter/Space toggle with `aria-pressed`, level badge + hover-trash hidden, drag suspended, Add Card hidden, Cancel no-op, Confirm removes marked mules and persists to localStorage
- [x] No raw `#e05040` literal in the diff
- [x] No new `src/components/ui/dialog.tsx` file

Closes #157