### PR TITLE
Slice 1 — introduce src/modules/income.tsx + consolidated tests (no migration)

### DIFF
--- a/src/modules/__tests__/income.test.tsx
+++ b/src/modules/__tests__/income.test.tsx
@@ -1,0 +1,276 @@
+import { describe, expect, it, vi } from 'vitest'
+import { act, render, renderHook, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import {
+  Income,
+  IncomeProvider,
+  useAutoFullFormatOnZero,
+  useIncome,
+} from '../income.tsx'
+import { MuleBossSlate } from '../../data/muleBossSlate'
+import { bosses } from '../../data/bosses'
+
+const LUCID = bosses.find((b) => b.family === 'lucid')!.id
+const WILL = bosses.find((b) => b.family === 'will')!.id
+const HARD_LUCID = `${LUCID}:hard:weekly`
+const HARD_WILL = `${WILL}:hard:weekly`
+
+const AbbrevOff = ({ children }: { children: ReactNode }) => (
+  <IncomeProvider defaultAbbreviated={false}>{children}</IncomeProvider>
+)
+
+describe('Income.of', () => {
+  it('delegates per-mule arithmetic to MuleBossSlate.totalCrystalValue', () => {
+    const mule = { selectedBosses: [HARD_LUCID, HARD_WILL] }
+    const expected = MuleBossSlate.from(mule.selectedBosses).totalCrystalValue
+    expect(Income.of(mule, true).raw).toBe(expected)
+    expect(Income.of(mule, false).raw).toBe(expected)
+  })
+
+  it('formatted calls formatMeso with the abbreviation flag', () => {
+    const mule = { selectedBosses: [HARD_LUCID, HARD_WILL] }
+    expect(Income.of(mule, true).formatted).toBe('1.13B')
+    expect(Income.of(mule, false).formatted).toBe('1,125,810,000')
+  })
+
+  it('applies the Active-Flag Filter to a roster (excludes active===false only)', () => {
+    const mules = [
+      { selectedBosses: [HARD_LUCID], active: true },
+      { selectedBosses: [HARD_WILL], active: false },
+      { selectedBosses: [HARD_WILL], active: undefined },
+      { selectedBosses: [HARD_LUCID] },
+    ]
+    // active===false (HARD_WILL) excluded; the rest sum normally
+    const expected =
+      MuleBossSlate.from([HARD_LUCID]).totalCrystalValue +
+      MuleBossSlate.from([HARD_WILL]).totalCrystalValue +
+      MuleBossSlate.from([HARD_LUCID]).totalCrystalValue
+    expect(Income.of(mules, false).raw).toBe(expected)
+  })
+
+  it('returns raw 0 and formatted "0" for an empty roster in both modes', () => {
+    expect(Income.of([], true).raw).toBe(0)
+    expect(Income.of([], true).formatted).toBe('0')
+    expect(Income.of([], false).raw).toBe(0)
+    expect(Income.of([], false).formatted).toBe('0')
+  })
+
+  it('toString() equals formatted', () => {
+    const mule = { selectedBosses: [HARD_LUCID] }
+    const income = Income.of(mule, true)
+    expect(income.toString()).toBe(income.formatted)
+    expect(String(income)).toBe('504M')
+  })
+
+  it('formatted is lazy — consecutive reads both succeed and match formatMeso', () => {
+    const income = Income.of({ selectedBosses: [HARD_LUCID] }, true)
+    // Two consecutive reads should be equal; the getter pattern means we can
+    // flip abbr internally only via a new instance, not via mutation.
+    expect(income.formatted).toBe('504M')
+    expect(income.formatted).toBe('504M')
+  })
+
+  it('rejects calling the constructor directly (compile-time only)', () => {
+    // The private constructor is enforced by TS, not at runtime.
+    // @ts-expect-error — private constructor should not be callable.
+    const illegal = new Income(1, true)
+    expect(illegal).toBeInstanceOf(Income)
+  })
+})
+
+describe('IncomeProvider', () => {
+  it('defaults Format Preference to true (abbreviated)', () => {
+    function Consumer() {
+      const { abbreviated } = useIncome()
+      return <span data-testid="abbrev">{String(abbreviated)}</span>
+    }
+    render(
+      <IncomeProvider>
+        <Consumer />
+      </IncomeProvider>,
+    )
+    expect(screen.getByTestId('abbrev').textContent).toBe('true')
+  })
+
+  it('respects defaultAbbreviated={false}', () => {
+    function Consumer() {
+      const { abbreviated } = useIncome()
+      return <span data-testid="abbrev">{String(abbreviated)}</span>
+    }
+    render(
+      <IncomeProvider defaultAbbreviated={false}>
+        <Consumer />
+      </IncomeProvider>,
+    )
+    expect(screen.getByTestId('abbrev').textContent).toBe('false')
+  })
+})
+
+describe('useIncome', () => {
+  it('throws when rendered outside an IncomeProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() =>
+      renderHook(() => useIncome({ selectedBosses: [HARD_LUCID] })),
+    ).toThrow(/IncomeProvider/)
+    spy.mockRestore()
+  })
+
+  it('throws from the no-arg form too when outside IncomeProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => renderHook(() => useIncome())).toThrow(/IncomeProvider/)
+    spy.mockRestore()
+  })
+
+  it('returns raw+formatted matching Income.of for a single mule', () => {
+    const mule = { selectedBosses: [HARD_LUCID] }
+    const { result } = renderHook(() => useIncome(mule), { wrapper: IncomeProvider })
+    expect(result.current.raw).toBe(Income.of(mule, true).raw)
+    expect(result.current.formatted).toBe('504M')
+  })
+
+  it('returns raw+formatted matching Income.of for a roster', () => {
+    const mules = [
+      { selectedBosses: [HARD_LUCID] },
+      { selectedBosses: [HARD_WILL] },
+    ]
+    const { result } = renderHook(() => useIncome(mules), { wrapper: IncomeProvider })
+    expect(result.current.raw).toBe(Income.of(mules, true).raw)
+    expect(result.current.formatted).toBe('1.13B')
+  })
+
+  it('respects the current Format Preference (full mode)', () => {
+    const mule = { selectedBosses: [HARD_LUCID] }
+    const { result } = renderHook(() => useIncome(mule), { wrapper: AbbrevOff })
+    expect(result.current.formatted).toBe('504,000,000')
+  })
+
+  it('returns raw 0 + toggle when called with no argument', () => {
+    const { result } = renderHook(() => useIncome(), { wrapper: IncomeProvider })
+    expect(result.current.raw).toBe(0)
+    expect(result.current.formatted).toBe('0')
+    expect(result.current.abbreviated).toBe(true)
+    expect(typeof result.current.toggle).toBe('function')
+  })
+
+  it('returns a stable Income reference across re-renders with unchanged input', () => {
+    const mule = { selectedBosses: [HARD_LUCID] }
+    const { result, rerender } = renderHook(({ m }) => useIncome(m), {
+      wrapper: IncomeProvider,
+      initialProps: { m: mule },
+    })
+    const first = result.current
+    rerender({ m: mule })
+    expect(result.current).toBe(first)
+  })
+
+  it('re-derives when selectedBosses identity changes', () => {
+    const first = { selectedBosses: [HARD_LUCID] }
+    const second = { selectedBosses: [HARD_LUCID, HARD_WILL] }
+    const { result, rerender } = renderHook(({ m }) => useIncome(m), {
+      wrapper: IncomeProvider,
+      initialProps: { m: first },
+    })
+    const before = result.current
+    rerender({ m: second })
+    expect(result.current).not.toBe(before)
+    expect(result.current.raw).toBe(Income.of(second, true).raw)
+  })
+
+  it('re-derives when Format Preference toggles', () => {
+    const mule = { selectedBosses: [HARD_LUCID] }
+    const { result } = renderHook(() => useIncome(mule), { wrapper: IncomeProvider })
+    expect(result.current.formatted).toBe('504M')
+    const before = result.current
+    act(() => {
+      result.current.toggle()
+    })
+    expect(result.current).not.toBe(before)
+    expect(result.current.abbreviated).toBe(false)
+    expect(result.current.formatted).toBe('504,000,000')
+  })
+})
+
+describe('useAutoFullFormatOnZero', () => {
+  it('fires toggle exactly once when raw === 0 and abbreviated === true', () => {
+    const { result } = renderHook(
+      () => {
+        const income = useIncome()
+        useAutoFullFormatOnZero(0)
+        return income
+      },
+      { wrapper: IncomeProvider },
+    )
+    expect(result.current.abbreviated).toBe(false)
+  })
+
+  it('does not re-fire across re-renders with the same zero+abbreviated state', () => {
+    // The effect must toggle only on the *first* render where raw===0 and
+    // abbreviated===true. After that the state is abbreviated===false, and a
+    // rerender at raw===0 must not flip us back to abbreviated and repeat.
+    const { rerender, result } = renderHook(
+      () => {
+        const income = useIncome()
+        useAutoFullFormatOnZero(0)
+        return income
+      },
+      { wrapper: IncomeProvider },
+    )
+    // First effect fired: we're now in full mode.
+    expect(result.current.abbreviated).toBe(false)
+    // Re-render with the same inputs — the effect must not flip us back.
+    rerender()
+    expect(result.current.abbreviated).toBe(false)
+    rerender()
+    expect(result.current.abbreviated).toBe(false)
+  })
+
+  it('no-ops when raw > 0', () => {
+    const { result } = renderHook(
+      () => {
+        const income = useIncome()
+        useAutoFullFormatOnZero(100)
+        return income
+      },
+      { wrapper: IncomeProvider },
+    )
+    expect(result.current.abbreviated).toBe(true)
+  })
+
+  it('no-ops when abbreviated === false', () => {
+    const { result } = renderHook(
+      () => {
+        const income = useIncome()
+        useAutoFullFormatOnZero(0)
+        return income
+      },
+      { wrapper: AbbrevOff },
+    )
+    expect(result.current.abbreviated).toBe(false)
+  })
+
+  it('re-arms after a non-trigger state, then fires once more on next zero', () => {
+    // raw goes 0 -> 100 -> 0. First zero flips to full (no re-fire). We then
+    // manually toggle back to abbreviated; the effect should fire again on
+    // the next zero render to preserve the UX invariant "dead roster renders 0".
+    const { result, rerender } = renderHook(
+      ({ raw }: { raw: number }) => {
+        const income = useIncome()
+        useAutoFullFormatOnZero(raw)
+        return income
+      },
+      {
+        wrapper: IncomeProvider,
+        initialProps: { raw: 0 },
+      },
+    )
+    expect(result.current.abbreviated).toBe(false)
+    rerender({ raw: 100 })
+    // Flip back to abbreviated manually to simulate the user re-engaging it.
+    act(() => {
+      result.current.toggle()
+    })
+    expect(result.current.abbreviated).toBe(true)
+    rerender({ raw: 0 })
+    expect(result.current.abbreviated).toBe(false)
+  })
+})

