### PR TITLE
feat: introduce MuleStore persistence module with boundary tests

### DIFF
--- a/src/persistence/__tests__/muleMigrate.test.ts
+++ b/src/persistence/__tests__/muleMigrate.test.ts
@@ -1,0 +1,444 @@
+import { describe, expect, it } from 'vitest';
+import { muleMigrate, CURRENT_SCHEMA_VERSION } from '../muleMigrate';
+import { bosses } from '../../data/bosses';
+import type { BossTier, Mule } from '../../types';
+
+/**
+ * Boundary tests for the pure `muleMigrate(raw)` function. Every **Load
+ * Mode** branch is driven via fixture strings — no JSDOM storage, no
+ * fake timers, no React mounting. The fixtures below build selection
+ * keys from the live `bosses` catalog so this file never hard-codes a
+ * UUID (which would drift silently on catalog edits).
+ */
+
+function idForFamily(family: string): string {
+  const boss = bosses.find((b) => b.family === family);
+  if (!boss) throw new Error(`No boss found for family ${family}`);
+  return boss.id;
+}
+
+/** Fabricate a native `<uuid>:<tier>:<cadence>` **Slate Key** from boss data. */
+function nativeKey(bossId: string, tier: BossTier): string {
+  const boss = bosses.find((b) => b.id === bossId)!;
+  const diff = boss.difficulty.find((d) => d.tier === tier)!;
+  return `${bossId}:${tier}:${diff.cadence}`;
+}
+
+const LUCID = idForFamily('lucid');
+const VELLUM = idForFamily('vellum');
+
+const HARD_LUCID = nativeKey(LUCID, 'hard');
+const NORMAL_LUCID = nativeKey(LUCID, 'normal');
+const NORMAL_VELLUM_DAILY = nativeKey(VELLUM, 'normal');
+const CHAOS_VELLUM_WEEKLY = nativeKey(VELLUM, 'chaos');
+
+const LEGACY_HARD_LUCID = `${LUCID}:hard`;
+const LEGACY_NORMAL_VELLUM = `${VELLUM}:normal`;
+const LEGACY_CHAOS_VELLUM = `${VELLUM}:chaos`;
+
+describe('muleMigrate', () => {
+  describe('input-shape failures → Wipe to empty array', () => {
+    it('returns [] for null input', () => {
+      expect(muleMigrate(null)).toEqual([]);
+    });
+
+    it('returns [] for corrupt JSON', () => {
+      expect(muleMigrate('not json')).toEqual([]);
+      expect(muleMigrate('{incomplete')).toEqual([]);
+    });
+
+    it('returns [] for valid JSON with unusable shape', () => {
+      // Not an array, not a { mules: [...] } envelope.
+      expect(muleMigrate(JSON.stringify({ foo: 'bar' }))).toEqual([]);
+      expect(muleMigrate(JSON.stringify(42))).toEqual([]);
+      expect(muleMigrate(JSON.stringify('string'))).toEqual([]);
+    });
+  });
+
+  describe('pre-1B bare-array payload → Wipe', () => {
+    it('returns [] for an empty bare array', () => {
+      expect(muleMigrate('[]')).toEqual([]);
+    });
+
+    it('wipes legacy-id selections but preserves non-selection fields', () => {
+      const legacyRoot = [
+        {
+          id: 'a',
+          name: 'Legacy',
+          level: 200,
+          muleClass: 'Hero',
+          selectedBosses: ['hard-lucid', 'normal-will'],
+          partySizes: { lucid: 3 },
+        },
+      ];
+      const [mule] = muleMigrate(JSON.stringify(legacyRoot));
+      expect(mule.id).toBe('a');
+      expect(mule.name).toBe('Legacy');
+      expect(mule.level).toBe(200);
+      expect(mule.muleClass).toBe('Hero');
+      expect(mule.selectedBosses).toEqual([]);
+      // partySizes are dropped alongside the wiped selections.
+      expect(mule.partySizes).toEqual({});
+      // Active Default applied.
+      expect(mule.active).toBe(true);
+    });
+
+    it('wipes when any entry lacks a colon', () => {
+      const legacyRoot = [
+        {
+          id: 'a',
+          name: 'Legacy',
+          level: 1,
+          muleClass: 'A',
+          selectedBosses: ['no-colon'],
+        },
+      ];
+      expect(muleMigrate(JSON.stringify(legacyRoot))[0].selectedBosses).toEqual([]);
+    });
+  });
+
+  describe('schemaVersion 2 → Upgrade V2', () => {
+    it('rewrites <uuid>:<tier> keys to <uuid>:<tier>:<cadence>', () => {
+      const v2 = {
+        schemaVersion: 2,
+        mules: [
+          {
+            id: 'a',
+            name: 'V2',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [LEGACY_HARD_LUCID],
+            partySizes: { lucid: 3 },
+          },
+        ],
+      };
+      const [mule] = muleMigrate(JSON.stringify(v2));
+      expect(mule.selectedBosses).toEqual([HARD_LUCID]);
+      // partySizes survive the upgrade untouched.
+      expect(mule.partySizes).toEqual({ lucid: 3 });
+      expect(mule.active).toBe(true);
+    });
+
+    it('upgrades mixed daily + weekly v2 keys on the same boss', () => {
+      // Vellum: Normal (daily) + Chaos (weekly) — both cadences coexist.
+      const v2 = {
+        schemaVersion: 2,
+        mules: [
+          {
+            id: 'a',
+            name: 'V2',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [LEGACY_NORMAL_VELLUM, LEGACY_CHAOS_VELLUM],
+          },
+        ],
+      };
+      expect(muleMigrate(JSON.stringify(v2))[0].selectedBosses).toEqual([
+        NORMAL_VELLUM_DAILY,
+        CHAOS_VELLUM_WEEKLY,
+      ]);
+    });
+
+    it('silently drops v2 entries whose boss is no longer in the dataset', () => {
+      const v2 = {
+        schemaVersion: 2,
+        mules: [
+          {
+            id: 'a',
+            name: 'V2',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [LEGACY_HARD_LUCID, 'unknown-boss-id:hard'],
+          },
+        ],
+      };
+      expect(muleMigrate(JSON.stringify(v2))[0].selectedBosses).toEqual([HARD_LUCID]);
+    });
+
+    it('silently drops v2 entries whose tier is not offered for the boss', () => {
+      // Lucid does not offer chaos.
+      const v2 = {
+        schemaVersion: 2,
+        mules: [
+          {
+            id: 'a',
+            name: 'V2',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [LEGACY_HARD_LUCID, `${LUCID}:chaos`],
+          },
+        ],
+      };
+      expect(muleMigrate(JSON.stringify(v2))[0].selectedBosses).toEqual([HARD_LUCID]);
+    });
+  });
+
+  describe('schemaVersion 3 → As-Is Load + Active Default', () => {
+    it('loads native selection keys unchanged', () => {
+      const v3 = {
+        schemaVersion: 3,
+        mules: [
+          {
+            id: 'a',
+            name: 'V3',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [HARD_LUCID],
+            partySizes: { lucid: 3 },
+          },
+        ],
+      };
+      const [mule] = muleMigrate(JSON.stringify(v3));
+      expect(mule.selectedBosses).toEqual([HARD_LUCID]);
+      expect(mule.partySizes).toEqual({ lucid: 3 });
+    });
+
+    it('applies Active Default when `active` is missing', () => {
+      const v3 = {
+        schemaVersion: 3,
+        mules: [
+          {
+            id: 'a',
+            name: 'V3',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [HARD_LUCID],
+          },
+        ],
+      };
+      expect(muleMigrate(JSON.stringify(v3))[0].active).toBe(true);
+    });
+
+    it('prunes unknown keys via MuleBossSlate.from', () => {
+      const v3 = {
+        schemaVersion: 3,
+        mules: [
+          {
+            id: 'a',
+            name: 'V3',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [HARD_LUCID, 'stale:id', 'another-stale'],
+          },
+        ],
+      };
+      expect(muleMigrate(JSON.stringify(v3))[0].selectedBosses).toEqual([HARD_LUCID]);
+    });
+
+    it('enforces one-winner-per-(bossId,cadence) via MuleBossSlate.from', () => {
+      // Both HARD_LUCID and NORMAL_LUCID land in the (lucid, weekly) bucket;
+      // the higher crystalValue key (HARD_LUCID) wins.
+      const v3 = {
+        schemaVersion: 3,
+        mules: [
+          {
+            id: 'a',
+            name: 'V3',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [NORMAL_LUCID, HARD_LUCID],
+          },
+        ],
+      };
+      expect(muleMigrate(JSON.stringify(v3))[0].selectedBosses).toEqual([HARD_LUCID]);
+    });
+  });
+
+  describe('schemaVersion 4 → identity round-trip', () => {
+    it('round-trips a canonical v4 payload', () => {
+      const mules: Mule[] = [
+        {
+          id: 'a',
+          name: 'Test',
+          level: 200,
+          muleClass: 'Hero',
+          selectedBosses: [HARD_LUCID, NORMAL_VELLUM_DAILY, CHAOS_VELLUM_WEEKLY],
+          partySizes: { lucid: 3 },
+          active: true,
+        },
+      ];
+      const raw = JSON.stringify({ schemaVersion: 4, mules });
+      expect(muleMigrate(raw)).toEqual(mules);
+    });
+
+    it('preserves active: false on a v4 payload', () => {
+      const v4 = {
+        schemaVersion: 4,
+        mules: [
+          {
+            id: 'a',
+            name: 'Inactive',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [HARD_LUCID],
+            partySizes: {},
+            active: false,
+          },
+        ],
+      };
+      expect(muleMigrate(JSON.stringify(v4))[0].active).toBe(false);
+    });
+
+    it('treats non-boolean `active` as missing and defaults to true', () => {
+      const v4 = {
+        schemaVersion: 4,
+        mules: [
+          {
+            id: 'a',
+            name: 'BadActive',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [HARD_LUCID],
+            active: 'yes',
+          },
+        ],
+      };
+      expect(muleMigrate(JSON.stringify(v4))[0].active).toBe(true);
+    });
+
+    it('rejects Legacy Slate Keys even on v4 payloads', () => {
+      const v4 = {
+        schemaVersion: 4,
+        mules: [
+          {
+            id: 'a',
+            name: 'Test',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [HARD_LUCID, LEGACY_HARD_LUCID],
+            partySizes: {},
+            active: true,
+          },
+        ],
+      };
+      expect(muleMigrate(JSON.stringify(v4))[0].selectedBosses).toEqual([HARD_LUCID]);
+    });
+  });
+
+  describe('unknown schemaVersion → Wipe (fail-safe)', () => {
+    it('wipes legacy selections when schemaVersion is 999', () => {
+      const future = {
+        schemaVersion: 999,
+        mules: [
+          {
+            id: 'a',
+            name: 'Future',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: ['hard-lucid'],
+          },
+        ],
+      };
+      const [mule] = muleMigrate(JSON.stringify(future));
+      expect(mule.selectedBosses).toEqual([]);
+    });
+
+    it('wipes when schemaVersion is missing', () => {
+      const missing = {
+        mules: [
+          {
+            id: 'a',
+            name: 'Missing',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: ['hard-lucid'],
+          },
+        ],
+      };
+      expect(muleMigrate(JSON.stringify(missing))[0].selectedBosses).toEqual([]);
+    });
+  });
+
+  describe('per-item validation', () => {
+    it('drops structurally invalid mules and keeps valid ones', () => {
+      const payload = {
+        schemaVersion: 3,
+        mules: [
+          {
+            id: 'valid',
+            name: 'Valid',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [HARD_LUCID],
+          },
+          { id: 123, name: 'BadId' },
+          { name: 'MissingId' },
+          { id: 'no-name', level: 200 },
+          {
+            id: 'bad-bosses',
+            name: 'BadBosses',
+            level: 1,
+            muleClass: 'A',
+            selectedBosses: 'not-an-array',
+          },
+          null,
+          'scalar',
+        ],
+      };
+      const mules = muleMigrate(JSON.stringify(payload));
+      expect(mules).toHaveLength(1);
+      expect(mules[0].id).toBe('valid');
+    });
+
+    it('sanitizes partySizes — drops non-number and non-finite entries', () => {
+      const v3 = {
+        schemaVersion: 3,
+        mules: [
+          {
+            id: 'a',
+            name: 'Test',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [],
+            partySizes: {
+              lucid: 3,
+              will: 'six',
+              gloom: Number.NaN,
+              vellum: Number.POSITIVE_INFINITY,
+              lotus: 4,
+            },
+          },
+        ],
+      };
+      expect(muleMigrate(JSON.stringify(v3))[0].partySizes).toEqual({
+        lucid: 3,
+        lotus: 4,
+      });
+    });
+
+    it('returns partySizes: {} when the field is absent', () => {
+      const v3 = {
+        schemaVersion: 3,
+        mules: [
+          {
+            id: 'a',
+            name: 'Test',
+            level: 200,
+            muleClass: 'Hero',
+            selectedBosses: [],
+          },
+        ],
+      };
+      expect(muleMigrate(JSON.stringify(v3))[0].partySizes).toEqual({});
+    });
+  });
+
+  describe('schema lineage constant', () => {
+    it('exports CURRENT_SCHEMA_VERSION = 4', () => {
+      // Sanity: guards against an accidental bump without test updates.
+      expect(CURRENT_SCHEMA_VERSION).toBe(4);
+    });
+  });
+
+  describe('purity — no React, no window, no storage APIs', () => {
+    it('never touches window.localStorage (sanity: running in jsdom by default)', () => {
+      // The migrator is a pure function; this is a smoke test that it
+      // never crashes even if storage is unavailable. We run it against
+      // a fixture and assert on the return value — no spy needed because
+      // touching `localStorage` inside the pure function would require
+      // an import we grep for separately in the acceptance criteria.
+      expect(muleMigrate('[]')).toEqual([]);
+      expect(muleMigrate(null)).toEqual([]);
+    });
+  });
+});

