### PR TITLE
Boss preset: Same-Cadence Equality + Conform + LOMIEN multi-tier

### DIFF
--- a/src/components/MatrixToolbar.tsx
+++ b/src/components/MatrixToolbar.tsx
@@ -4,8 +4,9 @@ export type PresetKey = 'CRA' | 'LOMIEN' | 'CTENE';
 interface MatrixToolbarProps {
   filter: CadenceFilter;
   onFilterChange: (next: CadenceFilter) => void;
-  activePresets: ReadonlySet<PresetKey>;
-  onTogglePreset: (preset: PresetKey) => void;
+  /** The single currently-lit **Preset Pill**, or `null` when none matches. */
+  activePill: PresetKey | null;
+  onApplyPreset: (preset: PresetKey) => void;
   /** Count of `weekly`-cadence selections; displayed as `{weeklyCount}/14`. */
   weeklyCount: number;
   /** Invoked when the Matrix Reset button is clicked. */
@@ -61,8 +62,8 @@ const PRESETS: readonly PresetKey[] = ['CRA', 'LOMIEN', 'CTENE'];
 export function MatrixToolbar({
   filter,
   onFilterChange,
-  activePresets,
-  onTogglePreset,
+  activePill,
+  onApplyPreset,
   weeklyCount,
   onReset,
 }: MatrixToolbarProps) {
@@ -89,8 +90,8 @@ export function MatrixToolbar({
             <button
               key={preset}
               type="button"
-              className={activePresets.has(preset) ? 'on' : ''}
-              onClick={() => onTogglePreset(preset)}
+              className={activePill === preset ? 'on' : ''}
+              onClick={() => onApplyPreset(preset)}
             >
               {preset}
             </button>

--- a/src/components/MuleDetailDrawer.tsx
+++ b/src/components/MuleDetailDrawer.tsx
@@ -250,8 +250,8 @@ export function MuleDetailDrawer({
                 <MatrixToolbar
                   filter={matrix.filter}
                   onFilterChange={matrix.setFilter}
-                  activePresets={matrix.activePresets}
-                  onTogglePreset={matrix.togglePreset}
+                  activePill={matrix.activePill}
+                  onApplyPreset={matrix.applyPreset}
                   weeklyCount={matrix.weeklyCount}
                   onReset={matrix.resetBosses}
                 />

--- a/src/components/MuleDetailDrawer/hooks/__tests__/useBossMatrixView.test.tsx
+++ b/src/components/MuleDetailDrawer/hooks/__tests__/useBossMatrixView.test.tsx
@@ -3,7 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 
 import { useBossMatrixView } from '../useBossMatrixView';
 import { bosses } from '../../../../data/bosses';
-import { PRESET_FAMILIES, presetEntryFamily, presetEntryKey } from '../../../../data/bossPresets';
+import { PRESET_FAMILIES, presetEntryKey } from '../../../../data/bossPresets';
 import { MuleBossSlate } from '../../../../data/muleBossSlate';
 
 const LUCID_BOSS = bosses.find((b) => b.family === 'lucid')!;
@@ -18,6 +18,9 @@ const CRIMSON_QUEEN_BOSS = bosses.find((b) => b.family === 'crimson-queen')!;
 const BLACK_MAGE_BOSS = bosses.find((b) => b.family === 'black-mage')!;
 const HORNTAIL_BOSS = bosses.find((b) => b.family === 'horntail')!;
 const MORI_BOSS = bosses.find((b) => b.family === 'mori-ranmaru')!;
+const DAMIEN_BOSS = bosses.find((b) => b.family === 'damien')!;
+const LOTUS_BOSS = bosses.find((b) => b.family === 'lotus')!;
+const ARKARIUM_BOSS = bosses.find((b) => b.family === 'arkarium')!;
 
 const CRA_KEYS = PRESET_FAMILIES.CRA.map((entry) => presetEntryKey(entry)!);
 const LOMIEN_KEYS = PRESET_FAMILIES.LOMIEN.map((entry) => presetEntryKey(entry)!);
@@ -82,8 +85,8 @@ describe('useBossMatrixView', () => {
     });
   });
 
-  describe('togglePreset (Preset Swap)', () => {
-    it('applies preset on empty selection', () => {
+  describe('applyPreset (Conform)', () => {
+    it('applies CRA on empty selection', () => {
       const onUpdate = vi.fn();
       const { result } = renderHook(() =>
         useBossMatrixView({
@@ -95,13 +98,35 @@ describe('useBossMatrixView', () => {
       );
 
       act(() => {
-        result.current.togglePreset('CRA');
+        result.current.applyPreset('CRA');
       });
       const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] };
       expect(new Set(update.selectedBosses)).toEqual(new Set(CRA_KEYS));
     });
 
-    it('strips other active presets before applying (swap semantics)', () => {
+    it('wipes non-preset weeklies when swapping from CRA + extra to CRA', () => {
+      // Starts in Custom territory (no canonical match because Arkarium is
+      // non-preset). Clicking CRA conforms, wiping Arkarium.
+      const arkariumKey = `${ARKARIUM_BOSS.id}:normal:weekly`;
+      const onUpdate = vi.fn();
+      const { result } = renderHook(() =>
+        useBossMatrixView({
+          muleId: 'mule-1',
+          selectedBosses: [...CRA_KEYS, arkariumKey],
+          partySizes: undefined,
+          onUpdate,
+        }),
+      );
+
+      act(() => {
+        result.current.applyPreset('CRA');
+      });
+      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] };
+      expect(update.selectedBosses).not.toContain(arkariumKey);
+      for (const k of CRA_KEYS) expect(update.selectedBosses).toContain(k);
+    });
+
+    it('swap CRA → CTENE: adds CTENE keys and drops CRA-only families', () => {
       const onUpdate = vi.fn();
       const { result } = renderHook(() =>
         useBossMatrixView({
@@ -113,22 +138,13 @@ describe('useBossMatrixView', () => {
       );
 
       act(() => {
-        result.current.togglePreset('CTENE');
+        result.current.applyPreset('CTENE');
       });
       const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] };
-      // All CTENE keys present.
-      for (const k of CTENE_KEYS) {
-        expect(update.selectedBosses).toContain(k);
-      }
-      // CRA-only families cleared.
-      const cteneFamilies = new Set(PRESET_FAMILIES.CTENE.map(presetEntryFamily));
-      for (const entry of PRESET_FAMILIES.CRA) {
-        if (cteneFamilies.has(presetEntryFamily(entry))) continue;
-        expect(update.selectedBosses).not.toContain(presetEntryKey(entry)!);
-      }
+      for (const k of CTENE_KEYS) expect(update.selectedBosses).toContain(k);
     });
 
-    it('clicking the currently active preset deselects it', () => {
+    it('short-circuits (zero onUpdate) when clicking the Active Pill', () => {
       const onUpdate = vi.fn();
       const { result } = renderHook(() =>
         useBossMatrixView({
@@ -140,29 +156,51 @@ describe('useBossMatrixView', () => {
       );
 
       act(() => {
-        result.current.togglePreset('CRA');
+        result.current.applyPreset('CRA');
       });
-      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] };
-      expect(update.selectedBosses).toEqual([]);
+      expect(onUpdate).not.toHaveBeenCalled();
     });
 
-    it('preserves hand-picked non-preset keys on a swap', () => {
+    it('preserves daily keys on conform', () => {
+      const horntailDaily = `${HORNTAIL_BOSS.id}:chaos:daily`;
       const onUpdate = vi.fn();
-      const HARD_HORNTAIL = `${HORNTAIL_BOSS.id}:chaos:daily`;
       const { result } = renderHook(() =>
         useBossMatrixView({
           muleId: 'mule-1',
-          selectedBosses: [...CRA_KEYS, HARD_HORNTAIL],
+          selectedBosses: [horntailDaily],
           partySizes: undefined,
           onUpdate,
         }),
       );
 
       act(() => {
-        result.current.togglePreset('CTENE');
+        result.current.applyPreset('CRA');
       });
       const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] };
-      expect(update.selectedBosses).toContain(HARD_HORNTAIL);
+      expect(update.selectedBosses).toContain(horntailDaily);
+    });
+
+    it('LOMIEN swap from CTENE preserves Hard Damien + Hard Lotus', () => {
+      // CTENE has Damien (hardest = hard) + Hard Lotus — both tiers LOMIEN
+      // accepts. After swap, those keys stay put; the rest of CTENE's unique
+      // families (Darknell, Verus Hilla, etc.) get wiped; CRA-shared families
+      // in LOMIEN remain at Hardest.
+      const onUpdate = vi.fn();
+      const { result } = renderHook(() =>
+        useBossMatrixView({
+          muleId: 'mule-1',
+          selectedBosses: CTENE_KEYS,
+          partySizes: undefined,
+          onUpdate,
+        }),
+      );
+
+      act(() => {
+        result.current.applyPreset('LOMIEN');
+      });
+      const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] };
+      expect(update.selectedBosses).toContain(`${DAMIEN_BOSS.id}:hard:weekly`);
+      expect(update.selectedBosses).toContain(`${LOTUS_BOSS.id}:hard:weekly`);
     });
 
     it('normalizes resulting keys through MuleBossSlate.from (Selection Invariant)', () => {
@@ -177,10 +215,9 @@ describe('useBossMatrixView', () => {
       );
 
       act(() => {
-        result.current.togglePreset('CRA');
+        result.current.applyPreset('CRA');
       });
       const update = onUpdate.mock.calls[0][1] as { selectedBosses: string[] };
-      // `MuleBossSlate.from` round-trips to the same key set.
       expect(new Set(update.selectedBosses)).toEqual(
         new Set(MuleBossSlate.from(update.selectedBosses).keys),
       );
@@ -198,26 +235,39 @@ describe('useBossMatrixView', () => {
       );
 
       act(() => {
-        result.current.togglePreset('CRA');
+        result.current.applyPreset('CRA');
       });
       expect(onUpdate).not.toHaveBeenCalled();
     });
   });
 
-  describe('activePresets', () => {
-    it('is empty when no preset is fully selected', () => {
+  describe('activePill (Same-Cadence Equality)', () => {
+    it('is null for an empty selection', () => {
       const { result } = renderHook(() =>
         useBossMatrixView({
           muleId: 'mule-1',
-          selectedBosses: [HARD_LUCID],
+          selectedBosses: [],
           partySizes: undefined,
           onUpdate: vi.fn(),
         }),
       );
-      expect(result.current.activePresets.size).toBe(0);
+      expect(result.current.activePill).toBeNull();
     });
 
-    it('includes CRA when all CRA keys selected', () => {
+    it('is null for CRA + extra non-preset weekly (CUSTOM comes in slice 2)', () => {
+      const arkariumKey = `${ARKARIUM_BOSS.id}:normal:weekly`;
+      const { result } = renderHook(() =>
+        useBossMatrixView({
+          muleId: 'mule-1',
+          selectedBosses: [...CRA_KEYS, arkariumKey],
+          partySizes: undefined,
+          onUpdate: vi.fn(),
+        }),
+      );
+      expect(result.current.activePill).toBeNull();
+    });
+
+    it('is "CRA" for an exact CRA selection', () => {
       const { result } = renderHook(() =>
         useBossMatrixView({
           muleId: 'mule-1',
@@ -226,10 +276,10 @@ describe('useBossMatrixView', () => {
           onUpdate: vi.fn(),
         }),
       );
-      expect(result.current.activePresets.has('CRA')).toBe(true);
+      expect(result.current.activePill).toBe('CRA');
     });
 
-    it('excludes CRA when LOMIEN is active (LOMIEN supersedes)', () => {
+    it('is "LOMIEN" for an exact LOMIEN selection', () => {
       const { result } = renderHook(() =>
         useBossMatrixView({
           muleId: 'mule-1',
@@ -238,8 +288,47 @@ describe('useBossMatrixView', () => {
           onUpdate: vi.fn(),
         }),
       );
-      expect(result.current.activePresets.has('LOMIEN')).toBe(true);
-      expect(result.current.activePresets.has('CRA')).toBe(false);
+      expect(result.current.activePill).toBe('LOMIEN');
+    });
+
+    it('is "CTENE" for an exact CTENE selection', () => {
+      const { result } = renderHook(() =>
+        useBossMatrixView({
+          muleId: 'mule-1',
+          selectedBosses: CTENE_KEYS,
+          partySizes: undefined,
+          onUpdate: vi.fn(),
+        }),
+      );
+      expect(result.current.activePill).toBe('CTENE');
+    });
+
+    it('LOMIEN stays lit when Damien is swapped Normal → Hard', () => {
+      const swapped = LOMIEN_KEYS.filter((k) => !k.startsWith(`${DAMIEN_BOSS.id}:`)).concat([
+        `${DAMIEN_BOSS.id}:hard:weekly`,
+      ]);
+      const { result } = renderHook(() =>
+        useBossMatrixView({
+          muleId: 'mule-1',
+          selectedBosses: swapped,
+          partySizes: undefined,
+          onUpdate: vi.fn(),
+        }),
+      );
+      expect(result.current.activePill).toBe('LOMIEN');
+    });
+
+    it('is null when only daily keys are selected', () => {
+      const vellumDaily = `${VELLUM_BOSS.id}:normal:daily`;
+      const { result } = renderHook(() =>
+        useBossMatrixView({
+          muleId: 'mule-1',
+          selectedBosses: [vellumDaily],
+          partySizes: undefined,
+          onUpdate: vi.fn(),
+        }),
+      );
+      expect(result.current.activePill).toBeNull();
     });
   });
 

--- a/src/components/MuleDetailDrawer/hooks/useBossMatrixView.ts
+++ b/src/components/MuleDetailDrawer/hooks/useBossMatrixView.ts
@@ -1,15 +1,10 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { Mule } from '../../../types';
 import { MuleBossSlate, type SlateFamily } from '../../../data/muleBossSlate';
-import {
-  PRESET_FAMILIES,
-  applyPreset,
-  isPresetActive,
-  removePreset,
-} from '../../../data/bossPresets';
+import { conform, isPresetActive } from '../../../data/bossPresets';
 import type { CadenceFilter, PresetKey } from '../../MatrixToolbar';
 
-const PRESET_KEYS: readonly PresetKey[] = ['CRA', 'LOMIEN', 'CTENE'];
+const CANONICAL_PRESETS: readonly PresetKey[] = ['CRA', 'LOMIEN', 'CTENE'];
 
 const PARTY_SIZE_MIN = 1;
 const PARTY_SIZE_MAX = 6;
@@ -30,9 +25,11 @@ function filterFamiliesByCadence(families: SlateFamily[], filter: CadenceFilter)
  *
  * - Search + cadence-filter composition with the `MuleBossSlate.view`
  *   projection.
- * - Preset pill semantics — LOMIEN supersedes CRA in `activePresets`, and
- *   `togglePreset` strips every other active preset before applying the new
- *   one (Preset Swap).
+ * - **Preset Pill** semantics — `activePill` is derived each render via
+ *   **Same-Cadence Equality**; at most one canonical preset lights up, or
+ *   `null` when no canonical preset matches. `applyPreset` runs **Conform**
+ *   and short-circuits when the clicked preset is already the **Active
+ *   Pill**.
  * - Party-Size Clamp to [1, 6] on write.
  * - Toggle / reset dispatches routed through `onUpdate`. All dispatchers
  *   no-op when `muleId === null`.
@@ -58,10 +55,10 @@ export function useBossMatrixView({
   setFilter: (f: CadenceFilter) => void;
   visibleBosses: SlateFamily[];
   weeklyCount: number;
-  activePresets: ReadonlySet<PresetKey>;
+  activePill: PresetKey | null;
   stablePartySizes: Record<string, number>;
   toggleKey: (key: string) => void;
-  togglePreset: (preset: PresetKey) => void;
+  applyPreset: (preset: PresetKey) => void;
   setPartySize: (family: string, n: number) => void;
   resetBosses: () => void;
 } {
@@ -84,13 +81,10 @@ export function useBossMatrixView({
     [slate, search, filter],
   );
 
-  const activePresets = useMemo<ReadonlySet<PresetKey>>(() => {
-    const set = new Set(PRESET_KEYS.filter((p) => isPresetActive(p, selectedBosses as string[])));
-    // LOMIEN's resolved keys are a superset of CRA's, so both would light up
-    // whenever LOMIEN is fully selected. Prefer the more specific pill.
-    if (set.has('LOMIEN')) set.delete('CRA');
-    return set;
-  }, [selectedBosses]);
+  const activePill = useMemo<PresetKey | null>(
+    () => CANONICAL_PRESETS.find((p) => isPresetActive(p, selectedBosses)) ?? null,
+    [selectedBosses],
+  );
 
   const stablePartySizes = useMemo(() => partySizes ?? {}, [partySizes]);
 
@@ -102,29 +96,17 @@ export function useBossMatrixView({
     [muleId, slate, onUpdate],
   );
 
-  const togglePreset = useCallback(
+  const applyPreset = useCallback(
     (preset: PresetKey) => {
       if (!muleId) return;
-      const presetFamilies = PRESET_FAMILIES[preset];
-      let next: string[];
-      if (activePresets.has(preset)) {
-        next = removePreset(slate.keys as string[], presetFamilies);
-      } else {
-        // Preset Swap: strip every OTHER active preset's families first,
-        // then apply this one. Keeps at most one preset active at a time
-        // while preserving hand-picked selections outside any preset family.
-        let cleared = slate.keys as string[];
-        for (const other of activePresets) {
-          cleared = removePreset(cleared, PRESET_FAMILIES[other]);
-        }
-        next = applyPreset(cleared, presetFamilies);
-      }
-      // Normalize through construction so the Selection Invariant holds.
+      // Re-click on the Active Pill: no state churn, no persist fire.
+      if (activePill === preset) return;
+      const next = conform(slate.keys, preset);
       onUpdate(muleId, {
         selectedBosses: MuleBossSlate.from(next).keys as string[],
       });
     },
-    [muleId, slate, activePresets, onUpdate],
+    [muleId, slate, activePill, onUpdate],
   );
 
   const setPartySize = useCallback(
@@ -150,10 +132,10 @@ export function useBossMatrixView({
     setFilter,
     visibleBosses,
     weeklyCount: slate.weeklyCount,
-    activePresets,
+    activePill,
     stablePartySizes,
     toggleKey,
-    togglePreset,
+    applyPreset,
     setPartySize,
     resetBosses,
   };

--- a/src/components/__tests__/MatrixToolbar.test.tsx
+++ b/src/components/__tests__/MatrixToolbar.test.tsx
@@ -4,14 +4,13 @@ import { render, screen, fireEvent } from '@/test/test-utils';
 import { MatrixToolbar } from '../MatrixToolbar';
 
 const noop = () => {};
-const EMPTY_PRESETS: ReadonlySet<'CRA' | 'LOMIEN' | 'CTENE'> = new Set();
 
 function renderToolbar(overrides: Partial<Parameters<typeof MatrixToolbar>[0]> = {}) {
   const props = {
     filter: 'All' as const,
     onFilterChange: vi.fn(),
-    activePresets: EMPTY_PRESETS,
-    onTogglePreset: vi.fn(),
+    activePill: null as Parameters<typeof MatrixToolbar>[0]['activePill'],
+    onApplyPreset: vi.fn(),
     weeklyCount: 0,
     onReset: vi.fn(),
     ...overrides,
@@ -84,7 +83,6 @@ describe('MatrixToolbar', () => {
     const weeklyBtn = screen.getByRole('button', { name: /^weekly$/i });
     const svg = weeklyBtn.querySelector('svg');
     expect(svg).toBeTruthy();
-    // Calendar shape: rect + 2 lines for tabs + 1 horizontal line
     expect(svg?.querySelector('rect')).toBeTruthy();
     expect(svg?.querySelectorAll('line').length).toBeGreaterThanOrEqual(3);
   });
@@ -94,7 +92,6 @@ describe('MatrixToolbar', () => {
     const dailyBtn = screen.getByRole('button', { name: /^daily$/i });
     const svg = dailyBtn.querySelector('svg');
     expect(svg).toBeTruthy();
-    // Clock shape: circle + polyline for the hands
     expect(svg?.querySelector('circle')).toBeTruthy();
     expect(svg?.querySelector('polyline')).toBeTruthy();
   });
@@ -106,11 +103,9 @@ describe('MatrixToolbar', () => {
   });
 
   it('accepts the unused preset / count / reset props without crashing', () => {
-    // Smoke test: full prop surface is declared up front so future slices
-    // can add right-side controls without churning the API.
     renderToolbar({
-      activePresets: new Set(['CRA']),
-      onTogglePreset: noop,
+      activePill: 'CRA',
+      onApplyPreset: noop,
       weeklyCount: 5,
       onReset: noop,
     });
@@ -151,8 +146,6 @@ describe('MatrixToolbar', () => {
     it('uses JetBrains Mono at 11px for the count text', () => {
       renderToolbar({ weeklyCount: 3 });
       const count = screen.getByLabelText(/weekly boss selections/i) as HTMLElement;
-      // Either inline font-family or font-mono-nums class satisfies monospaced
-      // numerics; inline font-size must be 11px per the design spec.
       const hasMonoClass = count.classList.contains('font-mono-nums');
       const hasMonoInline = /JetBrains Mono/i.test(count.style.fontFamily ?? '');
       expect(hasMonoClass || hasMonoInline).toBe(true);
@@ -187,9 +180,6 @@ describe('MatrixToolbar', () => {
       expect(seps.length).toBeGreaterThanOrEqual(1);
       const count = screen.getByLabelText(/weekly boss selections/i);
       const resetBtn = screen.getByRole('button', { name: /^reset$/i });
-      // Find the separator that sits between the count and the reset button.
-      // After Slice 4, an earlier .d-toolbar-sep also separates the cadence
-      // filter from the Boss Presets control; that one is not the subject here.
       const sep = Array.from(seps).find((s) => {
         const countVsSep = count.compareDocumentPosition(s);
         const sepVsReset = s.compareDocumentPosition(resetBtn);
@@ -203,15 +193,15 @@ describe('MatrixToolbar', () => {
   });
 
   describe('Boss Presets segmented control', () => {
-    it('renders CRA and CTENE buttons after the Cadence Filter', () => {
+    it('renders CRA, LOMIEN, CTENE buttons after the Cadence Filter', () => {
       renderToolbar();
       expect(screen.getByRole('button', { name: /^cra$/i })).toBeTruthy();
+      expect(screen.getByRole('button', { name: /^lomien$/i })).toBeTruthy();
       expect(screen.getByRole('button', { name: /^ctene$/i })).toBeTruthy();
     });
 
     it('wraps the preset buttons in their own .d-c-toggle container', () => {
       const { container } = renderToolbar();
-      // Two .d-c-toggle groups: cadence filter (3 buttons) + preset row (3 buttons: CRA, LOMIEN, CTENE).
       const groups = container.querySelectorAll('.d-c-toggle');
       expect(groups.length).toBeGreaterThanOrEqual(2);
       const presetGroup = Array.from(groups).find((g) => {
@@ -239,35 +229,57 @@ describe('MatrixToolbar', () => {
       expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     });
 
-    it('applies the .on class to active preset pills only', () => {
-      renderToolbar({ activePresets: new Set(['CRA']) });
-      const craBtn = screen.getByRole('button', { name: /^cra$/i });
-      const cteneBtn = screen.getByRole('button', { name: /^ctene$/i });
-      expect(craBtn.classList.contains('on')).toBe(true);
-      expect(cteneBtn.classList.contains('on')).toBe(false);
+    it('applies the .on class to the single active pill only', () => {
+      renderToolbar({ activePill: 'CRA' });
+      expect(screen.getByRole('button', { name: /^cra$/i }).classList.contains('on')).toBe(true);
+      expect(screen.getByRole('button', { name: /^lomien$/i }).classList.contains('on')).toBe(
+        false,
+      );
+      expect(screen.getByRole('button', { name: /^ctene$/i }).classList.contains('on')).toBe(false);
     });
 
-    it('marks both pills active when activePresets holds CRA and CTENE', () => {
-      renderToolbar({ activePresets: new Set(['CRA', 'CTENE']) });
-      expect(screen.getByRole('button', { name: /^cra$/i }).classList.contains('on')).toBe(true);
+    it('lights LOMIEN when activePill === "LOMIEN"', () => {
+      renderToolbar({ activePill: 'LOMIEN' });
+      expect(screen.getByRole('button', { name: /^lomien$/i }).classList.contains('on')).toBe(true);
+      expect(screen.getByRole('button', { name: /^cra$/i }).classList.contains('on')).toBe(false);
+    });
+
+    it('lights CTENE when activePill === "CTENE"', () => {
+      renderToolbar({ activePill: 'CTENE' });
       expect(screen.getByRole('button', { name: /^ctene$/i }).classList.contains('on')).toBe(true);
     });
 
-    it('calls onTogglePreset with "CRA" when CRA is clicked', () => {
-      const onTogglePreset = vi.fn();
-      renderToolbar({ onTogglePreset });
+    it('lights no pills when activePill is null', () => {
+      renderToolbar({ activePill: null });
+      expect(screen.getByRole('button', { name: /^cra$/i }).classList.contains('on')).toBe(false);
+      expect(screen.getByRole('button', { name: /^lomien$/i }).classList.contains('on')).toBe(
+        false,
+      );
+      expect(screen.getByRole('button', { name: /^ctene$/i }).classList.contains('on')).toBe(false);
+    });
+
+    it('calls onApplyPreset with "CRA" when CRA is clicked', () => {
+      const onApplyPreset = vi.fn();
+      renderToolbar({ onApplyPreset });
       fireEvent.click(screen.getByRole('button', { name: /^cra$/i }));
-      expect(onTogglePreset).toHaveBeenCalledWith('CRA');
+      expect(onApplyPreset).toHaveBeenCalledWith('CRA');
     });
 
-    it('calls onTogglePreset with "CTENE" when CTENE is clicked', () => {
-      const onTogglePreset = vi.fn();
-      renderToolbar({ onTogglePreset });
+    it('calls onApplyPreset with "LOMIEN" when LOMIEN is clicked', () => {
+      const onApplyPreset = vi.fn();
+      renderToolbar({ onApplyPreset });
+      fireEvent.click(screen.getByRole('button', { name: /^lomien$/i }));
+      expect(onApplyPreset).toHaveBeenCalledWith('LOMIEN');
+    });
+
+    it('calls onApplyPreset with "CTENE" when CTENE is clicked', () => {
+      const onApplyPreset = vi.fn();
+      renderToolbar({ onApplyPreset });
       fireEvent.click(screen.getByRole('button', { name: /^ctene$/i }));
-      expect(onTogglePreset).toHaveBeenCalledWith('CTENE');
+      expect(onApplyPreset).toHaveBeenCalledWith('CTENE');
     });
 
-    it('renders a LOMIEN pill between CRA and CTENE', () => {
+    it('renders LOMIEN between CRA and CTENE', () => {
       renderToolbar();
       const craBtn = screen.getByRole('button', { name: /^cra$/i });
       const lomienBtn = screen.getByRole('button', { name: /^lomien$/i });
@@ -283,6 +295,7 @@ describe('MatrixToolbar', () => {
     it('preset buttons render no SVG icons', () => {
       renderToolbar();
       expect(screen.getByRole('button', { name: /^cra$/i }).querySelector('svg')).toBeNull();
+      expect(screen.getByRole('button', { name: /^lomien$/i }).querySelector('svg')).toBeNull();
       expect(screen.getByRole('button', { name: /^ctene$/i }).querySelector('svg')).toBeNull();
     });
   });

--- a/src/data/__tests__/bossPresets.test.ts
+++ b/src/data/__tests__/bossPresets.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
   PRESET_FAMILIES,
-  applyPreset,
-  removePreset,
+  conform,
   isPresetActive,
-  presetEntryKey,
+  normalizeEntry,
   presetEntryFamily,
+  presetEntryKey,
   type PresetFamily,
 } from '../bossPresets';
 import type { Boss, BossDifficulty } from '../../types';
@@ -13,10 +13,10 @@ import { bosses, getBossByFamily } from '../bosses';
 
 /**
  * Test-local key-shape helpers. The selection-key grammar itself is
- * module-private inside `muleBossSlate.ts`; these helpers just duplicate
- * its string shape so these tests can assert against bare `<uuid>:<tier>:<cadence>`
- * strings. Validation and invariants flow through `MuleBossSlate.from`
- * wherever preset output actually enters the app state.
+ * module-private inside `muleBossSlate.ts`; these helpers just duplicate its
+ * string shape so tests can assert against bare `<uuid>:<tier>:<cadence>`
+ * strings. Validation flows through `MuleBossSlate.from` wherever preset
+ * output actually enters app state.
  */
 function buildKey(
   bossId: string,
@@ -28,19 +28,6 @@ function buildKey(
 
 function pickHardest(boss: Boss): BossDifficulty {
   return boss.difficulty.reduce((best, d) => (d.crystalValue > best.crystalValue ? d : best));
-}
-
-/** Parse `<uuid>:<tier>:<cadence>` without any validation against boss data. */
-function shallowParseKey(key: string): { bossId: string; tier: string; cadence: string } | null {
-  const lastColon = key.lastIndexOf(':');
-  if (lastColon < 0) return null;
-  const tierColon = key.lastIndexOf(':', lastColon - 1);
-  if (tierColon < 0) return null;
-  return {
-    bossId: key.slice(0, tierColon),
-    tier: key.slice(tierColon + 1, lastColon),
-    cadence: key.slice(lastColon + 1),
-  };
 }
 
 const CRA_FAMILIES = [
@@ -57,23 +44,6 @@ const CRA_FAMILIES = [
   'princess-no',
 ] as const;
 
-const CTENE_FAMILIES: readonly PresetFamily[] = [
-  'akechi-mitsuhide',
-  'princess-no',
-  'darknell',
-  'verus-hilla',
-  'gloom',
-  'will',
-  'lucid',
-  'guardian-angel-slime',
-  'damien',
-  { family: 'lotus', tier: 'hard' },
-  'vellum',
-  'crimson-queen',
-  'papulatus',
-  'magnus',
-];
-
 const CTENE_OVERLAP = ['vellum', 'crimson-queen', 'papulatus', 'magnus', 'princess-no'] as const;
 
 /** Hardest-tier selection key for a family slug. */
@@ -83,7 +53,7 @@ function hardestKey(family: string): string {
   return buildKey(boss.id, diff.tier, diff.cadence);
 }
 
-/** Resolved selection key for a preset entry (respects tier overrides). */
+/** Resolved **Default Tier** key for a preset entry. */
 function entryKey(entry: PresetFamily): string {
   return presetEntryKey(entry)!;
 }
@@ -91,10 +61,6 @@ function entryKey(entry: PresetFamily): string {
 describe('PRESET_FAMILIES membership', () => {
   it('contains exactly the 11 CRA families in spec order', () => {
     expect(PRESET_FAMILIES.CRA).toEqual(CRA_FAMILIES);
-  });
-
-  it('contains exactly the 14 CTENE families in spec order', () => {
-    expect(PRESET_FAMILIES.CTENE).toEqual(CTENE_FAMILIES);
   });
 
   it('every CRA family resolves to a known boss', () => {
@@ -110,6 +76,13 @@ describe('PRESET_FAMILIES membership', () => {
     }
   });
 
+  it('every LOMIEN family resolves to a known boss', () => {
+    for (const entry of PRESET_FAMILIES.LOMIEN) {
+      const family = presetEntryFamily(entry);
+      expect(bosses.find((b) => b.family === family)).toBeDefined();
+    }
+  });
+
   it('CRA ∩ CTENE shares Vellum, Crimson Queen, Papulatus, Magnus, Princess No', () => {
     const craSet: ReadonlySet<string> = new Set(PRESET_FAMILIES.CRA);
     const overlap = PRESET_FAMILIES.CTENE.map(presetEntryFamily).filter((f) => craSet.has(f));
@@ -117,192 +90,230 @@ describe('PRESET_FAMILIES membership', () => {
   });
 });
 
-describe('applyPreset', () => {
-  it('selects the hardest-tier key for each preset family from an empty selection', () => {
-    const result = applyPreset([], PRESET_FAMILIES.CRA);
-    const expected = CRA_FAMILIES.map(hardestKey);
+describe('normalizeEntry', () => {
+  it('resolves a bare family to Default Tier = Hardest Tier', () => {
+    const entry = normalizeEntry('vellum')!;
+    const vellum = getBossByFamily('vellum')!;
+    expect(entry).toEqual({ family: 'vellum', tiers: [pickHardest(vellum).tier] });
+  });
+
+  it('desugars legacy { family, tier } to a single-element tiers list', () => {
+    const entry = normalizeEntry({ family: 'lotus', tier: 'hard' })!;
+    expect(entry).toEqual({ family: 'lotus', tiers: ['hard'] });
+  });
+
+  it('passes { family, tiers } through with tiers[0] as Default Tier', () => {
+    const entry = normalizeEntry({ family: 'damien', tiers: ['normal', 'hard'] })!;
+    expect(entry.family).toBe('damien');
+    expect(entry.tiers).toEqual(['normal', 'hard']);
+    expect(entry.tiers[0]).toBe('normal');
+  });
+
+  it('returns null for an unknown family', () => {
+    expect(normalizeEntry('not-a-real-family')).toBeNull();
+  });
+});
+
+describe('LOMIEN multi-tier entries', () => {
+  it('Lotus and Damien accept both normal and hard', () => {
+    const lotusEntry = PRESET_FAMILIES.LOMIEN.find(
+      (e) => typeof e === 'object' && e.family === 'lotus',
+    );
+    const damienEntry = PRESET_FAMILIES.LOMIEN.find(
+      (e) => typeof e === 'object' && e.family === 'damien',
+    );
+    expect(lotusEntry).toBeDefined();
+    expect(damienEntry).toBeDefined();
+    expect(normalizeEntry(lotusEntry!)!.tiers).toEqual(['normal', 'hard']);
+    expect(normalizeEntry(damienEntry!)!.tiers).toEqual(['normal', 'hard']);
+  });
+
+  it('non-Lotus-non-Damien LOMIEN entries remain single-tier at Hardest Tier', () => {
+    for (const spec of PRESET_FAMILIES.LOMIEN) {
+      const family = presetEntryFamily(spec);
+      if (family === 'lotus' || family === 'damien') continue;
+      const entry = normalizeEntry(spec)!;
+      expect(entry.tiers).toHaveLength(1);
+      const boss = getBossByFamily(family)!;
+      expect(entry.tiers[0]).toBe(pickHardest(boss).tier);
+    }
+  });
+
+  it('LOMIEN default tier for Lotus and Damien is normal', () => {
+    const lotus = getBossByFamily('lotus')!;
+    const damien = getBossByFamily('damien')!;
+    expect(entryKey({ family: 'lotus', tiers: ['normal', 'hard'] })).toBe(
+      buildKey(lotus.id, 'normal', 'weekly'),
+    );
+    expect(entryKey({ family: 'damien', tiers: ['normal', 'hard'] })).toBe(
+      buildKey(damien.id, 'normal', 'weekly'),
+    );
+  });
+});
+
+describe('isPresetActive — Same-Cadence Equality', () => {
+  it('returns false for an empty selection', () => {
+    expect(isPresetActive('CRA', [])).toBe(false);
+    expect(isPresetActive('LOMIEN', [])).toBe(false);
+    expect(isPresetActive('CTENE', [])).toBe(false);
+  });
+
+  it('returns true for CRA when every CRA entry is satisfied at Hardest Tier', () => {
+    const keys = PRESET_FAMILIES.CRA.map(hardestKey);
+    expect(isPresetActive('CRA', keys)).toBe(true);
+  });
+
+  it('returns true for CTENE when all 14 resolved keys are present', () => {
+    const keys = PRESET_FAMILIES.CTENE.map(entryKey);
+    expect(isPresetActive('CTENE', keys)).toBe(true);
+  });
+
+  it('subset no longer matches: missing one CRA family returns false', () => {
+    const keys = PRESET_FAMILIES.CRA.map(hardestKey).filter((k) => k !== hardestKey('magnus'));
+    expect(isPresetActive('CRA', keys)).toBe(false);
+  });
+
+  it('non-preset weekly breaks the match (CRA + extra weekly Arkarium)', () => {
+    const arkarium = getBossByFamily('arkarium')!;
+    const arkariumWeekly = buildKey(arkarium.id, pickHardest(arkarium).tier, 'weekly');
+    const keys = [...PRESET_FAMILIES.CRA.map(hardestKey), arkariumWeekly];
+    expect(isPresetActive('CRA', keys)).toBe(false);
+  });
+
+  it('daily-only selections never trigger a canonical match', () => {
+    const vellum = getBossByFamily('vellum')!;
+    const vellumDaily = buildKey(vellum.id, 'normal', 'daily');
+    expect(isPresetActive('CRA', [vellumDaily])).toBe(false);
+  });
+
+  it('daily keys do not affect the match for an otherwise exact weekly selection', () => {
+    const horntail = getBossByFamily('horntail')!;
+    const horntailDaily = buildKey(horntail.id, 'chaos', 'daily');
+    const keys = [...PRESET_FAMILIES.CRA.map(hardestKey), horntailDaily];
+    expect(isPresetActive('CRA', keys)).toBe(true);
+  });
+
+  it('LOMIEN accepts Normal Damien (Default Tier)', () => {
+    const keys = PRESET_FAMILIES.LOMIEN.map(entryKey);
+    expect(isPresetActive('LOMIEN', keys)).toBe(true);
+  });
+
+  it('LOMIEN accepts Hard Damien + Hard Lotus as multi-tier swap', () => {
+    const damien = getBossByFamily('damien')!;
+    const lotus = getBossByFamily('lotus')!;
+    const baseKeys = PRESET_FAMILIES.LOMIEN.map(entryKey);
+    const swapped = baseKeys
+      .filter((k) => !k.startsWith(`${damien.id}:`) && !k.startsWith(`${lotus.id}:`))
+      .concat([buildKey(damien.id, 'hard', 'weekly'), buildKey(lotus.id, 'hard', 'weekly')]);
+    expect(isPresetActive('LOMIEN', swapped)).toBe(true);
+  });
+
+  it('LOMIEN rejects Extreme Lotus (outside Accepted Tiers)', () => {
+    const lotus = getBossByFamily('lotus')!;
+    const baseKeys = PRESET_FAMILIES.LOMIEN.map(entryKey);
+    const extremeSwap = baseKeys
+      .filter((k) => !k.startsWith(`${lotus.id}:`))
+      .concat([buildKey(lotus.id, 'extreme', 'weekly')]);
+    expect(isPresetActive('LOMIEN', extremeSwap)).toBe(false);
+  });
+
+  it('returns false when a family has only a lower-tier key than the single-tier entry', () => {
+    const vellum = getBossByFamily('vellum')!;
+    const keys = PRESET_FAMILIES.CRA.map(hardestKey)
+      .filter((k) => !k.startsWith(`${vellum.id}:`))
+      .concat([buildKey(vellum.id, 'normal', 'weekly')]);
+    expect(isPresetActive('CRA', keys)).toBe(false);
+  });
+});
+
+describe('conform', () => {
+  it('fills every preset entry at Default Tier from empty', () => {
+    const result = conform([], 'CRA');
+    const expected = PRESET_FAMILIES.CRA.map(hardestKey);
     expect(new Set(result)).toEqual(new Set(expected));
     expect(result).toHaveLength(CRA_FAMILIES.length);
   });
 
-  it('preserves pre-existing non-preset keys', () => {
-    const lucid = hardestKey('lucid');
-    const result = applyPreset([lucid], PRESET_FAMILIES.CRA);
-    expect(result).toContain(lucid);
-    for (const f of PRESET_FAMILIES.CRA) {
-      expect(result).toContain(hardestKey(f));
-    }
-  });
-
-  it('is idempotent: applying twice yields the same set', () => {
-    const once = applyPreset([], PRESET_FAMILIES.CRA);
-    const twice = applyPreset(once, PRESET_FAMILIES.CRA);
+  it('is idempotent on an Active Preset selection', () => {
+    const once = conform([], 'CRA');
+    const twice = conform(once, 'CRA');
     expect(new Set(twice)).toEqual(new Set(once));
   });
 
-  it('swaps a lower-tier same-cadence selection up to the hardest tier', () => {
-    // Start with a lower-tier Vellum daily selection (Normal Vellum daily).
-    const vellum = getBossByFamily('vellum')!;
-    const lowDailyKey = buildKey(vellum.id, 'normal', 'daily');
-    const result = applyPreset([lowDailyKey], ['vellum']);
-    // Hardest Vellum is chaos weekly; the daily entry is on a different
-    // cadence bucket so both selections coexist.
-    const hardestWeekly = hardestKey('vellum');
-    expect(result).toContain(hardestWeekly);
-    // Daily selection is preserved — applyPreset only swaps *same-cadence*
-    // siblings on the same boss, so opposite-cadence selections coexist.
-    expect(result).toContain(lowDailyKey);
-  });
-
-  it('keeps CRA and CTENE overlap intact when both are applied', () => {
-    const withCra = applyPreset([], PRESET_FAMILIES.CRA);
-    const withBoth = applyPreset(withCra, PRESET_FAMILIES.CTENE);
-    for (const f of CTENE_OVERLAP) {
-      expect(withBoth).toContain(hardestKey(f));
-    }
-    // All CRA and all CTENE resolved keys present.
-    for (const f of PRESET_FAMILIES.CRA) {
-      expect(withBoth).toContain(hardestKey(f));
-    }
-    for (const entry of PRESET_FAMILIES.CTENE) {
-      expect(withBoth).toContain(entryKey(entry));
-    }
-  });
-
-  it('selects Hard Lotus (not Extreme) for the CTENE preset', () => {
-    const result = applyPreset([], PRESET_FAMILIES.CTENE);
-    const lotus = getBossByFamily('lotus')!;
-    const hardLotus = buildKey(lotus.id, 'hard', 'weekly');
-    const extremeLotus = buildKey(lotus.id, 'extreme', 'weekly');
-    expect(result).toContain(hardLotus);
-    expect(result).not.toContain(extremeLotus);
-  });
-});
-
-describe('LOMIEN preset', () => {
-  it('applies CRA hardest keys plus Normal Lotus and Normal Damien from empty', () => {
-    const result = applyPreset([], PRESET_FAMILIES.LOMIEN);
+  it('wipes weekly keys on non-preset families', () => {
+    const arkarium = getBossByFamily('arkarium')!;
+    const arkariumWeekly = buildKey(arkarium.id, pickHardest(arkarium).tier, 'weekly');
+    const result = conform([...PRESET_FAMILIES.CRA.map(hardestKey), arkariumWeekly], 'CRA');
+    expect(result).not.toContain(arkariumWeekly);
     for (const f of CRA_FAMILIES) {
       expect(result).toContain(hardestKey(f));
     }
-    const lotus = getBossByFamily('lotus')!;
+  });
+
+  it('preserves a weekly key whose tier is in Accepted Tiers (Hard Damien on LOMIEN)', () => {
     const damien = getBossByFamily('damien')!;
+    const hardDamien = buildKey(damien.id, 'hard', 'weekly');
+    const result = conform([hardDamien], 'LOMIEN');
+    expect(result).toContain(hardDamien);
+    expect(isPresetActive('LOMIEN', result)).toBe(true);
+  });
+
+  it('replaces a non-accepted-tier weekly key with the Default Tier key', () => {
+    const damien = getBossByFamily('damien')!;
+    // Damien has normal, hard; 'easy' isn't offered. Use extreme Lotus as the
+    // non-accepted-tier example instead — LOMIEN Lotus accepts [normal, hard].
+    const lotus = getBossByFamily('lotus')!;
+    const extremeLotus = buildKey(lotus.id, 'extreme', 'weekly');
+    const result = conform([extremeLotus], 'LOMIEN');
+    expect(result).not.toContain(extremeLotus);
     expect(result).toContain(buildKey(lotus.id, 'normal', 'weekly'));
+    // And Damien Default Tier was filled in.
     expect(result).toContain(buildKey(damien.id, 'normal', 'weekly'));
   });
 
-  it('includes Akechi Mitsuhide', () => {
-    const result = applyPreset([], PRESET_FAMILIES.LOMIEN);
-    expect(result).toContain(hardestKey('akechi-mitsuhide'));
-  });
-});
-
-describe('removePreset', () => {
-  it('drops every key whose boss family is in the list', () => {
-    const withCra = applyPreset([], PRESET_FAMILIES.CRA);
-    const result = removePreset(withCra, PRESET_FAMILIES.CRA);
-    expect(result).toEqual([]);
-  });
-
-  it('preserves non-preset keys', () => {
-    const lucid = hardestKey('lucid');
-    const withCra = applyPreset([lucid], PRESET_FAMILIES.CRA);
-    const result = removePreset(withCra, PRESET_FAMILIES.CRA);
-    expect(result).toEqual([lucid]);
-  });
-
-  it('drops ALL keys for a family in the list, regardless of tier/cadence', () => {
+  it('preserves daily keys (different cadence is orthogonal to preset)', () => {
+    const horntail = getBossByFamily('horntail')!;
+    const horntailDaily = buildKey(horntail.id, 'chaos', 'daily');
     const vellum = getBossByFamily('vellum')!;
-    const normalDaily = buildKey(vellum.id, 'normal', 'daily');
-    const chaosWeekly = buildKey(vellum.id, 'chaos', 'weekly');
-    const result = removePreset([normalDaily, chaosWeekly], ['vellum']);
-    expect(result).toEqual([]);
+    const vellumDaily = buildKey(vellum.id, 'normal', 'daily');
+    const result = conform([horntailDaily, vellumDaily], 'CRA');
+    expect(result).toContain(horntailDaily);
+    expect(result).toContain(vellumDaily);
   });
 
-  it('leaves CTENE overlap intact when only CRA is removed while CTENE is still active', () => {
-    // Apply CRA and CTENE; then remove CRA. The 4 overlap families
-    // (Vellum, CQ, Papulatus, Magnus) must come back because CTENE still
-    // holds them — but under the spec, removePreset drops those families
-    // outright. The invariant is that the CALLER (MuleDetailDrawer) uses
-    // isPresetActive to choose whether to call applyPreset or removePreset,
-    // and the overlap persistence is realized by re-applying CTENE after
-    // CRA-remove. At the helper level: removePreset(CRA) drops all 10 CRA
-    // families including the overlap.
-    const withBoth = applyPreset(applyPreset([], PRESET_FAMILIES.CRA), PRESET_FAMILIES.CTENE);
-    const afterCraRemoved = removePreset(withBoth, PRESET_FAMILIES.CRA);
-    // Non-overlap CTENE families survive.
-    const craSet: ReadonlySet<string> = new Set(CRA_FAMILIES);
-    for (const entry of PRESET_FAMILIES.CTENE) {
-      if (craSet.has(presetEntryFamily(entry))) continue;
-      expect(afterCraRemoved).toContain(entryKey(entry));
+  it('CRA → LOMIEN swap: preserves CRA-∩-LOMIEN overlap + adds LOMIEN-unique families', () => {
+    const withCra = conform([], 'CRA');
+    const withLomien = conform(withCra, 'LOMIEN');
+    for (const f of CRA_FAMILIES) {
+      expect(withLomien).toContain(hardestKey(f));
     }
-    // Overlap dropped (not re-added by this helper).
-    for (const f of CTENE_OVERLAP) {
-      expect(afterCraRemoved).not.toContain(hardestKey(f));
+    const akechi = getBossByFamily('akechi-mitsuhide')!;
+    const damien = getBossByFamily('damien')!;
+    const lotus = getBossByFamily('lotus')!;
+    expect(withLomien).toContain(buildKey(akechi.id, pickHardest(akechi).tier, 'weekly'));
+    expect(withLomien).toContain(buildKey(damien.id, 'normal', 'weekly'));
+    expect(withLomien).toContain(buildKey(lotus.id, 'normal', 'weekly'));
+    expect(isPresetActive('LOMIEN', withLomien)).toBe(true);
+  });
+
+  it('CRA → CTENE swap: wipes CRA-only families, keeps overlap at Hardest Tier', () => {
+    const withCra = conform([], 'CRA');
+    const withCtene = conform(withCra, 'CTENE');
+    const cteneFamilies = new Set(PRESET_FAMILIES.CTENE.map(presetEntryFamily));
+    for (const f of CRA_FAMILIES) {
+      if (cteneFamilies.has(f)) {
+        expect(withCtene).toContain(hardestKey(f));
+      } else {
+        expect(withCtene).not.toContain(hardestKey(f));
+      }
     }
-  });
-
-  it('ignores malformed keys in the input (no crash)', () => {
-    const result = removePreset(['stale-key'], PRESET_FAMILIES.CRA);
-    // Malformed keys have no parseable bossId; they are preserved since
-    // they do not match any family in the drop list.
-    expect(result).toEqual(['stale-key']);
-  });
-
-  it('returns empty input unchanged', () => {
-    expect(removePreset([], PRESET_FAMILIES.CRA)).toEqual([]);
-  });
-});
-
-describe('isPresetActive', () => {
-  it('returns false for an empty selection', () => {
-    expect(isPresetActive('CRA', [])).toBe(false);
-    expect(isPresetActive('CTENE', [])).toBe(false);
-  });
-
-  it('returns true iff every preset entry has its resolved key present', () => {
-    const withCra = applyPreset([], PRESET_FAMILIES.CRA);
-    expect(isPresetActive('CRA', withCra)).toBe(true);
-    expect(isPresetActive('CTENE', withCra)).toBe(false);
-  });
-
-  it('returns false when one CRA family is missing', () => {
-    const withCra = applyPreset([], PRESET_FAMILIES.CRA);
-    // Drop just Magnus's hardest key.
-    const magnusHard = hardestKey('magnus');
-    const missingOne = withCra.filter((k) => k !== magnusHard);
-    expect(isPresetActive('CRA', missingOne)).toBe(false);
-  });
-
-  it('returns false when a family has only a lower-tier key', () => {
-    // Replace the hardest Vellum key with Normal (daily) — lower tier.
-    const withCra = applyPreset([], PRESET_FAMILIES.CRA);
-    const vellum = getBossByFamily('vellum')!;
-    const hardestVellum = hardestKey('vellum');
-    const normalDaily = buildKey(vellum.id, 'normal', 'daily');
-    const downgraded = withCra.filter((k) => k !== hardestVellum).concat(normalDaily);
-    expect(isPresetActive('CRA', downgraded)).toBe(false);
-  });
-
-  it('returns true for CTENE iff all 14 resolved keys are present', () => {
-    const withCtene = applyPreset([], PRESET_FAMILIES.CTENE);
     expect(isPresetActive('CTENE', withCtene)).toBe(true);
   });
-});
 
-describe('cross-helper sanity', () => {
-  it('applyPreset output has parseable keys for every family', () => {
-    const keys = applyPreset([], PRESET_FAMILIES.CRA);
-    for (const k of keys) {
-      expect(shallowParseKey(k)).not.toBeNull();
-    }
-  });
-
-  it('removePreset output has parseable keys (or malformed pass-through)', () => {
-    const withCra = applyPreset([], PRESET_FAMILIES.CRA);
-    const lucid = hardestKey('lucid');
-    const partial = removePreset([...withCra, lucid], PRESET_FAMILIES.CRA);
-    expect(partial).toEqual([lucid]);
-    expect(shallowParseKey(partial[0])).not.toBeNull();
+  it('CTENE selects Hard Lotus (not Extreme)', () => {
+    const result = conform([], 'CTENE');
+    const lotus = getBossByFamily('lotus')!;
+    expect(result).toContain(buildKey(lotus.id, 'hard', 'weekly'));
+    expect(result).not.toContain(buildKey(lotus.id, 'extreme', 'weekly'));
   });
 });

--- a/src/data/bossPresets.ts
+++ b/src/data/bossPresets.ts
@@ -2,80 +2,88 @@ import type { Boss, BossCadence, BossDifficulty, BossTier } from '../types';
 import { getBossByFamily } from './bosses';
 
 /**
- * Boss Preset shortcuts for the Matrix Toolbar. Each preset is a fixed list
- * of boss family entries; clicking a preset pill swaps in (or drops) one
- * selection key per entry. A bare family slug resolves to the Hardest-Tier
- * key; an `{ family, tier }` entry pins a specific tier (e.g. CTENE's Hard
- * Lotus, chosen over the Extreme tier most mules can't clear).
+ * **Boss Preset** shortcuts for the **Matrix Toolbar**. Each preset is an
+ * ordered list of **Preset Entries**; clicking a **Preset Pill** runs
+ * **Conform**, which wipes weekly **Slate Keys** whose family is outside the
+ * preset and replaces non-**Accepted Tier** keys with the **Default Tier**.
+ * Dailies are always preserved.
  *
- * Single-select swap semantics: at most one preset pill is ever active.
- * Clicking an inactive preset while another is active first removes the
- * previously active preset's families from the selection, then applies the
- * clicked preset — so the CRA ∩ CTENE overlap (Vellum / Crimson Queen /
- * Papulatus / Magnus / Princess No) is just re-added by the apply step with
- * the clicked preset's resolved tiers, no special-casing needed. Clicking
- * the currently active preset deselects it. The drawer-level handler owns
- * this policy; the helpers below (`applyPreset` / `removePreset` /
- * `isPresetActive`) stay single-purpose and family-scoped.
+ * Entry authoring forms:
+ * - Bare string — family slug; **Accepted Tiers** = `[hardest]`.
+ * - `{ family, tier }` — legacy single-tier pin; desugars to `tiers: [tier]`.
+ * - `{ family, tiers }` — **Multi-Tier Entry** (e.g. LOMIEN's Damien and
+ *   Lotus `['normal', 'hard']`); `tiers[0]` is the **Default Tier**.
+ *
+ * **Same-Cadence Equality**: a **Canonical Preset** is **Active Preset** iff
+ * every **Preset Entry** is satisfied by exactly one weekly key on that
+ * family whose tier is in **Accepted Tiers**, and no weekly keys exist on
+ * families outside the preset's entries. Daily keys never affect the result.
  *
  * The selection-key grammar itself lives module-private inside
- * `muleBossSlate.ts`; the two tiny helpers below duplicate only the string
- * shape, because every key this module produces flows through
- * `MuleBossSlate.from` or `slate.toggle` downstream where the Selection
- * Invariant is actually enforced.
+ * `muleBossSlate.ts`; the helpers here duplicate only the string shape,
+ * because every key this module produces flows through `MuleBossSlate.from`
+ * or `slate.toggle` downstream where the **Selection Invariant** is actually
+ * enforced.
  */
 
-/** Build a native `<uuid>:<tier>:<cadence>` selection key. */
-function buildSelectionKey(bossId: string, tier: BossTier, cadence: BossCadence): string {
-  return `${bossId}:${tier}:${cadence}`;
+export type PresetKey = 'CRA' | 'LOMIEN' | 'CTENE';
+
+/** Authoring form for a preset entry; normalized via `normalizeEntry`. */
+export type PresetFamily =
+  | string
+  | { family: string; tier: BossTier }
+  | { family: string; tiers: readonly BossTier[] };
+
+/** Normalized **Preset Entry**; `tiers[0]` is the **Default Tier**. */
+export interface PresetEntry {
+  family: string;
+  tiers: readonly BossTier[];
 }
 
-/**
- * Extract the bossId prefix from a selection key. Returns `null` for any
- * string that doesn't have at least two colons, so malformed keys can pass
- * through `removePreset` untouched.
- */
-function keyBossIdPrefix(key: string): string | null {
+/** Shallow-parsed segments of a `<bossId>:<tier>:<cadence>` selection key. */
+interface ParsedKey {
+  bossId: string;
+  tier: string;
+  cadence: string;
+}
+
+/** Split a selection key on its last two colons; `null` if malformed. */
+function parseKey(key: string): ParsedKey | null {
   const lastColon = key.lastIndexOf(':');
   if (lastColon < 0) return null;
   const tierColon = key.lastIndexOf(':', lastColon - 1);
   if (tierColon < 0) return null;
-  return key.slice(0, tierColon);
+  return {
+    bossId: key.slice(0, tierColon),
+    tier: key.slice(tierColon + 1, lastColon),
+    cadence: key.slice(lastColon + 1),
+  };
 }
 
-/** Extract the `<cadence>` tail segment of a selection key, if present. */
-function keyCadenceSuffix(key: string): string | null {
-  const lastColon = key.lastIndexOf(':');
-  if (lastColon < 0) return null;
-  return key.slice(lastColon + 1);
+function buildSelectionKey(bossId: string, tier: BossTier, cadence: BossCadence): string {
+  return `${bossId}:${tier}:${cadence}`;
 }
 
-/**
- * Return the difficulty entry with the highest crystalValue for this boss.
- * "Hardest" means "biggest numeric reward", irrespective of tier name or
- * cadence — e.g. Vellum's weekly chaos beats its daily normal.
- */
+/** Hardest-Tier difficulty — biggest `crystalValue` wins, tier name ignored. */
 function pickHardest(boss: Boss): BossDifficulty {
   return boss.difficulty.reduce((best, d) => (d.crystalValue > best.crystalValue ? d : best));
 }
 
-/** Resolve a preset entry to `{ boss, diff }`, or `null` on an unknown family/tier. */
-function resolveEntry(entry: PresetFamily): { boss: Boss; diff: BossDifficulty } | null {
-  const { family, tier } = entryInfo(entry);
-  const boss = getBossByFamily(family);
-  if (!boss) return null;
-  const diff = tier ? boss.difficulty.find((d) => d.tier === tier) : pickHardest(boss);
-  if (!diff) return null;
-  return { boss, diff };
-}
-
-export type PresetKey = 'CRA' | 'LOMIEN' | 'CTENE';
-
 /**
- * A preset entry is either a family slug (resolves to the hardest tier) or
- * an `{ family, tier }` object that pins a specific tier for that family.
+ * Desugar an authoring-form entry into a normalized `PresetEntry`. Bare
+ * strings resolve **Default Tier** to the boss's **Hardest Tier**; legacy
+ * `{ family, tier }` becomes `tiers: [tier]`; `{ family, tiers }` passes
+ * through. Returns `null` for unknown families.
  */
-export type PresetFamily = string | { family: string; tier: BossTier };
+export function normalizeEntry(spec: PresetFamily): PresetEntry | null {
+  if (typeof spec === 'string') {
+    const boss = getBossByFamily(spec);
+    if (!boss) return null;
+    return { family: spec, tiers: [pickHardest(boss).tier] };
+  }
+  if ('tiers' in spec) return { family: spec.family, tiers: spec.tiers };
+  return { family: spec.family, tiers: [spec.tier] };
+}
 
 export const PRESET_FAMILIES = {
   CRA: [
@@ -104,8 +112,8 @@ export const PRESET_FAMILIES = {
     'zakum',
     'princess-no',
     'akechi-mitsuhide',
-    { family: 'lotus', tier: 'normal' },
-    { family: 'damien', tier: 'normal' },
+    { family: 'lotus', tiers: ['normal', 'hard'] },
+    { family: 'damien', tiers: ['normal', 'hard'] },
   ],
   CTENE: [
     'akechi-mitsuhide',
@@ -125,85 +133,104 @@ export const PRESET_FAMILIES = {
   ],
 } as const satisfies Record<PresetKey, readonly PresetFamily[]>;
 
-/** Unwrap a preset entry to `{ family, tier? }`. */
-function entryInfo(entry: PresetFamily): { family: string; tier?: BossTier } {
-  return typeof entry === 'string' ? { family: entry } : entry;
+/** Resolved **Default Tier** selection key for an entry, or `null`. */
+export function presetEntryKey(spec: PresetFamily): string | null {
+  const entry = normalizeEntry(spec);
+  if (!entry) return null;
+  return defaultTierKey(entry);
+}
+
+/** Family slug for an authoring-form entry. */
+export function presetEntryFamily(spec: PresetFamily): string {
+  return typeof spec === 'string' ? spec : spec.family;
+}
+
+/** Resolved **Default Tier** key for a normalized entry, or `null`. */
+function defaultTierKey(entry: PresetEntry): string | null {
+  const boss = getBossByFamily(entry.family);
+  if (!boss) return null;
+  const diff = boss.difficulty.find((d) => d.tier === entry.tiers[0]);
+  if (!diff) return null;
+  return buildSelectionKey(boss.id, diff.tier, diff.cadence);
 }
 
 /**
- * Selection key for a preset entry — uses the explicit tier if the entry
- * specifies one, else falls back to the hardest tier. Returns null if the
- * family is unknown or the pinned tier isn't offered by the boss.
+ * Build `{ bossId → entry }` for a preset's entries. Entries whose family
+ * doesn't resolve are skipped so callers can iterate without null checks.
  */
-export function presetEntryKey(entry: PresetFamily): string | null {
-  const resolved = resolveEntry(entry);
-  if (!resolved) return null;
-  return buildSelectionKey(resolved.boss.id, resolved.diff.tier, resolved.diff.cadence);
-}
-
-/** Family slug for a preset entry (unwraps the `{ family, tier }` form). */
-export function presetEntryFamily(entry: PresetFamily): string {
-  return entryInfo(entry).family;
-}
-
-/**
- * Swap each entry's target selection key into `keys`. Any prior same-cadence
- * sibling on that boss is replaced in-place (opposite-cadence selections are
- * preserved so a mule keeps its daily + weekly selections side-by-side).
- */
-export function applyPreset(keys: string[], families: readonly PresetFamily[]): string[] {
-  let next = keys;
-  for (const entry of families) {
-    const resolved = resolveEntry(entry);
-    if (!resolved) continue;
-    const { boss, diff } = resolved;
-    const target = buildSelectionKey(boss.id, diff.tier, diff.cadence);
-    if (next.includes(target)) continue; // idempotent
-
-    // Same-cadence sibling on this boss: replace in-place so array order
-    // (and opposite-cadence selections) are preserved.
-    const siblingIdx = next.findIndex(
-      (k) => keyBossIdPrefix(k) === boss.id && keyCadenceSuffix(k) === diff.cadence,
-    );
-    if (siblingIdx >= 0) {
-      next = next.map((k, i) => (i === siblingIdx ? target : k));
-    } else {
-      next = [...next, target];
-    }
+function entryByBossId(preset: PresetKey): Map<string, PresetEntry> {
+  const map = new Map<string, PresetEntry>();
+  for (const spec of PRESET_FAMILIES[preset]) {
+    const entry = normalizeEntry(spec);
+    if (!entry) continue;
+    const boss = getBossByFamily(entry.family);
+    if (!boss) continue;
+    map.set(boss.id, entry);
   }
-  return next;
+  return map;
 }
 
 /**
- * Drop every key whose bossId resolves to a family in `families`. Malformed
- * keys (unparseable) pass through untouched. Tier overrides on entries are
- * ignored here — removal is family-wide, matching the "Ctrl-click the pill
- * to clear the whole preset" gesture.
+ * **Same-Cadence Equality**: `true` iff every **Preset Entry** is satisfied
+ * by exactly one weekly key whose tier is in **Accepted Tiers**, AND no
+ * weekly keys exist on families outside the preset's entries. Daily keys
+ * are ignored entirely.
  */
-export function removePreset(keys: string[], families: readonly PresetFamily[]): string[] {
-  const dropFamilyIds = new Set<string>();
-  for (const entry of families) {
-    const boss = getBossByFamily(entryInfo(entry).family);
-    if (boss) dropFamilyIds.add(boss.id);
+export function isPresetActive(preset: PresetKey, keys: readonly string[]): boolean {
+  const entries = entryByBossId(preset);
+  const weeklyTierByBossId = new Map<string, string>();
+
+  for (const key of keys) {
+    const parsed = parseKey(key);
+    if (!parsed || parsed.cadence !== 'weekly') continue;
+    // Any weekly key on a non-preset family breaks the match.
+    if (!entries.has(parsed.bossId)) return false;
+    weeklyTierByBossId.set(parsed.bossId, parsed.tier);
   }
-  return keys.filter((k) => {
-    const bossId = keyBossIdPrefix(k);
-    if (bossId === null) return true;
-    return !dropFamilyIds.has(bossId);
-  });
-}
 
-/**
- * Active iff every preset entry has its resolved key present in `keys`.
- * Mirrors the visual: pill highlights iff the selection state fully matches
- * what `applyPreset` would have produced.
- */
-export function isPresetActive(preset: PresetKey, keys: string[]): boolean {
-  const keySet = new Set(keys);
-  for (const entry of PRESET_FAMILIES[preset]) {
-    const target = presetEntryKey(entry);
-    if (!target) return false;
-    if (!keySet.has(target)) return false;
+  for (const [bossId, entry] of entries) {
+    const tier = weeklyTierByBossId.get(bossId);
+    if (!tier) return false;
+    if (!entry.tiers.includes(tier as BossTier)) return false;
   }
   return true;
+}
+
+/**
+ * **Conform** the mule's selection to `preset`:
+ *
+ * - Preserve weekly keys whose family is in the preset's entries AND whose
+ *   tier is in **Accepted Tiers**.
+ * - Wipe every other weekly key (non-preset families + non-accepted tiers).
+ * - For every entry not already satisfied, add the **Default Tier** key.
+ * - All daily keys pass through untouched.
+ *
+ * Idempotent on an already-**Active Preset** selection.
+ */
+export function conform(keys: readonly string[], preset: PresetKey): string[] {
+  const entries = entryByBossId(preset);
+  const next: string[] = [];
+  const satisfied = new Set<string>();
+
+  for (const key of keys) {
+    const parsed = parseKey(key);
+    // Malformed keys (un-parseable) pass through. Dailies pass through too.
+    if (!parsed || parsed.cadence !== 'weekly') {
+      next.push(key);
+      continue;
+    }
+    const entry = entries.get(parsed.bossId);
+    if (!entry) continue; // weekly on non-preset family → wipe
+    if (!entry.tiers.includes(parsed.tier as BossTier)) continue; // non-accepted tier → wipe
+    next.push(key);
+    satisfied.add(parsed.bossId);
+  }
+
+  for (const [bossId, entry] of entries) {
+    if (satisfied.has(bossId)) continue;
+    const key = defaultTierKey(entry);
+    if (key) next.push(key);
+  }
+
+  return next;
 }


### PR DESCRIPTION
## Summary
- Replace subset-match `isPresetActive` + additive `applyPreset` with **Same-Cadence Equality** + **Conform**: clicking a **Preset Pill** wipes non-preset weekly **Slate Keys**, replaces non-accepted tiers with the **Default Tier**, and short-circuits when the clicked preset is already the **Active Pill**.
- Evolve `PresetFamily` to accept a `{ family, tiers }` spec; LOMIEN's Lotus and Damien become **Multi-Tier Entries** accepting `['normal', 'hard']` with default `normal`, so Normal↔Hard swaps on those families preserve LOMIEN's active status.
- Collapse `activePresets: Set<PresetKey>` → `activePill: PresetKey | null`; rename `onTogglePreset` → `onApplyPreset`; strip dead code (`removePreset`, LOMIEN-supersedes-CRA tiebreaker, old additive `applyPreset`, every `activePresets` reference). Custom Preset pill intentionally deferred to slice 2 — pill row just goes empty when the selection drifts off a preset.

## Test plan
- [x] `npm test` — 618 tests, all green (adds Same-Cadence Equality + conform + multi-tier + activePill derivation + short-circuit + 3-pill layout coverage)
- [x] `npx tsc -b` — clean; `PresetKey` unchanged at 3 values, entry type evolution surfaced, `activePill` nullable
- [x] `npm run lint` — clean
- [x] Acceptance criteria verified against issue

Closes #200