--- a/src/modules/income.tsx
+++ b/src/modules/income.tsx
@@ -1,0 +1,142 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { MuleBossSlate } from '../data/muleBossSlate'
+import { formatMeso } from '../utils/meso'
+
+/**
+ * An **Income Source** — anything whose **Raw Income** is the cadence-weighted
+ * sum of its **Slate Keys**. Today that's a **Mule** (`active` is the
+ * **Active Flag**), but the interface is deliberately narrower than `Mule` so
+ * non-mule sources (e.g. a hypothetical linked character) can slot in without
+ * churn.
+ */
+export interface IncomeSource {
+  selectedBosses: string[]
+  active?: boolean
+}
+
+/**
+ * Immutable **Potential Income** value — per-mule or across a roster, carrying
+ * the current **Format Preference** for lazy rendering. Construct only via
+ * `Income.of`; the constructor is private on purpose.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export class Income {
+  private constructor(
+    readonly raw: number,
+    private readonly abbr: boolean,
+  ) {}
+
+  /**
+   * Aggregate one or more **Income Sources** into an `Income`.
+   *
+   * - Per-mule arithmetic is delegated to
+   *   `MuleBossSlate.from(source.selectedBosses).totalCrystalValue`; this
+   *   module owns aggregation, not crystal summation.
+   * - For a roster, the **Active-Flag Filter** excludes sources with
+   *   `active === false` and includes `active === true` / `active === undefined`.
+   */
+  static of(source: IncomeSource | IncomeSource[], abbreviated: boolean): Income {
+    const sources = Array.isArray(source) ? source : [source]
+    let raw = 0
+    for (const s of sources) {
+      if (s.active === false) continue
+      raw += MuleBossSlate.from(s.selectedBosses).totalCrystalValue
+    }
+    return new Income(raw, abbreviated)
+  }
+
+  /** Rendered `raw` in the active **Format Preference**. Lazy — not precomputed. */
+  get formatted(): string {
+    return formatMeso(this.raw, this.abbr)
+  }
+
+  toString(): string {
+    return this.formatted
+  }
+}
+
+interface IncomeContextValue {
+  abbreviated: boolean
+  toggle: () => void
+}
+
+// Private to this module on purpose: slice 1 keeps the new module standalone
+// so slice 2 can migrate call sites in a single atomic pass.
+const IncomeContext = createContext<IncomeContextValue | undefined>(undefined)
+
+/**
+ * Holds the global **Format Preference** state and exposes a toggle to every
+ * `useIncome` consumer inside the tree. Defaults to abbreviated.
+ */
+export function IncomeProvider({
+  children,
+  defaultAbbreviated = true,
+}: {
+  children: ReactNode
+  defaultAbbreviated?: boolean
+}) {
+  const [abbreviated, setAbbreviated] = useState(defaultAbbreviated)
+  const toggle = useCallback(() => setAbbreviated((a) => !a), [])
+  const value = useMemo(() => ({ abbreviated, toggle }), [abbreviated, toggle])
+  return <IncomeContext.Provider value={value}>{children}</IncomeContext.Provider>
+}
+
+function useIncomeContext(): IncomeContextValue {
+  const ctx = useContext(IncomeContext)
+  if (!ctx) {
+    throw new Error('useIncome must be used within an IncomeProvider')
+  }
+  return ctx
+}
+
+type UseIncomeResult = Income & { abbreviated: boolean; toggle: () => void }
+
+/**
+ * Read **Potential Income** for a single **Mule**, a roster, or nothing (for
+ * toggle-only consumers). The returned object carries the current
+ * **Format Preference** and the `toggle` callback, so the typical
+ * KPI/toggle-button pattern needs only one hook call.
+ *
+ * The underlying `Income` is memoized by `selectedBosses` identity + active
+ * flags + **Format Preference** so callers get a stable reference across
+ * re-renders with unchanged inputs.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useIncome(source?: IncomeSource | IncomeSource[]): UseIncomeResult {
+  const { abbreviated, toggle } = useIncomeContext()
+  return useMemo(
+    () => Object.assign(Income.of(source ?? [], abbreviated), { abbreviated, toggle }),
+    [source, abbreviated, toggle],
+  )
+}
+
+/**
+ * **Auto-Fullformat-On-Zero Rule** — if `raw === 0` while abbreviated, flip
+ * the global **Format Preference** to full once so a dead roster renders as
+ * `0` instead of `0B`. No-op otherwise. Idempotent across re-renders of the
+ * same zero+abbreviated state.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useAutoFullFormatOnZero(raw: number): void {
+  const { abbreviated, toggle } = useIncomeContext()
+  const firedRef = useRef(false)
+  useEffect(() => {
+    if (raw === 0 && abbreviated) {
+      if (!firedRef.current) {
+        firedRef.current = true
+        toggle()
+      }
+    } else {
+      firedRef.current = false
+    }
+  }, [raw, abbreviated, toggle])
+}


### PR DESCRIPTION
## Summary
- Add `src/modules/income.tsx` exporting `Income` value class, `IncomeProvider`, `useIncome`, `useAutoFullFormatOnZero`
- Ship consolidated test suite (`src/modules/__tests__/income.test.tsx`, 23 cases) covering every acceptance-criteria checkbox on #180
- Leave existing `income.ts` / `income-hooks.ts` / `income-context.ts` / `IncomeProvider.tsx` in place — this slice does not migrate call sites

## Notes
- Because `income.ts` (old) and `income.tsx` (new) share a base name, the consolidated test file imports `../income.tsx` with an explicit extension. Vite/vitest and `allowImportingTsExtensions: true` make this unambiguous (cf. `src/main.tsx` which imports `./App.tsx`).
- `Income.of` delegates all cadence-weighted crystal summation to `MuleBossSlate.from(...).totalCrystalValue`; no new arithmetic lives in this module.
- `useIncome` returns a `useMemo`-stabilised `Income` with `abbreviated` and `toggle` attached, so the KPI/toggle-button pattern needs one hook call.
- `useAutoFullFormatOnZero` uses a `useRef` latch so StrictMode's double-invoke does not flip the format back and forth on mount.

## Test plan
- [x] `npm run test` — 23 new tests pass; no new failures (3 pre-existing failures in `src/components/__tests__/MuleDetailDrawer.test.tsx > class autocomplete` are present on `main` and unrelated to this slice)
- [x] `npx tsc -p tsconfig.app.json --noEmit` — no new errors on the changed files (3 pre-existing errors in `IncomePieChart.test.tsx`, `MuleDetailDrawer.test.tsx`, `RosterCardHeightParity.test.tsx` remain)
- [x] `npm run lint` — no new errors or warnings from the new files (8 pre-existing problems remain; baseline matches `main`)
- [x] Acceptance criteria verified against issue #180

Closes #180