### PR TITLE
World data module and WorldProvider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { createPortal } from 'react-dom';
 
 import { ThemeProvider } from './context/ThemeProvider';
 import { DensityProvider } from './context/DensityProvider';
+import { WorldProvider } from './context/WorldProvider';
 import { IncomeProvider } from './modules/income';
 import { useMules } from './hooks/useMules';
 import { useBulkDragPaint } from './hooks/useBulkDragPaint';
@@ -260,9 +261,11 @@ function App() {
   return (
     <ThemeProvider defaultTheme="dark">
       <DensityProvider>
-        <IncomeProvider>
-          <AppContent />
-        </IncomeProvider>
+        <WorldProvider>
+          <IncomeProvider>
+            <AppContent />
+          </IncomeProvider>
+        </WorldProvider>
       </DensityProvider>
     </ThemeProvider>
   );

--- a/src/context/WorldProvider.tsx
+++ b/src/context/WorldProvider.tsx
@@ -1,0 +1,67 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { WORLD_IDS, findWorld, type World, type WorldId } from '@/data/worlds';
+
+interface WorldContextValue {
+  world: World | null;
+  setWorld: (id: WorldId) => void;
+}
+
+const WorldContext = createContext<WorldContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'world';
+
+function readStoredWorldId(): WorldId | null {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored && WORLD_IDS.has(stored as WorldId)) return stored as WorldId;
+  } catch {
+    // localStorage can throw in private-mode / sandboxed iframes — fall through.
+  }
+  return null;
+}
+
+interface WorldProviderProps {
+  children: ReactNode;
+  /**
+   * Test-only override. When supplied, skips the localStorage read and seeds
+   * the provider with this value (including `null` for an explicit "no
+   * world" state). Matches `ThemeProvider`'s `defaultTheme` pattern.
+   */
+  defaultWorld?: WorldId | null;
+}
+
+export function WorldProvider({ children, defaultWorld }: WorldProviderProps) {
+  const [worldId, setWorldId] = useState<WorldId | null>(() => {
+    if (defaultWorld !== undefined) return defaultWorld;
+    return readStoredWorldId();
+  });
+
+  useEffect(() => {
+    try {
+      if (worldId === null) {
+        localStorage.removeItem(STORAGE_KEY);
+      } else {
+        localStorage.setItem(STORAGE_KEY, worldId);
+      }
+    } catch {
+      // localStorage can throw in private-mode / sandboxed iframes — ignore.
+    }
+  }, [worldId]);
+
+  const setWorld = (id: WorldId) => setWorldId(id);
+
+  return (
+    <WorldContext.Provider value={{ world: findWorld(worldId), setWorld }}>
+      {children}
+    </WorldContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useWorld() {
+  const context = useContext(WorldContext);
+  if (!context) {
+    throw new Error('useWorld must be used within a WorldProvider');
+  }
+  return context;
+}

--- a/src/context/__tests__/WorldProvider.test.tsx
+++ b/src/context/__tests__/WorldProvider.test.tsx
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WorldProvider, useWorld } from '../WorldProvider';
+
+function WorldConsumer() {
+  const { world, setWorld } = useWorld();
+  return (
+    <div>
+      <span data-testid="world-id">{world?.id ?? 'null'}</span>
+      <span data-testid="world-label">{world?.label ?? 'none'}</span>
+      <span data-testid="world-group">{world?.group ?? 'none'}</span>
+      <button data-testid="set-kronos" onClick={() => setWorld('heroic-kronos')}>
+        Set Kronos
+      </button>
+      <button data-testid="set-bera" onClick={() => setWorld('interactive-bera')}>
+        Set Bera
+      </button>
+      <button data-testid="set-cw-heroic" onClick={() => setWorld('heroic-challenger')}>
+        Set CW (Heroic)
+      </button>
+    </div>
+  );
+}
+
+describe('WorldProvider', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('starts with null when nothing is stored', () => {
+    render(
+      <WorldProvider>
+        <WorldConsumer />
+      </WorldProvider>,
+    );
+    expect(screen.getByTestId('world-id').textContent).toBe('null');
+    expect(screen.getByTestId('world-label').textContent).toBe('none');
+  });
+
+  it('initializes from a valid localStorage id', () => {
+    localStorage.setItem('world', 'heroic-hyperion');
+    render(
+      <WorldProvider>
+        <WorldConsumer />
+      </WorldProvider>,
+    );
+    expect(screen.getByTestId('world-id').textContent).toBe('heroic-hyperion');
+    expect(screen.getByTestId('world-label').textContent).toBe('Hyperion');
+    expect(screen.getByTestId('world-group').textContent).toBe('Heroic');
+  });
+
+  it('falls back to null when the stored id is unknown', () => {
+    localStorage.setItem('world', 'not-a-world');
+    render(
+      <WorldProvider>
+        <WorldConsumer />
+      </WorldProvider>,
+    );
+    expect(screen.getByTestId('world-id').textContent).toBe('null');
+    expect(screen.getByTestId('world-label').textContent).toBe('none');
+  });
+
+  it('falls back to null when the stored value is an empty string', () => {
+    localStorage.setItem('world', '');
+    render(
+      <WorldProvider>
+        <WorldConsumer />
+      </WorldProvider>,
+    );
+    expect(screen.getByTestId('world-id').textContent).toBe('null');
+  });
+
+  it('setWorld updates the current world', () => {
+    render(
+      <WorldProvider>
+        <WorldConsumer />
+      </WorldProvider>,
+    );
+    fireEvent.click(screen.getByTestId('set-kronos'));
+    expect(screen.getByTestId('world-id').textContent).toBe('heroic-kronos');
+    expect(screen.getByTestId('world-label').textContent).toBe('Kronos');
+    expect(screen.getByTestId('world-group').textContent).toBe('Heroic');
+  });
+
+  it('setWorld persists the id to localStorage under the "world" key', () => {
+    render(
+      <WorldProvider>
+        <WorldConsumer />
+      </WorldProvider>,
+    );
+    fireEvent.click(screen.getByTestId('set-bera'));
+    expect(localStorage.getItem('world')).toBe('interactive-bera');
+  });
+
+  it('setWorld round-trips through localStorage', () => {
+    const { unmount } = render(
+      <WorldProvider>
+        <WorldConsumer />
+      </WorldProvider>,
+    );
+    fireEvent.click(screen.getByTestId('set-cw-heroic'));
+    expect(screen.getByTestId('world-id').textContent).toBe('heroic-challenger');
+    unmount();
+
+    render(
+      <WorldProvider>
+        <WorldConsumer />
+      </WorldProvider>,
+    );
+    expect(screen.getByTestId('world-id').textContent).toBe('heroic-challenger');
+    expect(screen.getByTestId('world-label').textContent).toBe('CW (Heroic)');
+  });
+
+  it('defaultWorld prop overrides the localStorage read', () => {
+    localStorage.setItem('world', 'heroic-kronos');
+    render(
+      <WorldProvider defaultWorld="interactive-scania">
+        <WorldConsumer />
+      </WorldProvider>,
+    );
+    expect(screen.getByTestId('world-id').textContent).toBe('interactive-scania');
+    expect(screen.getByTestId('world-label').textContent).toBe('Scania');
+  });
+
+  it('defaultWorld={null} overrides a valid stored value with null', () => {
+    localStorage.setItem('world', 'heroic-kronos');
+    render(
+      <WorldProvider defaultWorld={null}>
+        <WorldConsumer />
+      </WorldProvider>,
+    );
+    expect(screen.getByTestId('world-id').textContent).toBe('null');
+  });
+
+  it('throws when useWorld is used outside a WorldProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(<WorldConsumer />)).toThrow();
+    spy.mockRestore();
+  });
+});

