### PR TITLE
Scope user-select and touch-action to bulk-mode cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -167,7 +167,7 @@ function AppContent() {
             modifiers={[restrictToParentElement]}
           >
             <SortableContext items={muleIds} strategy={rectSortingStrategy} disabled={bulkMode}>
-              <div style={isDragging ? dragBoundaryActiveStyle : dragBoundaryBaseStyle} className="transition-[border-color] duration-200" data-drag-boundary>
+              <div style={isDragging ? dragBoundaryActiveStyle : dragBoundaryBaseStyle} className="transition-[border-color] duration-200" data-drag-boundary data-bulk-mode={bulkMode ? 'true' : 'false'}>
                 <div
                   className="grid gap-4"
                   style={{

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -372,6 +372,19 @@ describe('Bulk Delete Mode', () => {
       restoreRect()
     }
   })
+
+  it('Drag Boundary exposes data-bulk-mode reflecting Bulk Delete Mode state', () => {
+    seedMules(testMules)
+    const { container } = render(<App />)
+    const boundary = container.querySelector('[data-drag-boundary]') as HTMLElement
+    expect(boundary.getAttribute('data-bulk-mode')).toBe('false')
+
+    enterBulk()
+    expect(boundary.getAttribute('data-bulk-mode')).toBe('true')
+
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    expect(boundary.getAttribute('data-bulk-mode')).toBe('false')
+  })
 })
 
 describe('section entrance animations', () => {

--- a/src/index.css
+++ b/src/index.css
@@ -451,6 +451,20 @@
 }
 
 /* ──────────────────────────────────────────────────────────────────────────
+ * Bulk Delete Mode — scope user-select / touch-action suppression to
+ * Character Cards inside the Drag Boundary while bulk mode is active. This
+ * kills the stray text-highlight bug on press-and-drag and prevents touch
+ * drags on a bulk-mode card from scrolling the page. Foundation for the
+ * forthcoming Drag-to-Select gesture.
+ * ────────────────────────────────────────────────────────────────────────── */
+[data-drag-boundary][data-bulk-mode="true"] [data-mule-card] {
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+  touch-action: none;
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
  * Bulk Delete Mode — animation keyframes read by RosterHeader's Bulk Action
  * Bar (bulk-slide) and Bulk Pulse Dot (bulk-pulse). All reds resolve through
  * --destructive so theme toggle carries them into light/dark automatically.


### PR DESCRIPTION
## Summary
- Adds `data-bulk-mode={bulkMode ? 'true' : 'false'}` to the existing `data-drag-boundary` wrapper in `src/App.tsx`.
- Adds a scoped CSS rule in `src/index.css` that applies `user-select: none`, `-webkit-user-select: none`, `-webkit-touch-callout: none`, and `touch-action: none` to every `[data-mule-card]` inside a bulk-mode Drag Boundary.
- Adds a small attribute-presence test verifying the Drag Boundary's `data-bulk-mode` state mirrors Bulk Delete Mode transitions.

This lands the platform foundation the forthcoming Drag-to-Select gesture needs (parent PRD #160) and on its own kills the stray text-highlight bug on press-and-drag plus the accidental page-scroll on touch drags of bulk-mode cards. Outside bulk mode, text selection and native touch-scroll are untouched.

## Test plan
- [x] `npm test` — the new `data-bulk-mode` attribute test passes. One pre-existing unrelated failure (`renders weekly income section` at `src/__tests__/App.test.tsx:110`) is present on `main` and predates this change.
- [x] Acceptance criteria verified against issue:
  - [x] Drag Boundary exposes `data-bulk-mode="true"` while `bulkMode` is true, `"false"` otherwise.
  - [x] CSS rule is scoped so it only applies inside the Drag Boundary when `data-bulk-mode="true"`.
  - [x] No gesture-behaviour tests added (per issue: "no new tests required for this slice").

Closes #161