### PR TITLE
Header World Select UI

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { Sun, Moon } from 'lucide-react';
 import { useTheme } from '../context/ThemeProvider';
 import { ResetCountdown } from './ResetCountdown';
+import { WorldSelect } from './WorldSelect';
 
 export function Header() {
   const { theme, toggleTheme } = useTheme();
@@ -46,6 +47,7 @@ export function Header() {
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
             <ResetCountdown />
+            <WorldSelect />
             <button
               onClick={toggleTheme}
               className="flex size-8  items-center justify-center rounded-md transition-colors cursor-pointer"

--- a/src/components/WorldSelect.tsx
+++ b/src/components/WorldSelect.tsx
@@ -1,0 +1,82 @@
+import { Select } from '@base-ui/react/select';
+import { Check, ChevronDown, Globe } from 'lucide-react';
+import { useWorld } from '@/context/WorldProvider';
+import { WORLDS, type World, type WorldGroup, type WorldId } from '@/data/worlds';
+
+const WORLDS_BY_GROUP: ReadonlyArray<{ group: WorldGroup; worlds: readonly World[] }> = [
+  { group: 'Heroic', worlds: WORLDS.filter((w) => w.group === 'Heroic') },
+  { group: 'Interactive', worlds: WORLDS.filter((w) => w.group === 'Interactive') },
+];
+
+/**
+ * Header World Select control. Renders two triggers sharing one
+ * `Select.Positioner` + `Select.Popup`: a soft chip at `≥sm` and an icon-only
+ * globe button at `<sm`. The panel groups the six canonical worlds by
+ * **World Group** with right-aligned check indicators on the selected row.
+ */
+export function WorldSelect() {
+  const { world, setWorld } = useWorld();
+
+  return (
+    <Select.Root
+      value={world?.id ?? null}
+      onValueChange={(id) => {
+        if (id) setWorld(id as WorldId);
+      }}
+    >
+      <Select.Trigger
+        data-slot="world-select-trigger-desktop"
+        className="hidden sm:inline-flex items-center gap-1.5 rounded-md bg-(--surface-2) px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+      >
+        {world ? (
+          <span>{world.label}</span>
+        ) : (
+          <span className="italic text-muted-foreground">Select world</span>
+        )}
+        <ChevronDown size={14} aria-hidden="true" />
+      </Select.Trigger>
+
+      <Select.Trigger
+        aria-label="Select world"
+        data-slot="world-select-trigger-mobile"
+        className="sm:hidden flex size-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+      >
+        <Globe size={16} aria-hidden="true" />
+      </Select.Trigger>
+
+      <Select.Portal>
+        <Select.Positioner sideOffset={6} align="end" className="isolate z-50 outline-hidden">
+          <Select.Popup
+            data-slot="world-select-popup"
+            className="min-w-44 rounded-lg bg-popover py-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden"
+          >
+            {WORLDS_BY_GROUP.map(({ group, worlds }) => (
+              <Select.Group key={group}>
+                <Select.GroupLabel className="block px-3 pt-2 pb-1 text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground/70">
+                  {group.toUpperCase()}
+                </Select.GroupLabel>
+                {worlds.map((w) => (
+                  <WorldSelectItem key={w.id} id={w.id} label={w.label} />
+                ))}
+              </Select.Group>
+            ))}
+          </Select.Popup>
+        </Select.Positioner>
+      </Select.Portal>
+    </Select.Root>
+  );
+}
+
+function WorldSelectItem({ id, label }: { id: WorldId; label: string }) {
+  return (
+    <Select.Item
+      value={id}
+      className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm outline-hidden data-highlighted:bg-accent data-highlighted:text-accent-foreground"
+    >
+      <Select.ItemText>{label}</Select.ItemText>
+      <Select.ItemIndicator className="ml-auto flex items-center">
+        <Check size={14} aria-hidden="true" data-testid="world-select-check" />
+      </Select.ItemIndicator>
+    </Select.Item>
+  );
+}

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@/test/test-utils';
+import { render, screen, fireEvent, within, waitFor } from '@/test/test-utils';
 import { Header } from '../Header';
 
 describe('Header (shadcn/ThemeProvider)', () => {
@@ -36,5 +36,121 @@ describe('Header (shadcn/ThemeProvider)', () => {
     expect(document.documentElement.classList.contains('dark')).toBe(true);
     fireEvent.click(screen.getByLabelText('Switch to light mode'));
     expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+});
+
+describe('Header WorldSelect integration', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+    document.body.classList.remove('light');
+  });
+
+  it('renders the WorldSelect placeholder (Select world) when no world is selected', () => {
+    render(<Header />, { defaultWorld: null });
+    // The desktop chip trigger shows the placeholder text.
+    const triggers = screen.getAllByText(/select world/i);
+    expect(triggers.length).toBeGreaterThan(0);
+  });
+
+  it('renders the selected world label in the trigger when a world is pre-selected', () => {
+    render(<Header />, { defaultWorld: 'heroic-kronos' });
+    expect(screen.getByText('Kronos')).toBeTruthy();
+  });
+
+  it('renders the mobile icon-only globe trigger with aria-label="Select world"', () => {
+    render(<Header />, { defaultWorld: null });
+    // The mobile trigger is rendered alongside the desktop trigger; CSS hides
+    // one or the other. The icon-only trigger carries an aria-label so screen
+    // readers (and tests) can target it directly.
+    const mobileTrigger = screen.getByLabelText('Select world');
+    expect(mobileTrigger).toBeTruthy();
+  });
+
+  it('renders the WorldSelect between the ResetCountdown and the theme toggle', () => {
+    render(<Header />, { defaultWorld: null });
+    const themeToggle = screen.getByLabelText('Switch to light mode');
+    const rightSide = themeToggle.parentElement!;
+    const children = Array.from(rightSide.children);
+    const countdownIdx = children.findIndex((c) => /RESET IN/.test(c.textContent ?? ''));
+    const worldSelectIdx = children.findIndex(
+      (c) => c.getAttribute('aria-label') === 'Select world',
+    );
+    const themeIdx = children.indexOf(themeToggle);
+    expect(countdownIdx).toBeGreaterThanOrEqual(0);
+    expect(worldSelectIdx).toBeGreaterThan(countdownIdx);
+    expect(themeIdx).toBeGreaterThan(worldSelectIdx);
+  });
+
+  it('opens the panel with two groups (HEROIC and INTERACTIVE) when the trigger is clicked', async () => {
+    render(<Header />, { defaultWorld: null });
+    const mobileTrigger = screen.getByLabelText('Select world');
+    fireEvent.click(mobileTrigger);
+
+    await waitFor(() => {
+      expect(screen.getByText('HEROIC')).toBeTruthy();
+      expect(screen.getByText('INTERACTIVE')).toBeTruthy();
+    });
+
+    // HEROIC should come before INTERACTIVE in document order.
+    const heroic = screen.getByText('HEROIC');
+    const interactive = screen.getByText('INTERACTIVE');
+    expect(heroic.compareDocumentPosition(interactive) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
+  it('renders all six worlds grouped correctly when the panel is open', async () => {
+    render(<Header />, { defaultWorld: null });
+    fireEvent.click(screen.getByLabelText('Select world'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Kronos' })).toBeTruthy();
+    });
+
+    expect(screen.getByRole('option', { name: 'Kronos' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'Hyperion' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'CW (Heroic)' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'Scania' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'Bera' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'CW (Interactive)' })).toBeTruthy();
+  });
+
+  it('selecting an option updates the trigger label', async () => {
+    render(<Header />, { defaultWorld: null });
+    fireEvent.click(screen.getByLabelText('Select world'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Hyperion' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('option', { name: 'Hyperion' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Hyperion')).toBeTruthy();
+    });
+  });
+
+  it('persists the selection across renders when defaultWorld is supplied', () => {
+    // This mirrors the "refresh persists" criterion — when WorldProvider
+    // initializes from localStorage (simulated via defaultWorld), the trigger
+    // renders the stored world's label without user interaction.
+    render(<Header />, { defaultWorld: 'interactive-bera' });
+    expect(screen.getByText('Bera')).toBeTruthy();
+  });
+
+  it('shows a check indicator next to the selected row when the panel reopens', async () => {
+    render(<Header />, { defaultWorld: 'heroic-hyperion' });
+    fireEvent.click(screen.getByLabelText('Select world'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: /Hyperion/ })).toBeTruthy();
+    });
+
+    const selectedOption = screen.getByRole('option', { name: /Hyperion/ });
+    // Base UI's SelectItem exposes `data-selected` on the selected item.
+    expect(selectedOption.getAttribute('data-selected')).not.toBeNull();
+    // The ItemIndicator renders an svg (lucide Check) inside the selected row.
+    expect(within(selectedOption).getByTestId('world-select-check')).toBeTruthy();
   });
 });

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -1,21 +1,34 @@
 import { type ReactElement } from 'react';
 import { render as rtlRender, type RenderOptions } from '@testing-library/react';
 import { ThemeProvider } from '@/context/ThemeProvider';