--- a/src/persistence/__tests__/muleStore.test.ts
+++ b/src/persistence/__tests__/muleStore.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { createMuleStore, type StoragePort } from '../muleStore';
+import { defaultStoragePort } from '../muleStorage';
+import { muleMigrate } from '../muleMigrate';
+import { bosses } from '../../data/bosses';
+import type { BossTier, Mule } from '../../types';
+
+/**
+ * Boundary tests for `createMuleStore(port?)`. Uses an in-memory
+ * `StoragePort` double for determinism; the default port
+ * (`defaultStoragePort`) is covered by a dedicated block at the bottom
+ * that drives it through `window.localStorage` / `window.sessionStorage`
+ * with spies.
+ */
+
+function makeFakePort(initial: string | null = null): StoragePort & {
+  writes: string[];
+} {
+  let current: string | null = initial;
+  const writes: string[] = [];
+  return {
+    read(): string | null {
+      return current;
+    },
+    write(data: string): void {
+      writes.push(data);
+      current = data;
+    },
+    writes,
+  };
+}
+
+function idForFamily(family: string): string {
+  const boss = bosses.find((b) => b.family === family);
+  if (!boss) throw new Error(`No boss found for family ${family}`);
+  return boss.id;
+}
+
+function nativeKey(bossId: string, tier: BossTier): string {
+  const boss = bosses.find((b) => b.id === bossId)!;
+  const diff = boss.difficulty.find((d) => d.tier === tier)!;
+  return `${bossId}:${tier}:${diff.cadence}`;
+}
+
+const LUCID = idForFamily('lucid');
+const HARD_LUCID = nativeKey(LUCID, 'hard');
+
+function muleFixture(overrides: Partial<Mule> = {}): Mule {
+  return {
+    id: 'a',
+    name: 'Test',
+    level: 200,
+    muleClass: 'Hero',
+    selectedBosses: [],
+    partySizes: {},
+    active: true,
+    ...overrides,
+  };
+}
+
+describe('createMuleStore', () => {
+  describe('load()', () => {
+    it('matches muleMigrate(port.read()) exactly', () => {
+      const payload = JSON.stringify({
+        schemaVersion: 4,
+        mules: [muleFixture({ selectedBosses: [HARD_LUCID] })],
+      });
+      const port = makeFakePort(payload);
+      const store = createMuleStore(port);
+      expect(store.load()).toEqual(muleMigrate(payload));
+    });
+
+    it('returns [] when the port yields null', () => {
+      const port = makeFakePort(null);
+      expect(createMuleStore(port).load()).toEqual([]);
+    });
+
+    it('returns [] on corrupt JSON', () => {
+      const port = makeFakePort('not json');
+      expect(createMuleStore(port).load()).toEqual([]);
+    });
+  });
+
+  describe('save() — debounced writes', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('does not write synchronously', () => {
+      const port = makeFakePort();
+      const store = createMuleStore(port);
+      store.save([muleFixture()]);
+      expect(port.writes).toHaveLength(0);
+    });
+
+    it('coalesces a burst of saves into a single write after 200ms', () => {
+      const port = makeFakePort();
+      const store = createMuleStore(port);
+      const m1 = muleFixture({ name: 'first' });
+      const m2 = muleFixture({ name: 'second' });
+      const m3 = muleFixture({ name: 'third' });
+      store.save([m1]);
+      store.save([m2]);
+      store.save([m3]);
+      expect(port.writes).toHaveLength(0);
+      vi.advanceTimersByTime(200);
+      expect(port.writes).toHaveLength(1);
+      const saved = JSON.parse(port.writes[0]);
+      expect(saved).toEqual({ schemaVersion: 4, mules: [m3] });
+    });
+
+    it('writes exactly once even when the debounce elapses from the last save', () => {
+      const port = makeFakePort();
+      const store = createMuleStore(port);
+      store.save([muleFixture({ name: 'a' })]);
+      vi.advanceTimersByTime(150);
+      // A fresh save restarts the debounce window.
+      store.save([muleFixture({ name: 'b' })]);
+      vi.advanceTimersByTime(150);
+      expect(port.writes).toHaveLength(0);
+      vi.advanceTimersByTime(60);
+      expect(port.writes).toHaveLength(1);
+      expect(JSON.parse(port.writes[0]).mules[0].name).toBe('b');
+    });
+
+    it('starts a fresh debounce after the previous one flushes', () => {
+      const port = makeFakePort();
+      const store = createMuleStore(port);
+      store.save([muleFixture({ name: 'first' })]);
+      vi.advanceTimersByTime(200);
+      expect(port.writes).toHaveLength(1);
+      store.save([muleFixture({ name: 'second' })]);
+      expect(port.writes).toHaveLength(1);
+      vi.advanceTimersByTime(200);
+      expect(port.writes).toHaveLength(2);
+      expect(JSON.parse(port.writes[1]).mules[0].name).toBe('second');
+    });
+
+    it('serializes as { schemaVersion: 4, mules }', () => {
+      const port = makeFakePort();
+      const store = createMuleStore(port);
+      const mules = [muleFixture({ selectedBosses: [HARD_LUCID] })];
+      store.save(mules);
+      vi.advanceTimersByTime(200);
+      const saved = JSON.parse(port.writes[0]);
+      expect(saved.schemaVersion).toBe(4);
+      expect(saved.mules).toEqual(mules);
+    });
+  });
+
+  describe('flush()', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('writes pending state immediately without waiting for the timer', () => {
+      const port = makeFakePort();
+      const store = createMuleStore(port);
+      store.save([muleFixture({ name: 'urgent' })]);
+      store.flush();
+      expect(port.writes).toHaveLength(1);
+      expect(JSON.parse(port.writes[0]).mules[0].name).toBe('urgent');
+    });
+
+    it('cancels the pending timer so no second write fires later', () => {
+      const port = makeFakePort();
+      const store = createMuleStore(port);
+      store.save([muleFixture({ name: 'urgent' })]);
+      store.flush();
+      vi.advanceTimersByTime(1000);
+      expect(port.writes).toHaveLength(1);
+    });
+
+    it('is a no-op when nothing is pending', () => {
+      const port = makeFakePort();
+      const store = createMuleStore(port);
+      store.flush();
+      expect(port.writes).toHaveLength(0);
+    });
+
+    it('is a no-op when called twice in a row (second flush has nothing pending)', () => {
+      const port = makeFakePort();
+      const store = createMuleStore(port);
+      store.save([muleFixture()]);
+      store.flush();
+      store.flush();
+      expect(port.writes).toHaveLength(1);
+    });
+  });
+
+  describe('instance isolation', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('each store owns its own pending/timer refs (no module-level state)', () => {
+      const portA = makeFakePort();
+      const portB = makeFakePort();
+      const storeA = createMuleStore(portA);
+      const storeB = createMuleStore(portB);
+      storeA.save([muleFixture({ name: 'from-a' })]);
+      storeB.save([muleFixture({ name: 'from-b' })]);
+      // Flushing storeA must not touch storeB's pending write.
+      storeA.flush();
+      expect(portA.writes).toHaveLength(1);
+      expect(portB.writes).toHaveLength(0);
+      vi.advanceTimersByTime(200);
+      expect(portB.writes).toHaveLength(1);
+      expect(JSON.parse(portB.writes[0]).mules[0].name).toBe('from-b');
+    });
+  });
+
+  describe('default port (no argument)', () => {
+    // Distinct jsdom-backed block — spies on window.localStorage to prove
+    // createMuleStore() without an arg binds to the Default Storage Port.
+    let localStorageStore: Record<string, string> = {};
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      localStorageStore = {};
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn((key: string) => localStorageStore[key] ?? null),
+        setItem: vi.fn((key: string, value: string) => {
+          localStorageStore[key] = value;
+        }),
+        removeItem: vi.fn((key: string) => {
+          delete localStorageStore[key];
+        }),
+        clear: vi.fn(() => {
+          localStorageStore = {};
+        }),
+        get length() {
+          return Object.keys(localStorageStore).length;
+        },
+        key: vi.fn((index: number) => Object.keys(localStorageStore)[index] ?? null),
+      });
+      vi.stubGlobal('sessionStorage', {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+        length: 0,
+        key: vi.fn(() => null),
+      });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    });
+
+    it('writes to localStorage under the expected storage key', () => {
+      const store = createMuleStore();
+      store.save([muleFixture({ name: 'default-port' })]);
+      vi.advanceTimersByTime(200);
+      expect(localStorage.setItem).toHaveBeenCalledTimes(1);
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'maplestory-mule-tracker',
+        expect.any(String),
+      );
+      const saved = JSON.parse(localStorageStore['maplestory-mule-tracker']);
+      expect(saved.mules[0].name).toBe('default-port');
+    });
+
+    it('reads via localStorage when load() is called', () => {
+      localStorageStore['maplestory-mule-tracker'] = JSON.stringify({
+        schemaVersion: 4,
+        mules: [muleFixture({ name: 'from-default-port' })],
+      });
+      const store = createMuleStore();
+      expect(store.load()[0].name).toBe('from-default-port');
+      expect(localStorage.getItem).toHaveBeenCalledWith('maplestory-mule-tracker');
+    });
+  });
+});
+
+describe('defaultStoragePort', () => {
+  // Direct coverage of the Storage Fallback Ladder — both directions.
+  let localStorageStore: Record<string, string> = {};
+  let sessionStorageStore: Record<string, string> = {};
+
+  beforeEach(() => {
+    localStorageStore = {};
+    sessionStorageStore = {};
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn((key: string) => localStorageStore[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        localStorageStore[key] = value;
+      }),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+      length: 0,
+      key: vi.fn(),
+    });
+    vi.stubGlobal('sessionStorage', {
+      getItem: vi.fn((key: string) => sessionStorageStore[key] ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        sessionStorageStore[key] = value;
+      }),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+      length: 0,
+      key: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('read() returns the localStorage value when present', () => {
+    localStorageStore['maplestory-mule-tracker'] = 'primary-payload';
+    expect(defaultStoragePort.read()).toBe('primary-payload');
+  });
+
+  it('read() falls through to sessionStorage when localStorage.getItem throws', () => {
+    vi.spyOn(localStorage, 'getItem').mockImplementation(() => {
+      throw new Error('boom');
+    });
+    sessionStorageStore['maplestory-mule-tracker-fallback'] = 'fallback-payload';
+    expect(defaultStoragePort.read()).toBe('fallback-payload');
+  });
+
+  it('read() falls through to sessionStorage when localStorage.getItem returns null', () => {
+    sessionStorageStore['maplestory-mule-tracker-fallback'] = 'fallback-payload';
+    expect(defaultStoragePort.read()).toBe('fallback-payload');
+  });
+
+  it('read() returns null when both storages return null', () => {
+    expect(defaultStoragePort.read()).toBeNull();
+  });
+
+  it('read() returns null when both storages throw', () => {
+    vi.spyOn(localStorage, 'getItem').mockImplementation(() => {
+      throw new Error('boom');
+    });
+    vi.spyOn(sessionStorage, 'getItem').mockImplementation(() => {
+      throw new Error('boom');
+    });
+    expect(defaultStoragePort.read()).toBeNull();
+  });
+
+  it('write() writes to localStorage on the happy path', () => {
+    defaultStoragePort.write('payload');
+    expect(localStorageStore['maplestory-mule-tracker']).toBe('payload');
+    // sessionStorage untouched when primary succeeds.
+    expect(sessionStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('write() falls through to sessionStorage when localStorage.setItem throws', () => {
+    vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+    });
+    defaultStoragePort.write('payload');
+    expect(sessionStorageStore['maplestory-mule-tracker-fallback']).toBe('payload');
+  });
+
+  it('write() swallows a second throw silently when both storages fail', () => {
+    vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+    });
+    vi.spyOn(sessionStorage, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+    });
+    expect(() => defaultStoragePort.write('payload')).not.toThrow();
+  });
+});

