### PR TITLE
Slice 3/4: Migrate MuleDetailDrawer + BossMatrix to slate-view interface

### DIFF
--- a/src/components/BossMatrix.tsx
+++ b/src/components/BossMatrix.tsx
@@ -1,11 +1,7 @@
 import { memo } from 'react';
-import type { Boss, BossDifficulty, BossTier } from '../types';
-import {
-  bossesByDisplayOrder,
-  makeKey,
-  parseKey,
-  TIER_ORDER,
-} from '../data/bossSelection';
+import type { BossTier } from '../types';
+import { TIER_ORDER } from '../data/bossSelection';
+import type { SlateFamily, SlateKey, SlateRow } from '../data/muleBossSlate';
 import { formatMeso } from '../utils/meso';
 
 const TIER_COLOR: Record<BossTier, string> = {
@@ -29,26 +25,16 @@ const GRID_TEMPLATE = '140px repeat(5, 1fr)';
 const STEPPER_BTN_CLASS =
   'grid place-items-center w-5 self-stretch text-sm leading-none text-[var(--muted-raw,var(--muted-foreground))] hover:bg-[var(--surface-2)] hover:text-[var(--accent)] disabled:opacity-40 disabled:cursor-not-allowed';
 
-// Precompute tier → BossDifficulty lookup per family once at module load.
-const tierByBossId = new Map<string, Map<BossTier, BossDifficulty>>(
-  bossesByDisplayOrder.map((b): [string, Map<BossTier, BossDifficulty>] => [
-    b.id,
-    new Map(b.difficulty.map((d) => [d.tier, d])),
-  ]),
-);
-
-const EMPTY_TIER_SET: ReadonlySet<BossTier> = new Set();
-
 interface BossMatrixProps {
-  selectedKeys: string[];
-  onToggleKey: (key: string) => void;
+  /**
+   * Projection from `MuleBossSlate.view(search)` — one entry per **Slate
+   * Family**, each carrying its **Slate Rows** with `selected: bool` baked
+   * into every row.
+   */
+  families: SlateFamily[];
+  onToggleKey: (key: SlateKey) => void;
   partySizes: Record<string, number>;
   onChangePartySize: (family: string, n: number) => void;
-  /**
-   * Optional filtered/re-ordered boss list. Defaults to
-   * `bossesByDisplayOrder` so existing callers render unchanged.
-   */
-  bosses?: readonly Boss[];
   /**
    * When true, the outer wrapper squares its top corners and drops its top
    * border so a search bar can sit fused directly above it. Defaults to
@@ -137,28 +123,34 @@ function PartyStepper({
   );
 }
 
-function FamilyRow({
-  boss,
-  selectedTiers,
+function FamilyMatrixRow({
+  family,
   partySize,
   onToggleKey,
   onChangePartySize,
 }: {
-  boss: Boss;
-  selectedTiers: ReadonlySet<BossTier>;
+  family: SlateFamily;
   partySize: number;
-  onToggleKey: (key: string) => void;
+  onToggleKey: (key: SlateKey) => void;
   onChangePartySize: (family: string, n: number) => void;
 }) {
-  const tierMap = tierByBossId.get(boss.id)!;
+  // Index rows by tier so we can render the 5-column grid even when the family
+  // doesn't offer a tier (empty cell) or offers multiple cadences on one tier
+  // (the project currently has at most one row per tier per family).
+  const rowByTier = new Map<BossTier, SlateRow>(
+    family.rows.map((r) => [r.tier, r]),
+  );
+
   // A tier cell dims iff another tier of the SAME cadence is selected on this
   // boss — opposite-cadence tiers stay fully clickable (slice 2).
   const selectedCadences = new Set(
-    boss.difficulty
-      .filter((d) => selectedTiers.has(d.tier))
-      .map((d) => d.cadence),
+    family.rows.filter((r) => r.selected).map((r) => r.cadence),
   );
-  const hasWeeklyTier = boss.difficulty.some((d) => d.cadence === 'weekly');
+  const hasWeeklyTier = family.rows.some((r) => r.cadence === 'weekly');
+  const displayName = family.displayName;
+  // Any row carries the bossId we need for stable test ids across cells.
+  const bossId = family.rows[0]?.bossId ?? family.family;
+
   return (
     <div
       role="row"
@@ -173,11 +165,11 @@ function FamilyRow({
           data-testid="family-name"
           className="font-display leading-[1.2] truncate"
         >
-          {boss.name}
+          {displayName}
         </span>
         {hasWeeklyTier ? (
           <PartyStepper
-            family={boss.family}
+            family={family.family}
             party={partySize}
             onChangePartySize={onChangePartySize}
           />
@@ -191,13 +183,13 @@ function FamilyRow({
         )}
       </div>
       {TIER_ORDER.map((tier) => {
-        const diff = tierMap.get(tier);
-        if (!diff) {
+        const row = rowByTier.get(tier);
+        if (!row) {
           return (
             <div
               key={tier}
               role="cell"
-              data-testid={`matrix-cell-${boss.id}-${tier}`}
+              data-testid={`matrix-cell-${bossId}-${tier}`}
               aria-disabled="true"
               className="grid place-items-center py-[10px] px-1 border-r border-[var(--border)] last:border-r-0 font-mono-nums text-[11px] text-[var(--muted-raw,var(--muted-foreground))]"
               style={{ cursor: 'default' }}
@@ -207,23 +199,22 @@ function FamilyRow({
           );
         }
 
-        const isSelected = selectedTiers.has(tier);
-        const isDim = !isSelected && selectedCadences.has(diff.cadence);
-        const key = makeKey(boss.id, tier, diff.cadence);
+        const isSelected = row.selected;
+        const isDim = !isSelected && selectedCadences.has(row.cadence);
         // Daily cells always render at full crystalValue; only weekly cells
         // divide by the party size.
         const displayedValue =
-          diff.cadence === 'daily' ? diff.crystalValue : diff.crystalValue / partySize;
+          row.cadence === 'daily' ? row.crystalValue : row.crystalValue / partySize;
 
         return (
           <button
             type="button"
             key={tier}
             role="cell"
-            data-testid={`matrix-cell-${boss.id}-${tier}`}
+            data-testid={`matrix-cell-${bossId}-${tier}`}
             data-state={isSelected ? 'on' : 'off'}
             data-dim={isDim ? 'true' : undefined}
-            onClick={() => onToggleKey(key)}
+            onClick={() => onToggleKey(row.key)}
             className={[
               'grid place-items-center py-[10px] px-1 border-r border-[var(--border)] last:border-r-0 font-mono-nums text-[11px] tabular-nums cursor-pointer transition-colors',
               isSelected
@@ -233,7 +224,7 @@ function FamilyRow({
           >
             <span style={isDim ? { opacity: 0.35 } : undefined}>
               {formatMeso(displayedValue, true)}
-              {diff.cadence === 'daily' && (
+              {row.cadence === 'daily' && (
                 <span className="ml-1 text-[9px] opacity-60">x 7</span>
               )}
             </span>
@@ -245,24 +236,12 @@ function FamilyRow({
 }
 
 export const BossMatrix = memo(function BossMatrix({
-  selectedKeys,
+  families,
   onToggleKey,
   partySizes,
   onChangePartySize,
-  bosses = bossesByDisplayOrder,
   fusedTop = false,
 }: BossMatrixProps) {
-  // Slice 2: a single boss can carry up to one daily + one weekly selection,
-  // so we track the full set of selected tiers per boss (not one winner).
-  const selectedTiersByBoss = new Map<string, Set<BossTier>>();
-  for (const key of selectedKeys) {
-    const parsed = parseKey(key);
-    if (!parsed) continue;
-    const existing = selectedTiersByBoss.get(parsed.bossId);
-    if (existing) existing.add(parsed.tier);
-    else selectedTiersByBoss.set(parsed.bossId, new Set([parsed.tier]));
-  }
-
   // When a search bar is fused above, the matrix drops its top border and
   // squares its top corners so the two elements visually share a border.
   const cornerClass = fusedTop
@@ -297,12 +276,11 @@ export const BossMatrix = memo(function BossMatrix({
           ))}
         </div>
 
-      {bosses.map((boss) => (
-        <FamilyRow
-          key={boss.id}
-          boss={boss}
-          selectedTiers={selectedTiersByBoss.get(boss.id) ?? EMPTY_TIER_SET}
-          partySize={partySizes[boss.family] ?? 1}
+      {families.map((family) => (
+        <FamilyMatrixRow
+          key={family.family}
+          family={family}
+          partySize={partySizes[family.family] ?? 1}
           onToggleKey={onToggleKey}
           onChangePartySize={onChangePartySize}
         />

--- a/src/components/MuleDetailDrawer.tsx
+++ b/src/components/MuleDetailDrawer.tsx
@@ -14,14 +14,7 @@ import { useMuleIncome } from '../modules/income-hooks';
 import { BossMatrix } from './BossMatrix';
 import { BossSearch } from './BossSearch';
 import { MatrixToolbar, type CadenceFilter, type PresetKey } from './MatrixToolbar';
-import type { Boss } from '../types';
-import {
-  bossesByDisplayOrder,
-  countWeeklySelections,
-  filterBySearch,
-  parseKey,
-  toggleBoss,
-} from '../data/bossSelection';
+import { MuleBossSlate, type SlateFamily } from '../data/muleBossSlate';
 import {
   PRESET_FAMILIES,
   applyPreset,
@@ -35,13 +28,18 @@ import { GMS_CLASSES } from '../constants/classes';
 
 const PRESET_KEYS: readonly PresetKey[] = ['CRA', 'LOMIEN', 'CTENE'];
 
-function filterByCadence(
-  list: readonly Boss[],
+/**
+ * Narrow `SlateFamily[]` to families whose rows include at least one row with
+ * the requested cadence. Applied post-`slate.view(search)` so the cadence
+ * filter composes with the search filter without reshaping slate internals.
+ */
+function filterFamiliesByCadence(
+  families: SlateFamily[],
   filter: CadenceFilter,
-): readonly Boss[] {
-  if (filter === 'All') return list;
+): SlateFamily[] {
+  if (filter === 'All') return families;
   const cadence = filter === 'Weekly' ? 'weekly' : 'daily';
-  return list.filter((b) => b.difficulty.some((d) => d.cadence === cadence));
+  return families.filter((f) => f.rows.some((r) => r.cadence === cadence));
 }
 
 interface MuleDetailDrawerProps {
@@ -104,24 +102,23 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
 
   const levelDisplay = Number(draftLevel) || 0;
 
-  const visibleBosses = useMemo(
-    () =>
-      filterBySearch(
-        filterByCadence(bossesByDisplayOrder, filter),
-        search,
-      ),
-    [filter, search],
-  );
-
-  const weeklyCount = useMemo(
-    () => countWeeklySelections(mule?.selectedBosses ?? []),
-    [mule?.selectedBosses],
-  );
-
   const selectedBosses = useMemo(
     () => mule?.selectedBosses ?? [],
     [mule?.selectedBosses],
   );
+  const slate = useMemo(
+    () => MuleBossSlate.from(selectedBosses),
+    [selectedBosses],
+  );
+  // Search projection first, then cadence filter on the resulting family list;
+  // `slate.view` already bakes each row's `selected: bool` from the slate.
+  const families = useMemo(
+    () => filterFamiliesByCadence(slate.view(search), filter),
+    [slate, search, filter],
+  );
+
+  const weeklyCount = slate.weeklyCount;
+
   const activePresets = useMemo(() => {
     const set = new Set(PRESET_KEYS.filter((p) => isPresetActive(p, selectedBosses)));
     // LOMIEN's resolved keys are a superset of CRA's, so both would light up
@@ -140,17 +137,9 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
   const handleToggleKey = useCallback(
     (key: string) => {
       if (!muleId) return;
-      const parsed = parseKey(key);
-      if (!parsed) return;
-      onUpdate(muleId, {
-        selectedBosses: toggleBoss(
-          selectedBosses,
-          parsed.bossId,
-          parsed.tier,
-        ),
-      });
+      onUpdate(muleId, { selectedBosses: slate.toggle(key).keys as string[] });
     },
-    [muleId, selectedBosses, onUpdate],
+    [muleId, slate, onUpdate],
   );
 
   const handleChangePartySize = useCallback(
@@ -171,22 +160,26 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
 
   function handleTogglePreset(preset: PresetKey) {
     if (!mule) return;
-    const families = PRESET_FAMILIES[preset];
+    const presetFamilies = PRESET_FAMILIES[preset];
     let next: string[];
     if (activePresets.has(preset)) {
       // Clicking the active pill deselects it.
-      next = removePreset(mule.selectedBosses, families);
+      next = removePreset(slate.keys as string[], presetFamilies);
     } else {
       // Swap semantics: strip every OTHER active preset's families first,
       // then apply this one. Keeps at most one preset active at a time while
       // preserving hand-picked selections outside any preset family.
-      let cleared = mule.selectedBosses;
+      let cleared = slate.keys as string[];
       for (const other of activePresets) {
         cleared = removePreset(cleared, PRESET_FAMILIES[other]);
       }
-      next = applyPreset(cleared, families);
+      next = applyPreset(cleared, presetFamilies);
     }
-    onUpdate(mule.id, { selectedBosses: next });
+    // Normalize through construction so the Selection Invariant holds before
+    // the write hits `onUpdate`.
+    onUpdate(mule.id, {
+      selectedBosses: MuleBossSlate.from(next).keys as string[],
+    });
   }
 
   function handleClose() {
@@ -390,9 +383,8 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
               <div className="mt-2">
                 <BossSearch fused value={search} onChange={setSearch} />
                 <BossMatrix
-                  bosses={visibleBosses}
+                  families={families}
                   fusedTop
-                  selectedKeys={mule.selectedBosses}
                   onToggleKey={handleToggleKey}
                   partySizes={stablePartySizes}
                   onChangePartySize={handleChangePartySize}

--- a/src/components/__tests__/BossMatrix.test.tsx
+++ b/src/components/__tests__/BossMatrix.test.tsx
@@ -3,7 +3,13 @@ import { render, screen, fireEvent } from '@/test/test-utils'
 import { BossMatrix } from '../BossMatrix'
 import { bosses } from '../../data/bosses'
 import { makeKey, TIER_ORDER } from '../../data/bossSelection'
+import { MuleBossSlate, type SlateFamily } from '../../data/muleBossSlate'
 import { formatMeso } from '../../utils/meso'
+
+/** Build the `SlateFamily[]` projection `BossMatrix` now consumes. */
+function viewOf(keys: string[] = []): SlateFamily[] {
+  return MuleBossSlate.from(keys).view()
+}
 
 const LUCID_BOSS = bosses.find((b) => b.family === 'lucid')!
 const LUCID = LUCID_BOSS.id
@@ -40,7 +46,7 @@ const BOSSES_WITH_WEEKLY_TIER_COUNT = bosses.filter((b) =>
 ).length
 
 function renderMatrix(
-  selectedKeys: string[] = [],
+  slateKeys: string[] = [],
   onToggleKey = vi.fn(),
   partySizes: Record<string, number> = {},
   onChangePartySize = vi.fn(),
@@ -48,7 +54,7 @@ function renderMatrix(
   return {
     ...render(
       <BossMatrix
-        selectedKeys={selectedKeys}
+        families={viewOf(slateKeys)}
         onToggleKey={onToggleKey}
         partySizes={partySizes}
         onChangePartySize={onChangePartySize}
@@ -493,7 +499,7 @@ describe('BossMatrix', () => {
 
       rerender(
         <BossMatrix
-          selectedKeys={[]}
+          families={viewOf([])}
           onToggleKey={vi.fn()}
           partySizes={{ [VELLUM_BOSS.family]: 3 }}
           onChangePartySize={vi.fn()}
@@ -559,14 +565,13 @@ describe('BossMatrix', () => {
       expect(rows).toHaveLength(bosses.length + 1)
     })
 
-    it('renders only the header row when bosses={[]} is passed', () => {
+    it('renders only the header row when families={[]} is passed', () => {
       render(
         <BossMatrix
-          selectedKeys={[]}
+          families={[]}
           onToggleKey={vi.fn()}
           partySizes={{}}
           onChangePartySize={vi.fn()}
-          bosses={[]}
         />,
       )
       const rows = screen.getAllByRole('row')
@@ -575,14 +580,26 @@ describe('BossMatrix', () => {
     })
 
     it('renders exactly the families given, in the order provided', () => {
-      const subset = [LUCID_BOSS, BLACK_MAGE_BOSS, VELLUM_BOSS]
+      const subsetFamilies = new Set([
+        LUCID_BOSS.family,
+        BLACK_MAGE_BOSS.family,
+        VELLUM_BOSS.family,
+      ])
+      // Preserve display order via the slate's view, then hand-order the
+      // subset to assert `families`-prop order is honoured by the render.
+      const all = viewOf([]).filter((f) => subsetFamilies.has(f.family))
+      const byFamily = new Map(all.map((f) => [f.family, f]))
+      const subset = [
+        byFamily.get(LUCID_BOSS.family)!,
+        byFamily.get(BLACK_MAGE_BOSS.family)!,
+        byFamily.get(VELLUM_BOSS.family)!,
+      ]
       render(
         <BossMatrix
-          selectedKeys={[]}
+          families={subset}
           onToggleKey={vi.fn()}
           partySizes={{}}
           onChangePartySize={vi.fn()}
-          bosses={subset}
         />,
       )
       const rowHeaders = screen.getAllByRole('rowheader')
@@ -604,7 +621,7 @@ describe('BossMatrix', () => {
     it('squares top corners and drops top border when fusedTop={true}', () => {
       const { container } = render(
         <BossMatrix
-          selectedKeys={[]}
+          families={viewOf([])}
           onToggleKey={vi.fn()}
           partySizes={{}}
           onChangePartySize={vi.fn()}
@@ -622,7 +639,7 @@ describe('BossMatrix', () => {
     it('keeps rounded-[10px] when fusedTop={false}', () => {
       const { container } = render(
         <BossMatrix
-          selectedKeys={[]}
+          families={viewOf([])}
           onToggleKey={vi.fn()}
           partySizes={{}}
           onChangePartySize={vi.fn()}
@@ -632,6 +649,78 @@ describe('BossMatrix', () => {
       const wrapper = container.querySelector('[role="table"]') as HTMLElement
       expect(wrapper.className).toContain('rounded-[10px]')
       expect(wrapper.className).not.toContain('rounded-t-none')
+    })
+  })
+
+  describe('slate view contract (slice 3)', () => {
+    it('renders `selected: true` Slate Rows with data-state="on"', () => {
+      renderMatrix([HARD_LUCID])
+      const cell = screen.getByTestId(`matrix-cell-${LUCID}-hard`)
+      expect(cell.getAttribute('data-state')).toBe('on')
+    })
+
+    it('Tier Swap: selecting a sibling-tier key on the same (bossId, weekly) bucket keeps exactly one row selected', () => {
+      // Simulate a Tier Swap at the slate layer — normal and hard Lucid are
+      // same-cadence on the same family; the slate must retain only one.
+      const swapped = MuleBossSlate.from([NORMAL_LUCID]).toggle(HARD_LUCID).keys
+      render(
+        <BossMatrix
+          families={MuleBossSlate.from(swapped as string[]).view()}
+          onToggleKey={vi.fn()}
+          partySizes={{}}
+          onChangePartySize={vi.fn()}
+        />,
+      )
+      expect(
+        screen.getByTestId(`matrix-cell-${LUCID}-hard`).getAttribute('data-state'),
+      ).toBe('on')
+      expect(
+        screen.getByTestId(`matrix-cell-${LUCID}-normal`).getAttribute('data-state'),
+      ).not.toBe('on')
+    })
+
+    it('cross-cadence coexistence: daily + weekly selections on a mixed boss both render as on', () => {
+      // Normal Vellum is daily; Chaos Vellum is weekly — both keys coexist in
+      // a single slate and both Slate Rows carry `selected: true`.
+      renderMatrix([NORMAL_VELLUM_DAILY, CHAOS_VELLUM_WEEKLY])
+      expect(
+        screen.getByTestId(`matrix-cell-${VELLUM}-normal`).getAttribute('data-state'),
+      ).toBe('on')
+      expect(
+        screen.getByTestId(`matrix-cell-${VELLUM}-chaos`).getAttribute('data-state'),
+      ).toBe('on')
+    })
+
+    it('search filter (slate.view(search)) hides non-matching families', () => {
+      const families = MuleBossSlate.from([HARD_LUCID]).view('lucid')
+      render(
+        <BossMatrix
+          families={families}
+          onToggleKey={vi.fn()}
+          partySizes={{}}
+          onChangePartySize={vi.fn()}
+        />,
+      )
+      const rowHeaders = screen.getAllByRole('rowheader')
+      expect(rowHeaders).toHaveLength(1)
+      expect(rowHeaders[0].textContent).toContain('Lucid')
+    })
+
+    it('selected state carries through the search filter', () => {
+      // Filter down to Lucid with Hard Lucid selected; the surviving row keeps
+      // its `selected: true` flag baked in by `slate.view`.
+      const families = MuleBossSlate.from([HARD_LUCID]).view('lucid')
+      render(
+        <BossMatrix
+          families={families}
+          onToggleKey={vi.fn()}
+          partySizes={{}}
+          onChangePartySize={vi.fn()}
+        />,
+      )
+      expect(
+        screen.getByTestId(`matrix-cell-${LUCID}-hard`).getAttribute('data-state'),
+      ).toBe('on')
     })
   })
 })

--- a/src/components/__tests__/MuleDetailDrawer.test.tsx
+++ b/src/components/__tests__/MuleDetailDrawer.test.tsx
@@ -317,7 +317,7 @@ describe('MuleDetailDrawer', () => {
       expect(screen.queryByPlaceholderText('Search bosses...')).toBeNull()
     })
 
-    it('clicking a tier cell calls onUpdate with toggleBoss result', () => {
+    it('clicking a tier cell calls onUpdate with slate.toggle(key).keys', () => {
       const onUpdate = vi.fn()
       renderDrawer({ onUpdate })
       const hardLucidCell = screen.getByTestId(`matrix-cell-${LUCID}-hard`)
@@ -351,6 +351,37 @@ describe('MuleDetailDrawer', () => {
       expect(onUpdate).toHaveBeenCalledWith('test-mule-1', {
         selectedBosses: [],
       })
+    })
+
+    it('Tier Swap: clicking a different tier of the same (bossId, weekly) bucket replaces the prior key one-for-one', () => {
+      const onUpdate = vi.fn()
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: [NORMAL_LUCID] },
+        onUpdate,
+      })
+      const hardLucidCell = screen.getByTestId(`matrix-cell-${LUCID}-hard`)
+      fireEvent.click(hardLucidCell)
+      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] }
+      // One key in, one key out — no doubling up on the weekly bucket.
+      expect(update.selectedBosses).toEqual([HARD_LUCID])
+    })
+
+    it('cross-cadence coexist: selecting a daily tier on a boss that already has a weekly selection keeps both keys', () => {
+      // Pick a mixed-cadence family (Vellum). Chaos Vellum is weekly; Normal
+      // Vellum is daily — the slate must carry both keys simultaneously.
+      const CHAOS_VELLUM_WEEKLY = makeKey(VELLUM_BOSS.id, 'chaos', 'weekly')
+      const NORMAL_VELLUM_DAILY = makeKey(VELLUM_BOSS.id, 'normal', 'daily')
+      const onUpdate = vi.fn()
+      renderDrawer({
+        mule: { ...baseMule, selectedBosses: [CHAOS_VELLUM_WEEKLY] },
+        onUpdate,
+      })
+      const normalVellum = screen.getByTestId(`matrix-cell-${VELLUM_BOSS.id}-normal`)
+      fireEvent.click(normalVellum)
+      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] }
+      expect(new Set(update.selectedBosses)).toEqual(
+        new Set([CHAOS_VELLUM_WEEKLY, NORMAL_VELLUM_DAILY]),
+      )
     })
   })
 
@@ -494,6 +525,16 @@ describe('MuleDetailDrawer', () => {
       renderDrawer()
       expect(getSearchInput().value).toBe('')
       expect(screen.getAllByRole('rowheader')).toHaveLength(bosses.length)
+    })
+
+    it('narrowing the search filter preserves the `selected` flag on the surviving row', () => {
+      // Hard Lucid is selected. Filter down to just Lucid — the surviving
+      // Slate Row must keep its `selected: true` state after the search.
+      renderDrawer({ mule: { ...baseMule, selectedBosses: [HARD_LUCID] } })
+      fireEvent.change(getSearchInput(), { target: { value: 'lucid' } })
+      expect(screen.getAllByRole('rowheader')).toHaveLength(1)
+      const hardLucidCell = screen.getByTestId(`matrix-cell-${LUCID}-hard`)
+      expect(hardLucidCell.getAttribute('data-state')).toBe('on')
     })
   })
 
@@ -881,6 +922,52 @@ describe('MuleDetailDrawer', () => {
       fireEvent.click(screen.getByRole('button', { name: /^ctene$/i }))
       const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] }
       expect(update.selectedBosses).toContain(HARD_HORNTAIL)
+    })
+
+    it('applying CRA then CTENE leaves CRA∩CTENE shared families selected (overlap survives the swap)', () => {
+      // Replay the user flow end-to-end: each click's payload becomes the
+      // next render's `selectedBosses`. After CRA → CTENE, the CRA∩CTENE
+      // overlap (Vellum / Crimson Queen / Papulatus / Magnus / Princess No)
+      // stays selected because CTENE's apply step re-adds them.
+      const craFamilies: ReadonlySet<string> = new Set(PRESET_FAMILIES.CRA)
+      const cteneFamilies: ReadonlySet<string> = new Set(
+        PRESET_FAMILIES.CTENE.map(presetEntryFamily),
+      )
+      const overlap = [...craFamilies].filter((f) => cteneFamilies.has(f))
+
+      let selectedBosses: string[] = []
+      const onUpdate = vi.fn((_id: string, upd: { selectedBosses?: string[] }) => {
+        if (upd.selectedBosses !== undefined) selectedBosses = upd.selectedBosses
+      })
+      const { rerender } = renderDrawer({
+        mule: { ...baseMule, selectedBosses },
+        onUpdate,
+      })
+      function renderWith(keys: string[]) {
+        rerender(
+          <MuleDetailDrawer
+            mule={{ ...baseMule, selectedBosses: keys }}
+            open={true}
+            onClose={vi.fn()}
+            onUpdate={onUpdate}
+            onDelete={vi.fn()}
+          />,
+        )
+      }
+
+      fireEvent.click(screen.getByRole('button', { name: /^cra$/i }))
+      renderWith(selectedBosses)
+      for (const f of overlap) {
+        expect(selectedBosses).toContain(hardestKey(f))
+      }
+      fireEvent.click(screen.getByRole('button', { name: /^ctene$/i }))
+      renderWith(selectedBosses)
+      // Each overlap family's CTENE-resolved key survives the swap.
+      for (const entry of PRESET_FAMILIES.CTENE) {
+        const family = presetEntryFamily(entry)
+        if (!craFamilies.has(family)) continue
+        expect(selectedBosses).toContain(presetEntryKey(entry)!)
+      }
     })
 
     it('the union state is unreachable via the pill-click flow (no sequence produces two active pills)', () => {


### PR DESCRIPTION
## Summary
- `BossMatrix` prop API swapped from `{ selectedKeys, onToggleKey }` -> `{ families, onToggleKey }` with `selected: bool` baked into each `SlateRow`
- `MuleDetailDrawer` memoizes a `MuleBossSlate` and passes its `view(search)` projection (plus a post-cadence-filter step) to `BossMatrix`
- Toggle and preset writes route through `slate.toggle(...)` / `MuleBossSlate.from(applyPreset(...))` so every write is normalized at construction time
- No UI behaviour change (Tier Swap, cross-cadence coexist, CRA/CTENE swap, search, cadence filter, Matrix Reset all identical)

## Test plan
- [x] npm test — 639 passing (up from 630 baseline); the same 3 pre-existing `ClassAutocomplete.scrollIntoView` failures remain (documented in the issue; unrelated to boss-selection)
- [x] Tier Swap (one-for-one replacement on same `(bossId, weekly)` bucket)
- [x] Cross-cadence coexist (Vellum weekly + Vellum daily both kept)
- [x] CRA -> CTENE overlap survives the swap
- [x] Search filter + selected-state carry-through
- [x] `rg 'selectedKeys' src/components` returns no matches
- [x] `rg '\btoggleBoss\b|\bparseKey\b' src/components` returns no matches
- [x] `npx tsc -b --noEmit` introduces no new errors (only the 3 pre-existing errors in IncomePieChart, RosterCardHeightParity, and the existing CRA-type-narrowing test remain)

Closes #173