--- a/src/data/__tests__/worlds.test.ts
+++ b/src/data/__tests__/worlds.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { WORLDS, WORLD_IDS, findWorld, type WorldId } from '../worlds';
+
+describe('worlds data module', () => {
+  it('contains exactly the six PRD-specified worlds in order', () => {
+    expect(WORLDS).toHaveLength(6);
+    expect(WORLDS.map((w) => w.id)).toEqual([
+      'heroic-kronos',
+      'heroic-hyperion',
+      'heroic-challenger',
+      'interactive-scania',
+      'interactive-bera',
+      'interactive-challenger',
+    ] satisfies WorldId[]);
+  });
+
+  it('every World id is distinct', () => {
+    const ids = new Set(WORLDS.map((w) => w.id));
+    expect(ids.size).toBe(WORLDS.length);
+  });
+
+  it('every World id is present in WORLD_IDS', () => {
+    for (const world of WORLDS) {
+      expect(WORLD_IDS.has(world.id)).toBe(true);
+    }
+    expect(WORLD_IDS.size).toBe(WORLDS.length);
+  });
+
+  it('WORLD_IDS contains exactly the six ids', () => {
+    expect(WORLD_IDS.size).toBe(6);
+    expect([...WORLD_IDS].sort()).toEqual(
+      [
+        'heroic-kronos',
+        'heroic-hyperion',
+        'heroic-challenger',
+        'interactive-scania',
+        'interactive-bera',
+        'interactive-challenger',
+      ].sort(),
+    );
+  });
+
+  it('Heroic worlds have group "Heroic"', () => {
+    const heroic = WORLDS.filter((w) => w.id.startsWith('heroic-'));
+    expect(heroic).toHaveLength(3);
+    for (const world of heroic) {
+      expect(world.group).toBe('Heroic');
+    }
+  });
+
+  it('Interactive worlds have group "Interactive"', () => {
+    const interactive = WORLDS.filter((w) => w.id.startsWith('interactive-'));
+    expect(interactive).toHaveLength(3);
+    for (const world of interactive) {
+      expect(world.group).toBe('Interactive');
+    }
+  });
+
+  it('Challenger entries include their group suffix in the label', () => {
+    const heroicCw = WORLDS.find((w) => w.id === 'heroic-challenger');
+    const interactiveCw = WORLDS.find((w) => w.id === 'interactive-challenger');
+    expect(heroicCw?.label).toBe('CW (Heroic)');
+    expect(interactiveCw?.label).toBe('CW (Interactive)');
+  });
+
+  it('non-Challenger world labels match expected display names', () => {
+    expect(WORLDS.find((w) => w.id === 'heroic-kronos')?.label).toBe('Kronos');
+    expect(WORLDS.find((w) => w.id === 'heroic-hyperion')?.label).toBe('Hyperion');
+    expect(WORLDS.find((w) => w.id === 'interactive-scania')?.label).toBe('Scania');
+    expect(WORLDS.find((w) => w.id === 'interactive-bera')?.label).toBe('Bera');
+  });
+});
+
+describe('findWorld', () => {
+  it('returns the matching World for every valid id', () => {
+    for (const world of WORLDS) {
+      expect(findWorld(world.id)).toBe(world);
+    }
+  });
+
+  it('returns null for null', () => {
+    expect(findWorld(null)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(findWorld('')).toBeNull();
+  });
+
+  it('returns null for an unknown id', () => {
+    expect(findWorld('not-a-world')).toBeNull();
+    expect(findWorld('heroic-unknown')).toBeNull();
+  });
+});

--- a/src/data/worlds.ts
+++ b/src/data/worlds.ts
@@ -1,0 +1,52 @@
+/**
+ * World data module — the single source of truth for the six World options
+ * the header World Select offers.
+ *
+ * MapleStory GMS partitions worlds into two World Groups: Heroic (Kronos,
+ * Hyperion, Challenger World (Heroic)) and Interactive (Scania, Bera,
+ * Challenger World (Interactive)). Challenger World exists in both groups
+ * and is disambiguated at the label level — `CW (Heroic)` / `CW (Interactive)`
+ * — while its `WorldId` keeps the two entries distinct.
+ *
+ * See issue #194 §Approach for the locked shape.
+ */
+
+export type WorldGroup = 'Heroic' | 'Interactive';
+
+export type WorldId =
+  | 'heroic-kronos'
+  | 'heroic-hyperion'
+  | 'heroic-challenger'
+  | 'interactive-scania'
+  | 'interactive-bera'
+  | 'interactive-challenger';
+
+export interface World {
+  id: WorldId;
+  label: string;
+  group: WorldGroup;
+}
+
+export const WORLDS: readonly World[] = [
+  { id: 'heroic-kronos', label: 'Kronos', group: 'Heroic' },
+  { id: 'heroic-hyperion', label: 'Hyperion', group: 'Heroic' },
+  { id: 'heroic-challenger', label: 'CW (Heroic)', group: 'Heroic' },
+  { id: 'interactive-scania', label: 'Scania', group: 'Interactive' },
+  { id: 'interactive-bera', label: 'Bera', group: 'Interactive' },
+  { id: 'interactive-challenger', label: 'CW (Interactive)', group: 'Interactive' },
+];
+
+export const WORLD_IDS: ReadonlySet<WorldId> = new Set(WORLDS.map((w) => w.id));
+
+const worldById = new Map<WorldId, World>(WORLDS.map((w) => [w.id, w]));
+
+/**
+ * Returns the `World` matching the supplied id, or `null` for any value that
+ * is not one of the six canonical `WorldId`s. Accepts `null`, empty strings,
+ * and arbitrary user-supplied strings (e.g. a stale localStorage payload)
+ * without throwing — the caller is expected to surface the placeholder state.
+ */
+export function findWorld(id: string | null): World | null {
+  if (!id) return null;
+  return worldById.get(id as WorldId) ?? null;
+}


### PR DESCRIPTION
## Summary

- Add `src/data/worlds.ts` — the single source of truth for the six World options (`WorldGroup`, `WorldId`, `World`, `WORLDS`, `WORLD_IDS`, `findWorld`). Challenger entries render as `CW (Heroic)` / `CW (Interactive)`.
- Add `src/context/WorldProvider.tsx` — `WorldProvider` + `useWorld` mirroring `ThemeProvider`'s lazy-init + effect-write pattern. Reads `localStorage.getItem('world')`, validates against `WORLD_IDS`, and falls back to `null` for unknown / missing / unparseable values. Accepts a `defaultWorld?: WorldId | null` override for tests.
- Wire `WorldProvider` into `App.tsx` as `ThemeProvider > DensityProvider > WorldProvider > IncomeProvider > AppContent` so the future Active World Lens can consume `useWorld()` outside the income domain.
- No visible UI change in this slice — the header control that renders the hook lands in a follow-up.

## Test plan

- [x] `pnpm test` — all 596 tests green (12 new `worlds` tests + 10 new `WorldProvider` tests)
- [x] `pnpm lint` — clean
- [x] `pnpm exec tsc -b` — clean
- [x] Acceptance criteria verified against issue:
  - `WORLDS` has the six options in PRD order with correct `CW (…)` labels
  - `findWorld` resolves valid ids and returns `null` for `null`, `''`, and unknown ids
  - Provider lazy-init from localStorage with `WORLD_IDS` validation; unknown stored id → `null`
  - `setWorld(id)` persists under `'world'` key; round-trip verified
  - `useWorld` throws outside provider
  - `defaultWorld` prop override works (including `null` override)

Closes #195