--- a/src/persistence/muleMigrate.ts
+++ b/src/persistence/muleMigrate.ts
@@ -1,0 +1,168 @@
+import type { BossTier, Mule } from '../types';
+import { getBossById } from '../data/bosses';
+import { MuleBossSlate } from '../data/muleBossSlate';
+
+/**
+ * Pure migration module for the **Persisted Root**. Owns the **Schema
+ * Lineage** (v1 → v4), **Load Mode** dispatch, `upgradeV2Key` cadence
+ * resolution, `validateMule`, and the **Active Default**. No React, no
+ * `window`, no `localStorage` — driven entirely by the raw string (or
+ * `null`) read out of a `StoragePort`. Corrupt JSON or `null` input
+ * returns `[]` (a **Wipe**).
+ */
+
+export const CURRENT_SCHEMA_VERSION = 4;
+
+/**
+ * Which migration path a given **Persisted Root** follows:
+ *
+ * - `wipe` — pre-1B bare array, unknown `schemaVersion`, or the payload is
+ *   tagged with a recognised version but the parser chose to fail-safe.
+ *   Legacy selection-key entries have their `selectedBosses` (and
+ *   `partySizes`) cleared to `[]` / `{}`.
+ * - `upgradeV2` — `schemaVersion === 2`. Each `<uuid>:<tier>` key is
+ *   resolved against the boss catalog and rewritten as
+ *   `<uuid>:<tier>:<cadence>`. Unresolvable entries drop silently.
+ * - `asIs` — `schemaVersion === 3 || 4`. Keys are already in the native
+ *   shape; `validateMule` still routes them through
+ *   `MuleBossSlate.from(...)` to enforce the **Selection Invariant** and
+ *   prune unknown / Legacy Slate Keys.
+ */
+export type LoadMode = 'wipe' | 'upgradeV2' | 'asIs';
+
+const LEGACY_ID_PREFIX = /^(extreme|hard|chaos|normal|easy)-/;
+
+/** A stored id looks legacy if it matches `<tier>-<family>` or lacks a colon. */
+function isLegacyId(id: string): boolean {
+  return LEGACY_ID_PREFIX.test(id) || !id.includes(':');
+}
+
+function readPartySizes(raw: unknown): Record<string, number> {
+  if (typeof raw !== 'object' || raw === null) return {};
+  const out: Record<string, number> = {};
+  for (const [family, n] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof n === 'number' && Number.isFinite(n)) out[family] = n;
+  }
+  return out;
+}
+
+/**
+ * Upgrade a single v2 `<uuid>:<tier>` **Slate Key** to the v3
+ * `<uuid>:<tier>:<cadence>` shape by resolving the **Boss Cadence** from
+ * the catalog. Returns `null` for unresolvable entries (unknown boss or
+ * tier no longer offered); the migrator drops those silently.
+ */
+function upgradeV2Key(key: string): string | null {
+  const colon = key.lastIndexOf(':');
+  if (colon < 0) return null;
+  const bossId = key.slice(0, colon);
+  const tier = key.slice(colon + 1) as BossTier;
+  const boss = getBossById(bossId);
+  if (!boss) return null;
+  const diff = boss.difficulty.find((d) => d.tier === tier);
+  if (!diff) return null;
+  // v3/v4 selection-key shape: `<uuid>:<tier>:<cadence>`. Built inline so
+  // this module doesn't reach into the slate module's private helpers —
+  // the key flows through `MuleBossSlate.from` immediately afterwards,
+  // which enforces the Selection Invariant.
+  return `${bossId}:${tier}:${diff.cadence}`;
+}
+
+function validateMule(raw: unknown, mode: LoadMode): Mule | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.id !== 'string') return null;
+  if (typeof obj.name !== 'string') return null;
+  if (typeof obj.level !== 'number') return null;
+  if (typeof obj.muleClass !== 'string') return null;
+  if (!Array.isArray(obj.selectedBosses)) return null;
+
+  const rawSelected = obj.selectedBosses as string[];
+  const wipe = mode === 'wipe' && rawSelected.some(isLegacyId);
+
+  let selectedBosses: string[];
+  if (wipe) {
+    selectedBosses = [];
+  } else if (mode === 'upgradeV2') {
+    // In-place upgrade of v2 `<uuid>:<tier>` keys. Unresolvable entries drop.
+    const upgraded: string[] = [];
+    for (const key of rawSelected) {
+      const next = upgradeV2Key(key);
+      if (next !== null) upgraded.push(next);
+    }
+    selectedBosses = [...MuleBossSlate.from(upgraded).keys];
+  } else {
+    selectedBosses = [...MuleBossSlate.from(rawSelected).keys];
+  }
+
+  return {
+    id: obj.id,
+    name: obj.name,
+    level: obj.level,
+    muleClass: obj.muleClass,
+    selectedBosses,
+    partySizes: wipe ? {} : readPartySizes(obj.partySizes),
+    // `active` lands in schemaVersion 4. Absent or non-boolean → default to
+    // `true` so pre-v4 payloads (and new mules added this slice) behave
+    // identically to the current app.
+    active: typeof obj.active === 'boolean' ? obj.active : true,
+  };
+}
+
+/** The persisted root shape after slice 1B. */
+interface PersistedRoot {
+  schemaVersion: number;
+  mules: Mule[];
+}
+
+/**
+ * Parse a persisted payload into `{ mules, mode }`. Returns `null` when
+ * the JSON is unusable (parse error or not a recognized shape). Mode
+ * controls downstream migration:
+ *
+ *  - `wipe` — pre-1B array shape / unknown `schemaVersion` → drop legacy
+ *    selections.
+ *  - `upgradeV2` — `schemaVersion === 2` → rewrite `<uuid>:<tier>` keys
+ *    to `<uuid>:<tier>:<cadence>` in place.
+ *  - `asIs` — `schemaVersion === 3 || 4` → keys already in native shape;
+ *    v3 gets the **Active Default** applied inside `validateMule`.
+ */
+function parsePayload(raw: string): { mules: unknown[]; mode: LoadMode } | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      // Pre-1B shape — root is bare array; always migrate.
+      return { mules: parsed, mode: 'wipe' };
+    }
+    if (typeof parsed === 'object' && parsed !== null) {
+      const root = parsed as Partial<PersistedRoot>;
+      if (Array.isArray(root.mules)) {
+        const mode: LoadMode =
+          root.schemaVersion === 4 || root.schemaVersion === 3
+            ? 'asIs'
+            : root.schemaVersion === 2
+              ? 'upgradeV2'
+              : 'wipe';
+        return { mules: root.mules, mode };
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pure entry point: turn a raw persisted string (or `null`) into a
+ * validated `Mule[]`. Any failure — `null` input, corrupt JSON,
+ * unrecognised shape — collapses to `[]` (a **Wipe**). Every caller
+ * reaches the migration pipeline through this function so the
+ * **Schema Lineage** is owned in one place.
+ */
+export function muleMigrate(raw: string | null): Mule[] {
+  if (raw === null) return [];
+  const payload = parsePayload(raw);
+  if (!payload) return [];
+  const validated = payload.mules.map((m) => validateMule(m, payload.mode));
+  return validated.filter((m): m is Mule => m !== null);
+}

--- a/src/persistence/muleStorage.ts
+++ b/src/persistence/muleStorage.ts
@@ -1,0 +1,50 @@
+import type { StoragePort } from './muleStore';
+
+/**
+ * **Default Storage Port** — binds the generic `StoragePort` interface to
+ * `window.localStorage` (primary) and `window.sessionStorage` (fallback).
+ * Implements the **Storage Fallback Ladder** on both read and write:
+ *
+ * - `read()` tries `localStorage.getItem`; if that throws or returns
+ *   `null`, it tries `sessionStorage.getItem`; returns `null` if both
+ *   fail.
+ * - `write(data)` tries `localStorage.setItem`; on throw (e.g.
+ *   `QuotaExceededError`), falls through to `sessionStorage.setItem`;
+ *   on a second throw it swallows silently (state still lives in React).
+ *
+ * The port deals only in raw strings — JSON (de)serialization happens in
+ * `muleStore.ts`, so tests that inject an in-memory port never touch
+ * JSON at all.
+ */
+
+const STORAGE_KEY = 'maplestory-mule-tracker';
+const FALLBACK_KEY = 'maplestory-mule-tracker-fallback';
+
+export const defaultStoragePort: StoragePort = {
+  read(): string | null {
+    try {
+      const data = localStorage.getItem(STORAGE_KEY);
+      if (data !== null) return data;
+    } catch {
+      // fall through to sessionStorage
+    }
+    try {
+      return sessionStorage.getItem(FALLBACK_KEY);
+    } catch {
+      return null;
+    }
+  },
+  write(data: string): void {
+    try {
+      localStorage.setItem(STORAGE_KEY, data);
+      return;
+    } catch {
+      // fall through to sessionStorage
+    }
+    try {
+      sessionStorage.setItem(FALLBACK_KEY, data);
+    } catch {
+      // Both storages failed; data persists in React state only.
+    }
+  },
+};

--- a/src/persistence/muleStore.ts
+++ b/src/persistence/muleStore.ts
@@ -1,0 +1,73 @@
+import type { Mule } from '../types';
+import { CURRENT_SCHEMA_VERSION, muleMigrate } from './muleMigrate';
+import { defaultStoragePort } from './muleStorage';
+
+/**
+ * `StoragePort` — the narrow outbound seam every `MuleStore` writes
+ * through. Two primitives: `read()` returns the raw persisted string (or
+ * `null` when nothing is stored / storage failed), `write(data)`
+ * persists the raw string. JSON (de)serialization and the **Schema
+ * Lineage** live above the port; the port itself knows nothing about
+ * **Mules**.
+ */
+export interface StoragePort {
+  read(): string | null;
+  write(data: string): void;
+}
+
+/**
+ * `MuleStore` — the persistence facade consumed by `useMules`. `load()`
+ * stays synchronous so it can initialize `useState`; `save(mules)` is
+ * coalesced over a 200ms **Storage Debounce**; `flush()` forces any
+ * pending write to land immediately (used on `pagehide` /
+ * `beforeunload`).
+ */
+export interface MuleStore {
+  load(): Mule[];
+  save(mules: Mule[]): void;
+  flush(): void;
+}
+
+/**
+ * Debounce window for **Storage Debounce**. 200ms coalesces keystroke
+ * bursts in drawer inputs into a single `port.write` without making the
+ * save-on-blur flow feel laggy.
+ */
+const STORAGE_DEBOUNCE_MS = 200;
+
+function serialize(mules: Mule[]): string {
+  return JSON.stringify({ schemaVersion: CURRENT_SCHEMA_VERSION, mules });
+}
+
+/**
+ * Build a `MuleStore` bound to `port` (defaults to the **Default Storage
+ * Port**). Each call produces an independent store with its own
+ * closure-local `pending` + `timer` refs — no module-level state — so
+ * tests can spin up many isolated stores in the same process.
+ */
+export function createMuleStore(port: StoragePort = defaultStoragePort): MuleStore {
+  let pending: Mule[] | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function drain(): void {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    const snapshot = pending;
+    pending = null;
+    if (snapshot !== null) port.write(serialize(snapshot));
+  }
+
+  return {
+    load(): Mule[] {
+      return muleMigrate(port.read());
+    },
+    save(mules: Mule[]): void {
+      pending = mules;
+      if (timer !== null) clearTimeout(timer);
+      timer = setTimeout(drain, STORAGE_DEBOUNCE_MS);
+    },
+    flush: drain,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `src/persistence/{muleMigrate,muleStorage,muleStore}.ts` alongside the existing `useMules.ts` hook (which stays live for this slice). Migrator is pure (`(raw: string | null) => Mule[]`) and owns the Schema Lineage, Load Mode dispatch, `upgradeV2Key` cadence resolution, `validateMule`, and the Active Default. Default storage port binds to `localStorage` + `sessionStorage` via the Storage Fallback Ladder.
- `createMuleStore(port?)` wires a 200ms Storage Debounce with closure-local `pending`/`timer` refs — no module-level state — so each store instance is independent.
- Ships 48 boundary tests across two files covering every migration branch (null/corrupt/v1/v2/v3/v4/unknown-version), debounce coalescing, `flush()` semantics, instance isolation, and the default port's fallback ladder on both read and write.

## Test plan
- [x] `npm test` — 604 passing (3 unrelated pre-existing failures in `MuleDetailDrawer` are on main)
- [x] `npx tsc -b` — no new errors (pre-existing unrelated type errors on main)
- [x] `npx eslint src/persistence` — clean
- [x] `muleMigrate.ts` verified pure — grep for `react|window|localStorage|sessionStorage` returns only a doc comment mention
- [x] `src/hooks/useMules.ts` is unchanged; no consumer imports from `src/persistence/`

Closes #185