+import { DensityProvider } from '@/context/DensityProvider';
+import { WorldProvider } from '@/context/WorldProvider';
 import { IncomeProvider } from '@/modules/income';
+import type { WorldId } from '@/data/worlds';
 
 interface CustomRenderOptions extends Omit<RenderOptions, 'wrapper'> {
   defaultTheme?: 'dark' | 'light';
   defaultAbbreviated?: boolean;
+  defaultWorld?: WorldId | null;
 }
 
 export function render(
   ui: ReactElement,
-  { defaultTheme = 'dark', defaultAbbreviated = true, ...options }: CustomRenderOptions = {},
+  {
+    defaultTheme = 'dark',
+    defaultAbbreviated = true,
+    defaultWorld,
+    ...options
+  }: CustomRenderOptions = {},
 ) {
   function Wrapper({ children }: { children: React.ReactNode }) {
     return (
       <ThemeProvider defaultTheme={defaultTheme}>
-        <IncomeProvider defaultAbbreviated={defaultAbbreviated}>{children}</IncomeProvider>
+        <DensityProvider>
+          <WorldProvider defaultWorld={defaultWorld}>
+            <IncomeProvider defaultAbbreviated={defaultAbbreviated}>{children}</IncomeProvider>
+          </WorldProvider>
+        </DensityProvider>
       </ThemeProvider>
     );
   }


### PR DESCRIPTION
## Summary
- Added `WorldSelect` header control built on `@base-ui/react/select` with a responsive chip/globe-icon trigger swap at `sm` (matches `ResetCountdown`'s responsive pattern).
- Mounted `<WorldSelect />` inside `Header.tsx` between `<ResetCountdown />` and the theme toggle.
- Extended the test wrapper in `src/test/test-utils.tsx` with `DensityProvider` + `WorldProvider` (App-tree order) and a `defaultWorld?: WorldId | null` option for tests that need a pre-selected world.

## Test plan
- [x] `pnpm test` — 605/605 green
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` (`tsc -b`) — clean
- [x] Acceptance criteria verified:
  - Desktop chip shows `Select world` placeholder when unset, selected label when set
  - Mobile icon trigger exposes `aria-label="Select world"`
  - Opening the panel reveals both `HEROIC` / `INTERACTIVE` groups with all six options in PRD order (CW entries labelled `CW (Heroic)` / `CW (Interactive)`)
  - Selecting an option calls `setWorld(id)` and updates the trigger label
  - Reopening the panel after selection renders a right-aligned check on the chosen row via `Select.ItemIndicator`
  - Both triggers share one `Select.Positioner` + `Select.Popup`
  - Header tests cover placeholder, persistence (`defaultWorld`), group rendering, option selection, and check indicator

Closes #196