### PR TITLE
Slice 2/4: Migrate useMules persistence boundary to MuleBossSlate.from

### DIFF
--- a/src/hooks/__tests__/useMules.test.ts
+++ b/src/hooks/__tests__/useMules.test.ts
@@ -155,6 +155,29 @@ describe('useMules', () => {
       expect(result.current.mules[0].selectedBosses).toEqual([HARD_LUCID])
     })
 
+    it('rejects Legacy Slate Keys at load time via MuleBossSlate.from', () => {
+      // A schemaVersion-tagged payload (no wipe, no v2 upgrade) that still
+      // somehow carries a two-segment Legacy Slate Key must drop that entry
+      // through MuleBossSlate.from; native keys alongside it survive.
+      const payload = {
+        schemaVersion: 4,
+        mules: [
+          {
+            id: 'a',
+            name: 'Test',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [HARD_LUCID, LEGACY_HARD_LUCID],
+            partySizes: {},
+            active: true,
+          },
+        ],
+      }
+      localStorageStore['maplestory-mule-tracker'] = JSON.stringify(payload)
+      const { result } = renderHook(() => useMules())
+      expect(result.current.mules[0].selectedBosses).toEqual([HARD_LUCID])
+    })
+
     it('enforces one-per-family on load', () => {
       const payload = {
         schemaVersion: 3,
@@ -462,6 +485,61 @@ describe('useMules', () => {
   })
 
   describe('updateMule', () => {
+    it('normalizes duplicate (bossId, cadence) keys via MuleBossSlate on update', () => {
+      // Both NORMAL_LUCID and HARD_LUCID map to the (lucid, weekly) bucket;
+      // the higher crystalValue key (HARD_LUCID) must win per the Selection
+      // Invariant enforced by MuleBossSlate.from.
+      const payload = {
+        schemaVersion: 4,
+        mules: [
+          {
+            id: 'a',
+            name: 'Test',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [],
+            partySizes: {},
+            active: true,
+          },
+        ],
+      }
+      localStorageStore['maplestory-mule-tracker'] = JSON.stringify(payload)
+      const { result } = renderHook(() => useMules())
+      act(() => {
+        result.current.updateMule('a', {
+          selectedBosses: [NORMAL_LUCID, HARD_LUCID],
+        })
+      })
+      expect(result.current.mules[0].selectedBosses).toEqual([HARD_LUCID])
+    })
+
+    it('round-trips a valid slate through updateMule into persisted storage', () => {
+      const payload = {
+        schemaVersion: 4,
+        mules: [
+          {
+            id: 'a',
+            name: 'Test',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [],
+            partySizes: {},
+            active: true,
+          },
+        ],
+      }
+      localStorageStore['maplestory-mule-tracker'] = JSON.stringify(payload)
+      const { result } = renderHook(() => useMules())
+      const slate = [HARD_LUCID, NORMAL_VELLUM_DAILY, CHAOS_VELLUM_WEEKLY]
+      act(() => {
+        result.current.updateMule('a', { selectedBosses: slate })
+      })
+      expect(result.current.mules[0].selectedBosses).toEqual(slate)
+      flushPersist()
+      const saved = JSON.parse(localStorageStore['maplestory-mule-tracker'])
+      expect(saved.mules[0].selectedBosses).toEqual(slate)
+    })
+
     it('prunes stale keys on update', () => {
       const payload = {
         schemaVersion: 3,

--- a/src/hooks/useMules.ts
+++ b/src/hooks/useMules.ts
@@ -3,7 +3,8 @@ import { arrayMove } from '@dnd-kit/sortable';
 import { v4 as uuidv4 } from 'uuid';
 import type { BossTier, Mule } from '../types';
 import { getBossById } from '../data/bosses';
-import { makeKey, validateBossSelection } from '../data/bossSelection';
+import { makeKey } from '../data/bossSelection';
+import { MuleBossSlate } from '../data/muleBossSlate';
 
 const STORAGE_KEY = 'maplestory-mule-tracker';
 const FALLBACK_KEY = 'maplestory-mule-tracker-fallback';
@@ -75,9 +76,9 @@ function validateMule(raw: unknown, mode: LoadMode): Mule | null {
       const next = upgradeV2Key(key);
       if (next !== null) upgraded.push(next);
     }
-    selectedBosses = validateBossSelection(upgraded);
+    selectedBosses = [...MuleBossSlate.from(upgraded).keys];
   } else {
-    selectedBosses = validateBossSelection(rawSelected);
+    selectedBosses = [...MuleBossSlate.from(rawSelected).keys];
   }
 
   return {
@@ -227,7 +228,7 @@ export function useMules() {
           if (m.id !== id) return m;
           const merged = { ...m, ...updates };
           if (updates.selectedBosses) {
-            merged.selectedBosses = validateBossSelection(updates.selectedBosses);
+            merged.selectedBosses = [...MuleBossSlate.from(updates.selectedBosses).keys];
           }
           return merged;
         }),


### PR DESCRIPTION
## Summary
- Replace `validateBossSelection` call in `useMules` with `MuleBossSlate.from(keys).keys` at every write + load path
- Enforce the Selection Invariant at the persistence boundary via construction

## Test plan
- [x] npm test — all green (except 3 pre-existing `MuleDetailDrawer` jsdom `scrollIntoView` failures unrelated to this slice)
- [x] Acceptance criteria verified against issue
- [x] `rg 'validateBossSelection' src/hooks` returns no matches
- [x] Added tests for: duplicate-key normalization via `updateMule`, Legacy Slate Key rejection at load time, and round-trip of a valid slate through `updateMule`

Closes #172