### PR TITLE
Extract identity-draft hooks + fix drawer close-drops-drafts bug

### DIFF
--- a/src/components/MuleDetailDrawer.tsx
+++ b/src/components/MuleDetailDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { Trash2, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -22,9 +22,9 @@ import {
   removePreset,
 } from '../data/bossPresets';
 import blankCharacterPng from '../assets/blank-character.png';
-import { sanitizeMuleName } from '../utils/muleName';
 import { ClassAutocomplete } from './ClassAutocomplete';
 import { GMS_CLASSES } from '../constants/classes';
+import { useMuleIdentityDraft } from './MuleDetailDrawer/hooks/useMuleIdentityDraft';
 
 const PRESET_KEYS: readonly PresetKey[] = ['CRA', 'LOMIEN', 'CTENE'];
 
@@ -59,51 +59,24 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
   // show potential income regardless of active state.
   const { formatted: potentialIncome } = useIncome({ selectedBosses: mule?.selectedBosses ?? [] });
 
-  // Drafts prevent per-keystroke setMules from re-rendering the pie chart and
-  // roster cards; commits on blur/select instead.
-  const [draftName, setDraftName] = useState(mule?.name ?? '');
-  const [draftLevel, setDraftLevel] = useState(mule?.level ? String(mule.level) : '');
+  // Identity draft pairs name + level with a single Commit On Exit so Mule
+  // Switch AND Drawer Close (Esc/backdrop) both flush unblurred edits.
+  const identity = useMuleIdentityDraft(mule, onUpdate);
+  const draftName = identity.name.draft;
+  const levelDisplay = identity.level.displayNumber;
 
-  const draftsRef = useRef({ name: draftName, level: draftLevel });
-  draftsRef.current = { name: draftName, level: draftLevel };
-  const lastMuleIdRef = useRef<string | null>(mule?.id ?? null);
-  // Ref so the mule-switch effect depends only on mule?.id, not onUpdate.
-  const onUpdateRef = useRef(onUpdate);
-  onUpdateRef.current = onUpdate;
-
-  useEffect(() => {
+  // Ambient UI state (delete confirm, search, filter) resets on Mule Switch.
+  // Use the "reset state on prop change" pattern — track the last mule id in
+  // state and reset during render when it flips. Keeps this side-effect out
+  // of `useEffect` so set-state-in-effect lint passes, and renders the
+  // resets synchronously before the first paint on the new mule.
+  const [lastMuleId, setLastMuleId] = useState<string | null>(mule?.id ?? null);
+  if (lastMuleId !== (mule?.id ?? null)) {
+    setLastMuleId(mule?.id ?? null);
     setConfirmDelete(false);
     setSearch('');
     setFilter('All');
-
-    const prevId = lastMuleIdRef.current;
-    const nextId = mule?.id ?? null;
-    // Flush drafts on switch/close — Esc and backdrop also route here since
-    // selectedMule derives from mule id.
-    if (prevId && prevId !== nextId) {
-      const { name, level } = draftsRef.current;
-      onUpdateRef.current(prevId, { name, level: Number(level) || 0 });
-    }
-    setDraftName(mule?.name ?? '');
-    setDraftLevel(mule?.level ? String(mule.level) : '');
-    lastMuleIdRef.current = nextId;
-  }, [mule?.id]);
-
-  const commitName = useCallback(() => {
-    if (mule && draftName !== mule.name) onUpdate(mule.id, { name: draftName });
-  }, [mule, draftName, onUpdate]);
-  const commitLevel = useCallback(() => {
-    if (!mule) return;
-    if (draftLevel === '') {
-      if (mule.level !== 0) onUpdate(mule.id, { level: 0 });
-      return;
-    }
-    const clamped = Math.min(300, Math.max(1, Number(draftLevel)));
-    if (String(clamped) !== draftLevel) setDraftLevel(String(clamped));
-    if (clamped !== mule.level) onUpdate(mule.id, { level: clamped });
-  }, [mule, draftLevel, onUpdate]);
-
-  const levelDisplay = Number(draftLevel) || 0;
+  }
 
   const selectedBosses = useMemo(
     () => mule?.selectedBosses ?? [],
@@ -329,10 +302,10 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
                   <Input
                     id="mule-name"
                     placeholder="Enter name"
-                    value={draftName}
+                    value={identity.name.draft}
                     maxLength={12}
-                    onChange={(e) => setDraftName(sanitizeMuleName(e.currentTarget.value))}
-                    onBlur={commitName}
+                    onChange={identity.name.onChange}
+                    onBlur={identity.name.onBlur}
                     className="bg-[var(--surface-2)] border-border/60 focus-visible:border-[var(--accent-raw,var(--accent))]/60 focus-visible:ring-1 focus-visible:ring-[var(--ring)]/20 placeholder:opacity-60 placeholder:text-xs placeholder:italic"
                   />
                 </div>
@@ -360,13 +333,9 @@ export function MuleDetailDrawer({ mule, open, onClose, onUpdate, onDelete }: Mu
                       type="text"
                       inputMode="numeric"
                       placeholder="0"
-                      value={draftLevel}
-                      onChange={(e) =>
-                        setDraftLevel(
-                          e.currentTarget.value.replace(/\D/g, '').slice(0, 3),
-                        )
-                      }
-                      onBlur={commitLevel}
+                      value={identity.level.draft}
+                      onChange={identity.level.onChange}
+                      onBlur={identity.level.onBlur}
                       className="bg-[var(--surface-2)] border-border/60 focus-visible:border-[var(--accent-raw,var(--accent))]/60 focus-visible:ring-1 focus-visible:ring-[var(--ring)]/20 font-mono-nums placeholder:opacity-60 placeholder:text-xs placeholder:italic"
                     />
                   </div>

--- a/src/components/MuleDetailDrawer/hooks/__tests__/useCommitOnExit.test.tsx
+++ b/src/components/MuleDetailDrawer/hooks/__tests__/useCommitOnExit.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+import { useCommitOnExit } from '../useCommitOnExit'
+
+type IdentityDrafts = { name: string; level: number }
+
+describe('useCommitOnExit', () => {
+  it('does NOT flush on initial mount', () => {
+    const commit = vi.fn()
+    renderHook(() =>
+      useCommitOnExit<IdentityDrafts>('mule-1', { name: 'A', level: 10 }, commit),
+    )
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('flushes previous muleId drafts on Mule Switch', () => {
+    const commit = vi.fn()
+    const { rerender } = renderHook(
+      ({
+        muleId,
+        drafts,
+      }: {
+        muleId: string | null
+        drafts: IdentityDrafts
+      }) => useCommitOnExit(muleId, drafts, commit),
+      { initialProps: { muleId: 'mule-1' as string | null, drafts: { name: 'Alpha', level: 10 } } },
+    )
+
+    // No flush on initial mount.
+    expect(commit).not.toHaveBeenCalled()
+
+    rerender({
+      muleId: 'mule-2',
+      drafts: { name: 'Beta', level: 20 },
+    })
+
+    // Must flush previous mule (mule-1) with its last-seen drafts.
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(commit).toHaveBeenCalledWith('mule-1', { name: 'Alpha', level: 10 })
+  })
+
+  it('flushes current muleId drafts on unmount (Drawer Close)', () => {
+    const commit = vi.fn()
+    const { unmount, rerender } = renderHook(
+      ({ drafts }: { drafts: IdentityDrafts }) =>
+        useCommitOnExit('mule-1', drafts, commit),
+      { initialProps: { drafts: { name: 'Alpha', level: 10 } } },
+    )
+
+    // Edit then unmount — should flush the latest drafts.
+    rerender({ drafts: { name: 'AlphaEdit', level: 15 } })
+    unmount()
+
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(commit).toHaveBeenCalledWith('mule-1', { name: 'AlphaEdit', level: 15 })
+  })
+
+  it('no-op when muleId is null on mount (no flush, no error)', () => {
+    const commit = vi.fn()
+    const { unmount } = renderHook(() =>
+      useCommitOnExit<IdentityDrafts>(null, { name: '', level: 0 }, commit),
+    )
+    unmount()
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('no-op on unmount when current muleId is null', () => {
+    const commit = vi.fn()
+    const { rerender, unmount } = renderHook(
+      ({ muleId }: { muleId: string | null }) =>
+        useCommitOnExit<IdentityDrafts>(muleId, { name: 'A', level: 1 }, commit),
+      { initialProps: { muleId: 'mule-1' as string | null } },
+    )
+
+    // Switch to null — previous mule should flush, then unmount is a no-op.
+    rerender({ muleId: null })
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(commit).toHaveBeenCalledWith('mule-1', { name: 'A', level: 1 })
+
+    commit.mockClear()
+    unmount()
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('uses latest drafts at the moment of Mule Switch, not drafts at prior render', () => {
+    const commit = vi.fn()
+    const { rerender } = renderHook(
+      ({
+        muleId,
+        drafts,
+      }: {
+        muleId: string
+        drafts: IdentityDrafts
+      }) => useCommitOnExit(muleId, drafts, commit),
+      { initialProps: { muleId: 'mule-1', drafts: { name: 'A', level: 1 } } },
+    )
+
+    // User edits drafts several times before switching.
+    rerender({ muleId: 'mule-1', drafts: { name: 'AA', level: 2 } })
+    rerender({ muleId: 'mule-1', drafts: { name: 'AAA', level: 3 } })
+    expect(commit).not.toHaveBeenCalled()
+
+    rerender({ muleId: 'mule-2', drafts: { name: 'B', level: 10 } })
+
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(commit).toHaveBeenCalledWith('mule-1', { name: 'AAA', level: 3 })
+  })
+
+  it('uses the latest commit callback reference on unmount', () => {
+    const firstCommit = vi.fn()
+    const secondCommit = vi.fn()
+    const { rerender, unmount } = renderHook(
+      ({ commit }: { commit: typeof firstCommit }) =>
+        useCommitOnExit<IdentityDrafts>('mule-1', { name: 'A', level: 1 }, commit),
+      { initialProps: { commit: firstCommit } },
+    )
+
+    rerender({ commit: secondCommit })
+    unmount()
+
+    expect(firstCommit).not.toHaveBeenCalled()
+    expect(secondCommit).toHaveBeenCalledTimes(1)
+    expect(secondCommit).toHaveBeenCalledWith('mule-1', { name: 'A', level: 1 })
+  })
+})

--- a/src/components/MuleDetailDrawer/hooks/__tests__/useDraftField.test.tsx
+++ b/src/components/MuleDetailDrawer/hooks/__tests__/useDraftField.test.tsx
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+import { useDraftField } from '../useDraftField'
+
+describe('useDraftField', () => {
+  it('initializes draft to source', () => {
+    const commit = vi.fn()
+    const { result } = renderHook(() => useDraftField('initial', commit))
+    expect(result.current.draft).toBe('initial')
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('setDraft updates draft without calling commit', () => {
+    const commit = vi.fn()
+    const { result } = renderHook(() => useDraftField<string>('initial', commit))
+
+    act(() => {
+      result.current.setDraft('edited')
+    })
+
+    expect(result.current.draft).toBe('edited')
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('onBlur calls commit(draft) when draft !== source', () => {
+    const commit = vi.fn()
+    const { result } = renderHook(() => useDraftField<string>('initial', commit))
+
+    act(() => {
+      result.current.setDraft('edited')
+    })
+    act(() => {
+      result.current.onBlur()
+    })
+
+    expect(commit).toHaveBeenCalledWith('edited')
+    expect(commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('onBlur does not call commit when draft === source (equality short-circuit)', () => {
+    const commit = vi.fn()
+    const { result } = renderHook(() => useDraftField('initial', commit))
+
+    act(() => {
+      result.current.onBlur()
+    })
+
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('external source change resyncs draft when not equal', () => {
+    const commit = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ source }: { source: string }) => useDraftField(source, commit),
+      { initialProps: { source: 'a' } },
+    )
+
+    expect(result.current.draft).toBe('a')
+
+    rerender({ source: 'b' })
+
+    expect(result.current.draft).toBe('b')
+  })
+
+  it('external source resync does NOT call commit', () => {
+    const commit = vi.fn()
+    const { rerender } = renderHook(
+      ({ source }: { source: string }) => useDraftField(source, commit),
+      { initialProps: { source: 'a' } },
+    )
+
+    rerender({ source: 'b' })
+
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('parse adapter converts string draft to numeric commit', () => {
+    const commit = vi.fn()
+    const { result } = renderHook(() =>
+      useDraftField<number>(42, commit, {
+        parse: (raw) => Number(raw) || 0,
+      }),
+    )
+
+    act(() => {
+      // setDraft receives the parsed form in this contract; onChange handles string input.
+      result.current.onChange({
+        currentTarget: { value: '100' },
+      } as React.ChangeEvent<HTMLInputElement>)
+    })
+    act(() => {
+      result.current.onBlur()
+    })
+
+    expect(commit).toHaveBeenCalledWith(100)
+  })
+
+  it('onChange updates draft with raw input value when no parse adapter', () => {
+    const commit = vi.fn()
+    const { result } = renderHook(() => useDraftField('', commit))
+
+    act(() => {
+      result.current.onChange({
+        currentTarget: { value: 'hello' },
+      } as React.ChangeEvent<HTMLInputElement>)
+    })
+
+    expect(result.current.draft).toBe('hello')
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('custom equals prevents commit when drafts are equal by the custom predicate', () => {
+    const commit = vi.fn()
+    const { result } = renderHook(() =>
+      useDraftField<string>('A', commit, {
+        equals: (a, b) => a.toLowerCase() === b.toLowerCase(),
+      }),
+    )
+
+    act(() => {
+      result.current.setDraft('a')
+    })
+    act(() => {
+      result.current.onBlur()
+    })
+
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('does NOT resync draft when external source equals draft by equals predicate', () => {
+    const commit = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ source }: { source: string }) =>
+        useDraftField(source, commit, {
+          equals: (a, b) => a.toLowerCase() === b.toLowerCase(),
+        }),
+      { initialProps: { source: 'a' } },
+    )
+
+    act(() => {
+      result.current.setDraft('a')
+    })
+
+    rerender({ source: 'A' })
+
+    // Since 'a' and 'A' are equal by our predicate, draft should stay 'a'.
+    expect(result.current.draft).toBe('a')
+  })
+})

--- a/src/components/MuleDetailDrawer/hooks/__tests__/useMuleIdentityDraft.test.tsx
+++ b/src/components/MuleDetailDrawer/hooks/__tests__/useMuleIdentityDraft.test.tsx
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+
+import { useMuleIdentityDraft } from '../useMuleIdentityDraft'
+import type { Mule } from '../../../../types'
+
+const baseMule: Mule = {
+  id: 'mule-1',
+  name: 'Alpha',
+  level: 200,
+  muleClass: 'Hero',
+  selectedBosses: [],
+  active: true,
+}
+
+function makeOnChange(value: string): React.ChangeEvent<HTMLInputElement> {
+  return { currentTarget: { value } } as React.ChangeEvent<HTMLInputElement>
+}
+
+describe('useMuleIdentityDraft', () => {
+  it('seeds name and level drafts from the mule', () => {
+    const onUpdate = vi.fn()
+    const { result } = renderHook(() => useMuleIdentityDraft(baseMule, onUpdate))
+
+    expect(result.current.name.draft).toBe('Alpha')
+    expect(result.current.level.draft).toBe('200')
+    expect(result.current.level.displayNumber).toBe(200)
+  })
+
+  it('seeds empty drafts when mule is null', () => {
+    const onUpdate = vi.fn()
+    const { result } = renderHook(() => useMuleIdentityDraft(null, onUpdate))
+    expect(result.current.name.draft).toBe('')
+    expect(result.current.level.draft).toBe('')
+    expect(result.current.level.displayNumber).toBe(0)
+  })
+
+  it('sanitizes name input on change (strips non-letters, caps at 12)', () => {
+    const onUpdate = vi.fn()
+    const { result } = renderHook(() => useMuleIdentityDraft(baseMule, vi.fn()))
+    void onUpdate
+
+    act(() => {
+      result.current.name.onChange(makeOnChange('Hero123!WorldTooLong'))
+    })
+
+    expect(result.current.name.draft).toBe('HeroWorldToo')
+  })
+
+  it('name onBlur commits sanitized value via onUpdate when changed', () => {
+    const onUpdate = vi.fn()
+    const { result } = renderHook(() => useMuleIdentityDraft(baseMule, onUpdate))
+
+    act(() => {
+      result.current.name.onChange(makeOnChange('NewName'))
+    })
+    act(() => {
+      result.current.name.onBlur()
+    })
+
+    expect(onUpdate).toHaveBeenCalledWith('mule-1', { name: 'NewName' })
+  })
+
+  it('name onBlur is a no-op when draft equals committed name', () => {
+    const onUpdate = vi.fn()
+    const { result } = renderHook(() => useMuleIdentityDraft(baseMule, onUpdate))
+    act(() => {
+      result.current.name.onBlur()
+    })
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it('strips non-digits from level input', () => {
+    const { result } = renderHook(() => useMuleIdentityDraft(baseMule, vi.fn()))
+
+    act(() => {
+      result.current.level.onChange(makeOnChange('1a2'))
+    })
+
+    expect(result.current.level.draft).toBe('12')
+  })
+
+  it('caps level input at 3 digits', () => {
+    const { result } = renderHook(() => useMuleIdentityDraft(baseMule, vi.fn()))
+
+    act(() => {
+      result.current.level.onChange(makeOnChange('12345'))
+    })
+
+    expect(result.current.level.draft).toBe('123')
+  })
+
+  it('level onBlur clamps >300 to 300', () => {
+    const onUpdate = vi.fn()
+    const { result } = renderHook(() => useMuleIdentityDraft(baseMule, onUpdate))
+
+    act(() => {
+      result.current.level.onChange(makeOnChange('500'))
+    })
+    act(() => {
+      result.current.level.onBlur()
+    })
+
+    expect(result.current.level.draft).toBe('300')
+    expect(onUpdate).toHaveBeenCalledWith('mule-1', { level: 300 })
+  })
+
+  it('level onBlur clamps 0 to 1 when a non-empty zero is entered', () => {
+    const onUpdate = vi.fn()
+    const { result } = renderHook(() => useMuleIdentityDraft(baseMule, onUpdate))
+
+    act(() => {
+      result.current.level.onChange(makeOnChange('0'))
+    })
+    act(() => {
+      result.current.level.onBlur()
+    })
+
+    expect(result.current.level.draft).toBe('1')
+    expect(onUpdate).toHaveBeenCalledWith('mule-1', { level: 1 })
+  })
+
+  it('level onBlur commits 0 when the field is emptied', () => {
+    const onUpdate = vi.fn()
+    const { result } = renderHook(() => useMuleIdentityDraft(baseMule, onUpdate))
+
+    act(() => {
+      result.current.level.onChange(makeOnChange(''))
+    })
+    act(() => {
+      result.current.level.onBlur()
+    })
+
+    expect(onUpdate).toHaveBeenCalledWith('mule-1', { level: 0 })
+  })
+
+  it('level onBlur is a no-op when draft matches committed level', () => {
+    const onUpdate = vi.fn()
+    const { result } = renderHook(() => useMuleIdentityDraft(baseMule, onUpdate))
+    act(() => {
+      result.current.level.onBlur()
+    })
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it('flushes both name and level on Mule Switch', () => {
+    const onUpdate = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ mule }: { mule: Mule | null }) => useMuleIdentityDraft(mule, onUpdate),
+      { initialProps: { mule: baseMule as Mule | null } },
+    )
+
+    // Edit both without blurring.
+    act(() => {
+      result.current.name.onChange(makeOnChange('Edited'))
+    })
+    act(() => {
+      result.current.level.onChange(makeOnChange('150'))
+    })
+
+    const otherMule: Mule = { ...baseMule, id: 'mule-2', name: 'Beta', level: 100 }
+    rerender({ mule: otherMule })
+
+    // The hook should have flushed mule-1's drafts at switch time.
+    expect(onUpdate).toHaveBeenCalledWith('mule-1', { name: 'Edited', level: 150 })
+  })
+
+  it('flushes both name and level on unmount (Drawer Close)', () => {
+    const onUpdate = vi.fn()
+    const { result, unmount } = renderHook(() =>
+      useMuleIdentityDraft(baseMule, onUpdate),
+    )
+
+    act(() => {
+      result.current.name.onChange(makeOnChange('Closed'))
+    })
+    act(() => {
+      result.current.level.onChange(makeOnChange('77'))
+    })
+
+    unmount()
+
+    expect(onUpdate).toHaveBeenCalledWith('mule-1', { name: 'Closed', level: 77 })
+  })
+
+  it('does NOT flush on initial mount', () => {
+    const onUpdate = vi.fn()
+    renderHook(() => useMuleIdentityDraft(baseMule, onUpdate))
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it('resyncs drafts when mule prop changes externally', () => {
+    const onUpdate = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ mule }: { mule: Mule }) => useMuleIdentityDraft(mule, onUpdate),
+      { initialProps: { mule: baseMule } },
+    )
+
+    const edited: Mule = { ...baseMule, id: 'mule-2', name: 'Beta', level: 77 }
+    rerender({ mule: edited })
+
+    expect(result.current.name.draft).toBe('Beta')
+    expect(result.current.level.draft).toBe('77')
+  })
+
+  it('displayNumber reflects live draft for the hero tag', () => {
+    const { result } = renderHook(() => useMuleIdentityDraft(baseMule, vi.fn()))
+    act(() => {
+      result.current.level.onChange(makeOnChange('250'))
+    })
+    expect(result.current.level.displayNumber).toBe(250)
+  })
+
+  it('displayNumber is 0 when draft is empty', () => {
+    const { result } = renderHook(() => useMuleIdentityDraft(baseMule, vi.fn()))
+    act(() => {
+      result.current.level.onChange(makeOnChange(''))
+    })
+    expect(result.current.level.displayNumber).toBe(0)
+  })
+})

--- a/src/components/MuleDetailDrawer/hooks/useCommitOnExit.ts
+++ b/src/components/MuleDetailDrawer/hooks/useCommitOnExit.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Commit On Exit: flushes pending drafts on TWO boundaries —
+ *
+ *  1. Mule Switch: when `muleId` changes from A → B, flush A's drafts before
+ *     B takes over.
+ *  2. Drawer Close: when the hook unmounts, flush the current mule's drafts.
+ *
+ * Initial mount is suppressed so opening the drawer does not emit a spurious
+ * `commit(id, {})`.
+ *
+ * Callers pass their live `drafts` object every render; the hook keeps a
+ * ref pointing at the drafts associated with the most recent `muleId` so a
+ * Mule Switch (muleId changes) flushes the PREVIOUS mule's drafts — even
+ * when the caller has already rebased its local state to the next mule in
+ * the same render. Same ref-dance for `commit` so the unmount cleanup uses
+ * the latest caller.
+ *
+ * Closes the Esc/backdrop drop-drafts bug that lived in the drawer's
+ * `useEffect([mule?.id])` — that effect only flushed on switch, so closing
+ * the drawer via Esc or backdrop click silently dropped unblurred edits.
+ */
+export function useCommitOnExit<D extends Record<string, unknown>>(
+  muleId: string | null,
+  drafts: D,
+  commit: (id: string, patch: Partial<D>) => void,
+): void {
+  // `drafts` we saw during the render that owned `muleId`. When `muleId`
+  // changes, `drafts` may already have rebased to the new mule's seed — so
+  // we capture the previous drafts here, BEFORE updating on the next line.
+  const prevDraftsForMuleRef = useRef(drafts);
+  const muleIdRef = useRef<string | null>(muleId);
+
+  // If muleId is unchanged since last render, track the latest drafts for
+  // the current mule. If muleId *did* change, freeze prevDraftsForMuleRef
+  // at the last-seen drafts for the previous mule — the effect below will
+  // flush with that snapshot.
+  const muleSwitched = muleIdRef.current !== muleId;
+  if (!muleSwitched) {
+    prevDraftsForMuleRef.current = drafts;
+  }
+
+  const commitRef = useRef(commit);
+  commitRef.current = commit;
+
+  useEffect(() => {
+    const prevId = muleIdRef.current;
+    if (prevId !== null && prevId !== muleId) {
+      commitRef.current(prevId, prevDraftsForMuleRef.current);
+    }
+    // After the flush, drafts for the current (new) mule take over.
+    prevDraftsForMuleRef.current = drafts;
+    muleIdRef.current = muleId;
+    // Intentionally depend only on muleId: draft changes that don't flip
+    // muleId must not re-run this effect, or we'd flush every keystroke.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [muleId]);
+
+  // Unmount-only cleanup. Reads the latest muleId + drafts via refs.
+  useEffect(() => {
+    return () => {
+      const id = muleIdRef.current;
+      if (id !== null) {
+        commitRef.current(id, prevDraftsForMuleRef.current);
+      }
+    };
+  }, []);
+}

--- a/src/components/MuleDetailDrawer/hooks/useDraftField.ts
+++ b/src/components/MuleDetailDrawer/hooks/useDraftField.ts
@@ -1,0 +1,62 @@
+import { useCallback, useState, type ChangeEvent } from 'react';
+
+/**
+ * Generic Draft Field primitive. Holds a local `draft` state that diverges
+ * from the authoritative `source` until the user blurs; then `commit(draft)`
+ * is called iff `!equals(draft, source)`. An external `source` change
+ * (Draft Source Resync) rebases `draft` when it no longer matches source.
+ *
+ * The Draft-Commit split is what lets the roster pie chart and cards stay
+ * still while the user types in the drawer — per-keystroke `setMules` would
+ * thrash the whole tree.
+ */
+export function useDraftField<T>(
+  source: T,
+  commit: (v: T) => void,
+  opts?: {
+    parse?: (raw: string) => T;
+    equals?: (a: T, b: T) => boolean;
+  },
+): {
+  draft: T;
+  setDraft: (v: T) => void;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onBlur: () => void;
+} {
+  const equals = opts?.equals ?? defaultEquals<T>;
+  const parse = opts?.parse;
+
+  const [draft, setDraft] = useState<T>(source);
+  // Track the last-seen `source` as state so React's official
+  // "reset state when a prop changes" pattern applies: compare in render,
+  // call setState during render, React discards and reruns with the fresh
+  // value. No refs during render.
+  const [lastSource, setLastSource] = useState<T>(source);
+  if (!equals(lastSource, source)) {
+    setLastSource(source);
+    if (!equals(draft, source)) {
+      setDraft(source);
+    }
+  }
+
+  const onChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const raw = e.currentTarget.value;
+      const next = parse ? parse(raw) : (raw as unknown as T);
+      setDraft(next);
+    },
+    [parse],
+  );
+
+  const onBlur = useCallback(() => {
+    if (!equals(draft, source)) {
+      commit(draft);
+    }
+  }, [draft, source, commit, equals]);
+
+  return { draft, setDraft, onChange, onBlur };
+}
+
+function defaultEquals<T>(a: T, b: T): boolean {
+  return Object.is(a, b);
+}

--- a/src/components/MuleDetailDrawer/hooks/useMuleIdentityDraft.ts
+++ b/src/components/MuleDetailDrawer/hooks/useMuleIdentityDraft.ts
@@ -1,0 +1,111 @@
+import { useCallback, type ChangeEvent } from 'react';
+import type { Mule } from '../../../types';
+import { sanitizeMuleName } from '../../../utils/muleName';
+import { useDraftField } from './useDraftField';
+import { useCommitOnExit } from './useCommitOnExit';
+
+const LEVEL_MAX = 300;
+const LEVEL_MIN_NONZERO = 1;
+
+/** Clamp a non-empty level string to [1, 300]; empty string maps to 0. */
+function clampLevel(raw: string): number {
+  if (raw === '') return 0;
+  return Math.min(LEVEL_MAX, Math.max(LEVEL_MIN_NONZERO, Number(raw)));
+}
+
+/**
+ * Mule Identity Draft: pairs name + level Draft Fields with a single
+ * Commit On Exit so callers cannot forget the pairing. Owns the name
+ * sanitizer, Level Clamp 0–300, and digit-only input stripping.
+ *
+ * Level is held as a string draft (the `<input type="text" inputMode="numeric">`
+ * lets users briefly type "500" before the blur clamps it to 300). Commit
+ * converts the string to a clamped number and mirrors the clamp back into
+ * the draft so the input visibly reflects the clamp before the parent's
+ * mule prop re-renders.
+ */
+export function useMuleIdentityDraft(
+  mule: Mule | null,
+  onUpdate: (id: string, patch: Partial<Omit<Mule, 'id'>>) => void,
+): {
+  name: {
+    draft: string;
+    onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+    onBlur: () => void;
+  };
+  level: {
+    draft: string;
+    displayNumber: number;
+    onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+    onBlur: () => void;
+  };
+} {
+  const muleId = mule?.id ?? null;
+  const sourceName = mule?.name ?? '';
+  const sourceLevelStr = mule?.level ? String(mule.level) : '';
+
+  const commitName = useCallback(
+    (v: string) => {
+      if (muleId) onUpdate(muleId, { name: v });
+    },
+    [muleId, onUpdate],
+  );
+
+  const name = useDraftField<string>(sourceName, commitName, {
+    parse: sanitizeMuleName,
+  });
+
+  // We don't pass a commit to level's useDraftField because the level blur
+  // has two extra concerns (clamp write-back + empty→0) that need access to
+  // `level.setDraft`. We rebind onBlur below.
+  const level = useDraftField<string>(sourceLevelStr, () => {}, {
+    parse: (raw) => raw.replace(/\D/g, '').slice(0, 3),
+  });
+
+  const levelOnBlur = useCallback(() => {
+    if (!muleId || level.draft === sourceLevelStr) return;
+    const clamped = clampLevel(level.draft);
+    const clampedStr = level.draft === '' ? '' : String(clamped);
+    if (clampedStr !== level.draft) level.setDraft(clampedStr);
+    onUpdate(muleId, { level: clamped });
+  }, [muleId, level, sourceLevelStr, onUpdate]);
+
+  // Commit On Exit flushes both drafts on Mule Switch / Drawer Close.
+  // Gate each field with its own equality check so we never emit a no-op
+  // write, and route level through the same clamp as onBlur.
+  useCommitOnExit<{ name: string; level: string }>(
+    muleId,
+    { name: name.draft, level: level.draft },
+    useCallback(
+      (id, patch) => {
+        const update: Partial<Omit<Mule, 'id'>> = {};
+        if (patch.name !== undefined && patch.name !== sourceName) {
+          update.name = patch.name;
+        }
+        if (patch.level !== undefined && patch.level !== sourceLevelStr) {
+          update.level = clampLevel(patch.level);
+        }
+        if (Object.keys(update).length > 0) {
+          onUpdate(id, update);
+        }
+      },
+      [onUpdate, sourceName, sourceLevelStr],
+    ),
+  );
+
+  const displayNumber = Number(level.draft) || 0;
+
+  return {
+    name: {
+      draft: name.draft,
+      onChange: name.onChange,
+      onBlur: name.onBlur,
+    },
+    level: {
+      draft: level.draft,
+      displayNumber,
+      onChange: level.onChange,
+      onBlur: levelOnBlur,
+    },
+  };
+}

--- a/src/components/__tests__/MuleDetailDrawer.test.tsx
+++ b/src/components/__tests__/MuleDetailDrawer.test.tsx
@@ -85,6 +85,17 @@ describe('MuleDetailDrawer', () => {
     expect(props.onUpdate).toHaveBeenCalledWith(baseMule.id, { name: 'HeroWorldToo' })
   })
 
+  it('flushes unblurred name edits when the drawer unmounts (Drawer Close / Esc / backdrop)', () => {
+    // Regression for the latent bug: Esc / backdrop click unmount the drawer
+    // without firing blur on the name input, previously dropping the edit.
+    const onUpdate = vi.fn()
+    const { unmount } = renderDrawer({ onUpdate })
+    const input = screen.getByLabelText('Character Name') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'NewName' } })
+    unmount()
+    expect(onUpdate).toHaveBeenCalledWith(baseMule.id, { name: 'NewName' })
+  })
+
   describe('class autocomplete', () => {
     it('shows matching class options as the user types', async () => {
       renderDrawer()


### PR DESCRIPTION
## Summary

- Extract name/level draft machinery from `MuleDetailDrawer.tsx` into three composable hooks under `src/components/MuleDetailDrawer/hooks/`: `useDraftField`, `useCommitOnExit`, `useMuleIdentityDraft`.
- Fix latent bug where unblurred name/level edits were silently dropped when the drawer closed via Esc or backdrop click — `useCommitOnExit` now flushes on both Mule Switch AND unmount (Drawer Close).
- Delete the drawer's `draftsRef` / `lastMuleIdRef` / `onUpdateRef` refs and the `useEffect([mule?.id])` identity-flush — behavior now lives in the hooks. Ambient UI state (delete confirm, search, filter) resets via the "reset state on prop change" render-time pattern.

## Test plan

- [x] `npm run test` — 606 passing, 3 pre-existing failures (`ClassAutocomplete` scrollIntoView in jsdom, unrelated to this change)
- [x] `npm run lint` — 5 pre-existing errors (IncomePieChart fast-refresh, DensityProvider empty-block, ClassAutocomplete set-state-in-effect); reduced from baseline 7
- [x] `npx tsc -b` — 3 pre-existing errors (test fixtures with loose `active?` type); all new code typechecks
- [x] Per-hook boundary tests cover every acceptance criterion (34 new hook tests)
- [x] New drawer integration test verifies the close-drops-drafts bug fix: edit name, unmount drawer → `onUpdate` fires with the new name

Closes #190