### PR TITLE
Implement iPhone Photos-style drag-to-select gesture

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import {
 } from '@dnd-kit/core';
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
 import { restrictToParentElement } from '@dnd-kit/modifiers';
-import { useState, useCallback, useDeferredValue, useMemo } from 'react';
+import { useState, useCallback, useDeferredValue, useEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
 import { ThemeProvider } from './context/ThemeProvider';
@@ -19,6 +19,7 @@ import { DensityProvider } from './context/DensityProvider';
 import { IncomeProvider } from './modules/IncomeProvider';
 import { useFormatPreference } from './modules/income-hooks';
 import { useMules } from './hooks/useMules';
+import { useBulkDragPaint } from './hooks/useBulkDragPaint';
 import { MuleCharacterCard, MuleCharacterCardOverlay } from './components/MuleCharacterCard';
 import { MuleDetailDrawer } from './components/MuleDetailDrawer';
 import { AddCard } from './components/AddCard';
@@ -129,6 +130,42 @@ function AppContent() {
     });
   }, []);
 
+  // Exact-state setter used by the drag-paint hook. Returning `prev` when
+  // the value already matches keeps React from scheduling a re-render on
+  // every move frame that brushes an already-correct card.
+  const setSelected = useCallback((id: string, shouldBeSelected: boolean) => {
+    setToDelete((prev) => {
+      if (prev.has(id) === shouldBeSelected) return prev;
+      const next = new Set(prev);
+      if (shouldBeSelected) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  }, []);
+
+  // Live refs for the drag-paint hook: mule order feeds range math, and
+  // `isSelected` drives the Original Snapshot. Routing through refs lets
+  // the hook read current values across multi-frame gestures without
+  // recreating its callbacks on every toggle.
+  const orderRef = useRef<string[]>([]);
+  useEffect(() => {
+    orderRef.current = mules.map((m) => m.id);
+  }, [mules]);
+
+  const toDeleteRef = useRef(toDelete);
+  useEffect(() => {
+    toDeleteRef.current = toDelete;
+  }, [toDelete]);
+
+  const isSelected = useCallback((id: string) => toDeleteRef.current.has(id), []);
+
+  const dragPaintHandlers = useBulkDragPaint({
+    enabled: bulkMode,
+    orderRef,
+    isSelected,
+    setSelected,
+  });
+
   const handleBulkDelete = useCallback(() => {
     if (toDelete.size === 0) return;
     deleteMules([...toDelete]);
@@ -167,7 +204,13 @@ function AppContent() {
             modifiers={[restrictToParentElement]}
           >
             <SortableContext items={muleIds} strategy={rectSortingStrategy} disabled={bulkMode}>
-              <div style={isDragging ? dragBoundaryActiveStyle : dragBoundaryBaseStyle} className="transition-[border-color] duration-200" data-drag-boundary data-bulk-mode={bulkMode ? 'true' : 'false'}>
+              <div
+                style={isDragging ? dragBoundaryActiveStyle : dragBoundaryBaseStyle}
+                className="transition-[border-color] duration-200"
+                data-drag-boundary
+                data-bulk-mode={bulkMode ? 'true' : 'false'}
+                {...dragPaintHandlers}
+              >
                 <div
                   className="grid gap-4"
                   style={{

--- a/src/__tests__/bulkDragPaint.test.tsx
+++ b/src/__tests__/bulkDragPaint.test.tsx
@@ -1,0 +1,340 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@/test/test-utils'
+import App from '../App'
+import type { Mule } from '../types'
+
+const STORAGE_KEY = 'maplestory-mule-tracker'
+
+// Seven mules give us enough runway for revert-on-backtrack and cross-start tests.
+// PRD walkthrough uses A,B,C,D,E,F,G with S=start in the middle (index 3 = D).
+const testMules: Mule[] = [
+  { id: 'mule-a', name: 'Alpha', level: 200, muleClass: 'Hero', selectedBosses: [], active: true },
+  { id: 'mule-b', name: 'Beta', level: 180, muleClass: 'Paladin', selectedBosses: [], active: true },
+  { id: 'mule-c', name: 'Gamma', level: 160, muleClass: 'Dark Knight', selectedBosses: [], active: true },
+  { id: 'mule-d', name: 'Delta', level: 170, muleClass: 'Bishop', selectedBosses: [], active: true },
+  { id: 'mule-e', name: 'Epsilon', level: 190, muleClass: 'Shadower', selectedBosses: [], active: true },
+  { id: 'mule-f', name: 'Zeta', level: 150, muleClass: 'Night Lord', selectedBosses: [], active: true },
+  { id: 'mule-g', name: 'Eta', level: 140, muleClass: 'Mercedes', selectedBosses: [], active: true },
+]
+
+function persistedRoot(mules: Mule[]) {
+  return { schemaVersion: 2, mules }
+}
+
+function seedMules(mules: Mule[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(persistedRoot(mules)))
+}
+
+function resetTestEnvironment() {
+  localStorage.clear()
+  document.documentElement.classList.remove('dark')
+}
+
+/**
+ * Hit-test mock: each card owns a 200px-wide slot at `i*220`. Any x inside
+ * a slot returns the corresponding `[data-mule-card]` element. Outside all
+ * slots returns the document body. This drives `document.elementFromPoint`
+ * during pointermove.
+ */
+function mockElementFromPoint(container: HTMLElement, mules: Mule[]) {
+  const orig = document.elementFromPoint
+  document.elementFromPoint = ((x: number) => {
+    for (let i = 0; i < mules.length; i += 1) {
+      const lo = i * 220
+      const hi = lo + 200
+      if (x >= lo && x < hi) {
+        const card = container.querySelector(
+          `[data-mule-card="${mules[i].id}"]`,
+        ) as HTMLElement | null
+        return card ?? null
+      }
+    }
+    return document.body
+  }) as typeof document.elementFromPoint
+  return () => {
+    document.elementFromPoint = orig
+  }
+}
+
+function enterBulk() {
+  fireEvent.click(screen.getByRole('button', { name: /bulk.*delete|bulk.*trash/i }))
+}
+
+function getCardWrapper(container: HTMLElement, id: string): HTMLElement {
+  return container.querySelector(`[data-mule-card="${id}"]`) as HTMLElement
+}
+
+function isCardSelected(container: HTMLElement, id: string): boolean {
+  const panel = container.querySelector(
+    `[data-mule-card="${id}"] .panel`,
+  ) as HTMLElement
+  return panel.getAttribute('aria-pressed') === 'true'
+}
+
+function centerXFor(idx: number): number {
+  return idx * 220 + 100
+}
+
+function pointerDown(el: Element, x: number, y: number) {
+  fireEvent.pointerDown(el, {
+    pointerId: 1,
+    clientX: x,
+    clientY: y,
+    button: 0,
+    isPrimary: true,
+    bubbles: true,
+  })
+}
+
+function pointerMove(el: Element | Document, x: number, y: number) {
+  fireEvent.pointerMove(el, {
+    pointerId: 1,
+    clientX: x,
+    clientY: y,
+    isPrimary: true,
+    bubbles: true,
+  })
+}
+
+function pointerUp(el: Element | Document, x: number, y: number) {
+  fireEvent.pointerUp(el, {
+    pointerId: 1,
+    clientX: x,
+    clientY: y,
+    isPrimary: true,
+    bubbles: true,
+  })
+}
+
+function pointerCancel(el: Element | Document, x: number, y: number) {
+  fireEvent.pointerCancel(el, {
+    pointerId: 1,
+    clientX: x,
+    clientY: y,
+    isPrimary: true,
+    bubbles: true,
+  })
+}
+
+describe('useBulkDragPaint (drag-to-select gesture)', () => {
+  let restoreHitTest: (() => void) | null = null
+
+  beforeEach(() => {
+    resetTestEnvironment()
+  })
+
+  afterEach(() => {
+    if (restoreHitTest) {
+      restoreHitTest()
+      restoreHitTest = null
+    }
+  })
+
+  it('zero-move single-click preserved: pointerdown → pointerup on a card toggles selection', () => {
+    seedMules(testMules)
+    const { container } = render(<App />)
+    enterBulk()
+    restoreHitTest = mockElementFromPoint(container, testMules)
+
+    const cardA = getCardWrapper(container, 'mule-a')
+    const x = centerXFor(0)
+    const y = 150
+
+    pointerDown(cardA, x, y)
+    pointerUp(cardA, x, y)
+    // Simulate the browser's synthetic trailing click (zero-move path).
+    fireEvent.click(cardA.querySelector('.panel') as HTMLElement)
+
+    expect(isCardSelected(container, 'mule-a')).toBe(true)
+    expect(isCardSelected(container, 'mule-b')).toBe(false)
+    expect(screen.getByText(/1\s*SELECTED/i)).toBeTruthy()
+  })
+
+  it('forward paint (add): drag from unmarked S across two later cards marks all three', () => {
+    seedMules(testMules)
+    const { container } = render(<App />)
+    enterBulk()
+    restoreHitTest = mockElementFromPoint(container, testMules)
+
+    const cardA = getCardWrapper(container, 'mule-a')
+    pointerDown(cardA, centerXFor(0), 150)
+    pointerMove(document, centerXFor(1), 150)
+    pointerMove(document, centerXFor(2), 150)
+    pointerUp(document, centerXFor(2), 150)
+
+    expect(isCardSelected(container, 'mule-a')).toBe(true)
+    expect(isCardSelected(container, 'mule-b')).toBe(true)
+    expect(isCardSelected(container, 'mule-c')).toBe(true)
+    expect(isCardSelected(container, 'mule-d')).toBe(false)
+    expect(isCardSelected(container, 'mule-e')).toBe(false)
+  })
+
+  it('forward paint (remove): drag from marked S across two later marked cards unmarks all three', () => {
+    seedMules(testMules)
+    const { container } = render(<App />)
+    enterBulk()
+    restoreHitTest = mockElementFromPoint(container, testMules)
+
+    // Pre-mark three cards via clicks (zero-move path).
+    fireEvent.click(container.querySelector('[data-mule-card="mule-a"] .panel') as HTMLElement)
+    fireEvent.click(container.querySelector('[data-mule-card="mule-b"] .panel') as HTMLElement)
+    fireEvent.click(container.querySelector('[data-mule-card="mule-c"] .panel') as HTMLElement)
+    expect(isCardSelected(container, 'mule-a')).toBe(true)
+    expect(isCardSelected(container, 'mule-b')).toBe(true)
+    expect(isCardSelected(container, 'mule-c')).toBe(true)
+
+    const cardA = getCardWrapper(container, 'mule-a')
+    pointerDown(cardA, centerXFor(0), 150)
+    pointerMove(document, centerXFor(1), 150)
+    pointerMove(document, centerXFor(2), 150)
+    pointerUp(document, centerXFor(2), 150)
+
+    expect(isCardSelected(container, 'mule-a')).toBe(false)
+    expect(isCardSelected(container, 'mule-b')).toBe(false)
+    expect(isCardSelected(container, 'mule-c')).toBe(false)
+  })
+
+  it('revert on backtrack: forward across E,F,G then back to S leaves only S marked', () => {
+    seedMules(testMules)
+    const { container } = render(<App />)
+    enterBulk()
+    restoreHitTest = mockElementFromPoint(container, testMules)
+
+    const cardA = getCardWrapper(container, 'mule-a')
+    pointerDown(cardA, centerXFor(0), 150)
+    // Forward across mule-b, mule-c, mule-d.
+    pointerMove(document, centerXFor(1), 150)
+    pointerMove(document, centerXFor(2), 150)
+    pointerMove(document, centerXFor(3), 150)
+    // Backtrack to S.
+    pointerMove(document, centerXFor(0), 150)
+    pointerUp(document, centerXFor(0), 150)
+
+    expect(isCardSelected(container, 'mule-a')).toBe(true)
+    expect(isCardSelected(container, 'mule-b')).toBe(false)
+    expect(isCardSelected(container, 'mule-c')).toBe(false)
+    expect(isCardSelected(container, 'mule-d')).toBe(false)
+  })
+
+  it('cross the start: start=D, forward to F, back past D to B → B,C,D marked; E,F reverted (5-card range [B..D])', () => {
+    // PRD walkthrough: roster A,B,C,D,E,F,G. Start S=D (index 3). Drag right
+    // to F (index 5): range [D..F] brushes E, F. Drag left past D to B (index
+    // 1): new range [B..D] brushes B, C; E, F revert to Original Snapshot
+    // (unmarked). Final marked set = {B, C, D}; D is still marked as start.
+    seedMules(testMules)
+    const { container } = render(<App />)
+    enterBulk()
+    restoreHitTest = mockElementFromPoint(container, testMules)
+
+    const cardD = getCardWrapper(container, 'mule-d')
+    pointerDown(cardD, centerXFor(3), 150)
+    pointerMove(document, centerXFor(4), 150) // E
+    pointerMove(document, centerXFor(5), 150) // F
+    pointerMove(document, centerXFor(2), 150) // back across start to C
+    pointerMove(document, centerXFor(1), 150) // B — range = [1, 3] = B,C,D
+    pointerUp(document, centerXFor(1), 150)
+
+    expect(isCardSelected(container, 'mule-a')).toBe(false)
+    expect(isCardSelected(container, 'mule-b')).toBe(true)
+    expect(isCardSelected(container, 'mule-c')).toBe(true)
+    expect(isCardSelected(container, 'mule-d')).toBe(true)
+    // E and F were brushed then reverted when the range crossed the start.
+    expect(isCardSelected(container, 'mule-e')).toBe(false)
+    expect(isCardSelected(container, 'mule-f')).toBe(false)
+    expect(isCardSelected(container, 'mule-g')).toBe(false)
+  })
+
+  it('preserve pre-existing selection on revert: pre-marked X entering then leaving range restores to marked', () => {
+    // Pre-mark mule-c. Drag from unmarked mule-a forward to mule-d, then back to mule-a.
+    // At pointerup, the final range is [0, 0] = just A. But mule-c was pre-marked,
+    // so reverting it should leave it marked (not unmarked).
+    seedMules(testMules)
+    const { container } = render(<App />)
+    enterBulk()
+    restoreHitTest = mockElementFromPoint(container, testMules)
+
+    // Pre-mark mule-c via single click.
+    fireEvent.click(container.querySelector('[data-mule-card="mule-c"] .panel') as HTMLElement)
+    expect(isCardSelected(container, 'mule-c')).toBe(true)
+
+    const cardA = getCardWrapper(container, 'mule-a')
+    pointerDown(cardA, centerXFor(0), 150)
+    pointerMove(document, centerXFor(1), 150) // B
+    pointerMove(document, centerXFor(2), 150) // C (already marked)
+    pointerMove(document, centerXFor(3), 150) // D
+    pointerMove(document, centerXFor(0), 150) // back to A — range = [0,0]
+    pointerUp(document, centerXFor(0), 150)
+
+    expect(isCardSelected(container, 'mule-a')).toBe(true)
+    expect(isCardSelected(container, 'mule-b')).toBe(false)
+    // Pre-existing selection restored — not reset to unmarked.
+    expect(isCardSelected(container, 'mule-c')).toBe(true)
+    expect(isCardSelected(container, 'mule-d')).toBe(false)
+  })
+
+  it('synthetic click suppression: after an engaged drag, the trailing click on Start Card does not double-toggle', () => {
+    seedMules(testMules)
+    const { container } = render(<App />)
+    enterBulk()
+    restoreHitTest = mockElementFromPoint(container, testMules)
+
+    const cardA = getCardWrapper(container, 'mule-a')
+    const panelA = cardA.querySelector('.panel') as HTMLElement
+
+    pointerDown(cardA, centerXFor(0), 150)
+    pointerMove(document, centerXFor(0) + 10, 150) // engage
+    pointerUp(document, centerXFor(0) + 10, 150)
+
+    expect(isCardSelected(container, 'mule-a')).toBe(true)
+
+    // Browser fires the trailing synthetic click AFTER pointerup. Our hook
+    // must swallow this click or the panel's onClick handler would toggle A
+    // back to unmarked.
+    fireEvent.click(panelA)
+
+    expect(isCardSelected(container, 'mule-a')).toBe(true)
+  })
+
+  it('pointerdown outside any card is a no-op; subsequent pointermove/pointerup leave state unchanged', () => {
+    seedMules(testMules)
+    const { container } = render(<App />)
+    enterBulk()
+    restoreHitTest = mockElementFromPoint(container, testMules)
+
+    const boundary = container.querySelector('[data-drag-boundary]') as HTMLElement
+    // Start pointerdown on the boundary padding (not on a card).
+    pointerDown(boundary, 2000, 150) // far past any card slot
+    pointerMove(document, centerXFor(0), 150)
+    pointerMove(document, centerXFor(1), 150)
+    pointerUp(document, centerXFor(1), 150)
+
+    expect(isCardSelected(container, 'mule-a')).toBe(false)
+    expect(isCardSelected(container, 'mule-b')).toBe(false)
+    expect(isCardSelected(container, 'mule-c')).toBe(false)
+  })
+
+  it('pointercancel mid-drag reverts every Mule to its Original Snapshot', () => {
+    seedMules(testMules)
+    const { container } = render(<App />)
+    enterBulk()
+    restoreHitTest = mockElementFromPoint(container, testMules)
+
+    // Pre-mark mule-d so we can verify it's restored (not just reset to unmarked).
+    fireEvent.click(container.querySelector('[data-mule-card="mule-d"] .panel') as HTMLElement)
+    expect(isCardSelected(container, 'mule-d')).toBe(true)
+
+    const cardA = getCardWrapper(container, 'mule-a')
+    pointerDown(cardA, centerXFor(0), 150)
+    pointerMove(document, centerXFor(1), 150) // B brushed
+    pointerMove(document, centerXFor(2), 150) // C brushed
+    pointerMove(document, centerXFor(3), 150) // D hit by brush=add → no-op but in range
+    // Mid-gesture cancel.
+    pointerCancel(document, centerXFor(3), 150)
+
+    expect(isCardSelected(container, 'mule-a')).toBe(false) // original: unmarked
+    expect(isCardSelected(container, 'mule-b')).toBe(false) // original: unmarked
+    expect(isCardSelected(container, 'mule-c')).toBe(false) // original: unmarked
+    expect(isCardSelected(container, 'mule-d')).toBe(true)  // original: marked
+    expect(isCardSelected(container, 'mule-e')).toBe(false) // never touched
+  })
+})

--- a/src/hooks/useBulkDragPaint.ts
+++ b/src/hooks/useBulkDragPaint.ts
@@ -1,0 +1,258 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * iPhone Photos-style drag-to-select gesture for Bulk Delete Mode.
+ *
+ * Owns all pointer state as refs so the drag produces zero re-renders from
+ * the hook itself. On first `pointermove` after `pointerdown`, snapshots
+ * every Mule's current selection (the Original Snapshot) and fixes the
+ * Brush polarity from the inverse of the Start Card's snapshot value. The
+ * Paint Range is recomputed on every move as
+ * `[min(startIdx, curIdx), max(startIdx, curIdx)]` in Roster order; Mules
+ * that leave the range revert to their Original Snapshot, Mules that enter
+ * adopt the Brush. Zero-move pointerup falls through to the single-click
+ * `toggle` path. `pointercancel` reverts everything. `onClickCapture`
+ * swallows the browser's trailing synthetic click after an engaged gesture
+ * so the Start Card isn't double-toggled.
+ *
+ * `pointermove` / `pointerup` / `pointercancel` are attached to `document`
+ * while a gesture is active. This mirrors pointer-capture semantics
+ * (events keep flowing even if the pointer leaves the boundary) but is
+ * portable across JSDOM and real browsers without relying on
+ * `setPointerCapture` support.
+ */
+
+type Brush = 'add' | 'remove';
+
+interface Args {
+  enabled: boolean;
+  orderRef: React.RefObject<string[]>;
+  isSelected: (id: string) => boolean;
+  setSelected: (id: string, shouldBeSelected: boolean) => void;
+}
+
+interface PaintedRange {
+  lo: number;
+  hi: number;
+}
+
+interface Handlers {
+  onPointerDown: (e: React.PointerEvent<HTMLElement>) => void;
+  onClickCapture: (e: React.MouseEvent<HTMLElement>) => void;
+}
+
+function cardIdFromTarget(target: EventTarget | null): string | null {
+  if (!(target instanceof Element)) return null;
+  const card = target.closest('[data-mule-card]');
+  if (!card) return null;
+  return card.getAttribute('data-mule-card');
+}
+
+function cardIdFromPoint(x: number, y: number): string | null {
+  // JSDOM doesn't implement `elementFromPoint` by default — guard so an
+  // unrelated bulk-mode test that fires pointer events without mocking it
+  // doesn't throw. Real browsers always provide this API.
+  if (typeof document.elementFromPoint !== 'function') return null;
+  const el = document.elementFromPoint(x, y);
+  if (!el) return null;
+  const card = el.closest('[data-mule-card]');
+  if (!card) return null;
+  return card.getAttribute('data-mule-card');
+}
+
+export function useBulkDragPaint({
+  enabled,
+  orderRef,
+  isSelected,
+  setSelected,
+}: Args): Handlers {
+  const startIdRef = useRef<string | null>(null);
+  const startIdxRef = useRef<number | null>(null);
+  const pointerIdRef = useRef<number | null>(null);
+  const brushRef = useRef<Brush | null>(null);
+  const originalRef = useRef<Map<string, boolean>>(new Map());
+  const paintedRangeRef = useRef<PaintedRange | null>(null);
+  const suppressClickRef = useRef(false);
+  // Document-level listener cleanup. Kept in a ref so pointerup/cancel can
+  // remove the same functions we added on pointerdown.
+  const detachDocListenersRef = useRef<(() => void) | null>(null);
+
+  const resetGesture = useCallback(() => {
+    startIdRef.current = null;
+    startIdxRef.current = null;
+    pointerIdRef.current = null;
+    brushRef.current = null;
+    originalRef.current = new Map();
+    paintedRangeRef.current = null;
+    if (detachDocListenersRef.current) {
+      detachDocListenersRef.current();
+      detachDocListenersRef.current = null;
+    }
+  }, []);
+
+  const revertAll = useCallback(() => {
+    const snapshot = originalRef.current;
+    snapshot.forEach((wasSelected, id) => {
+      setSelected(id, wasSelected);
+    });
+  }, [setSelected]);
+
+  const applyRangeDiff = useCallback(
+    (next: PaintedRange) => {
+      const order = orderRef.current;
+      const prev = paintedRangeRef.current;
+      const brush = brushRef.current;
+      if (brush === null) return;
+      const brushValue = brush === 'add';
+      // Cards leaving the range → revert to Original Snapshot.
+      if (prev) {
+        for (let i = prev.lo; i <= prev.hi; i += 1) {
+          if (i < next.lo || i > next.hi) {
+            const id = order[i];
+            if (id === undefined) continue;
+            const original = originalRef.current.get(id);
+            if (original === undefined) continue;
+            setSelected(id, original);
+          }
+        }
+      }
+      // Cards entering the range → adopt Brush.
+      for (let i = next.lo; i <= next.hi; i += 1) {
+        if (prev && i >= prev.lo && i <= prev.hi) continue;
+        const id = order[i];
+        if (id === undefined) continue;
+        setSelected(id, brushValue);
+      }
+      paintedRangeRef.current = next;
+    },
+    [orderRef, setSelected],
+  );
+
+  const engageAtStart = useCallback(() => {
+    const startId = startIdRef.current;
+    const startIdx = startIdxRef.current;
+    if (startId === null || startIdx === null) return;
+    const snapshot = new Map<string, boolean>();
+    for (const id of orderRef.current) {
+      snapshot.set(id, isSelected(id));
+    }
+    originalRef.current = snapshot;
+    const wasSelected = snapshot.get(startId) ?? false;
+    brushRef.current = wasSelected ? 'remove' : 'add';
+    paintedRangeRef.current = null;
+    applyRangeDiff({ lo: startIdx, hi: startIdx });
+  }, [applyRangeDiff, isSelected, orderRef]);
+
+  const handleMove = useCallback(
+    (e: PointerEvent) => {
+      if (startIdRef.current === null || startIdxRef.current === null) return;
+      if (pointerIdRef.current !== null && e.pointerId !== pointerIdRef.current) return;
+      if (brushRef.current === null) {
+        engageAtStart();
+      }
+      const curId = cardIdFromPoint(e.clientX, e.clientY);
+      if (curId === null) return;
+      const curIdx = orderRef.current.indexOf(curId);
+      if (curIdx < 0) return;
+      const startIdx = startIdxRef.current;
+      const lo = Math.min(startIdx, curIdx);
+      const hi = Math.max(startIdx, curIdx);
+      applyRangeDiff({ lo, hi });
+    },
+    [applyRangeDiff, engageAtStart, orderRef],
+  );
+
+  const handleUp = useCallback(
+    (e: PointerEvent) => {
+      if (startIdRef.current === null) return;
+      if (pointerIdRef.current !== null && e.pointerId !== pointerIdRef.current) return;
+      const engaged = brushRef.current !== null;
+      if (engaged) {
+        // Engaged gesture → suppress the trailing synthetic click so the
+        // Start Card isn't double-toggled by its panel's onClick.
+        suppressClickRef.current = true;
+      }
+      // Zero-move release is a no-op for the hook — the browser's trailing
+      // synthetic click fires through to the Character Card's existing
+      // onClick, which already calls `toggleDelete`. That preserves today's
+      // single-click behaviour without risking a double-toggle.
+      resetGesture();
+    },
+    [resetGesture],
+  );
+
+  const handleCancel = useCallback(
+    (e: PointerEvent) => {
+      if (startIdRef.current === null) {
+        resetGesture();
+        return;
+      }
+      if (pointerIdRef.current !== null && e.pointerId !== pointerIdRef.current) return;
+      if (brushRef.current !== null) {
+        revertAll();
+      }
+      resetGesture();
+    },
+    [resetGesture, revertAll],
+  );
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      if (!enabled) return;
+      const id = cardIdFromTarget(e.target);
+      if (!id) return;
+      const idx = orderRef.current.indexOf(id);
+      if (idx < 0) return;
+      startIdRef.current = id;
+      startIdxRef.current = idx;
+      pointerIdRef.current = e.pointerId;
+      brushRef.current = null;
+      originalRef.current = new Map();
+      paintedRangeRef.current = null;
+      // Clear any leftover suppress flag. If the previous gesture released
+      // outside the boundary and the browser never fired a trailing click,
+      // the flag could be stuck true and would otherwise swallow the next
+      // real click.
+      suppressClickRef.current = false;
+
+      // Attach document-level listeners for the duration of the gesture.
+      // This keeps the gesture alive even if the pointer leaves the boundary
+      // element mid-drag, and avoids depending on setPointerCapture (which
+      // JSDOM doesn't implement).
+      if (detachDocListenersRef.current) {
+        detachDocListenersRef.current();
+      }
+      document.addEventListener('pointermove', handleMove);
+      document.addEventListener('pointerup', handleUp);
+      document.addEventListener('pointercancel', handleCancel);
+      detachDocListenersRef.current = () => {
+        document.removeEventListener('pointermove', handleMove);
+        document.removeEventListener('pointerup', handleUp);
+        document.removeEventListener('pointercancel', handleCancel);
+      };
+    },
+    [enabled, handleCancel, handleMove, handleUp, orderRef],
+  );
+
+  const onClickCapture = useCallback((e: React.MouseEvent<HTMLElement>) => {
+    if (!suppressClickRef.current) return;
+    suppressClickRef.current = false;
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  // Detach any in-flight document listeners on unmount so we don't leak.
+  useEffect(() => {
+    return () => {
+      if (detachDocListenersRef.current) {
+        detachDocListenersRef.current();
+        detachDocListenersRef.current = null;
+      }
+    };
+  }, []);
+
+  return {
+    onPointerDown,
+    onClickCapture,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `src/hooks/useBulkDragPaint.ts` — a ref-only pointer-state hook that snapshots every Mule's selection on first pointermove, fixes brush polarity from the Start Card's inverse, and diffs a contiguous Paint Range so cards entering adopt the brush and cards leaving revert to their Original Snapshot.
- Wires the hook into `src/App.tsx` with a live `orderRef` / `toDeleteRef` / exact-state `setSelected`, spread onto the existing `data-drag-boundary` wrapper. Document-level pointermove/pointerup/pointercancel listeners are attached only for the duration of a gesture; an `onClickCapture` swallows the trailing synthetic click after an engaged drag so the Start Card isn't double-toggled. Zero-move pointerup still routes through today's single-click path.
- Adds `src/__tests__/bulkDragPaint.test.tsx` with the 9 PRD-mandated tests (engage / forward paint add + remove / revert on backtrack / cross-start / preserve pre-existing selection / synthetic-click suppression / pointerdown-outside / pointercancel revert / zero-move click preserved).

## Test plan
- [x] `npm test -- src/__tests__/bulkDragPaint.test.tsx` — all 9 new tests green.
- [x] `npm test` — 568 passing, only the pre-existing unrelated "renders weekly income section" failure on `src/__tests__/App.test.tsx` remains (flagged by the orchestrator; not part of this slice).
- [x] Existing `src/components/__tests__/MuleCharacterCard.test.tsx` bulk-mode suite and `src/__tests__/App.test.tsx` "Bulk Delete Mode" suite remain green.
- [x] `npm run lint` — no new lint errors introduced in the touched files.

Closes #162