### PR TITLE
Boss preset: Custom pill indicator

### DIFF
--- a/src/components/MatrixToolbar.tsx
+++ b/src/components/MatrixToolbar.tsx
@@ -1,5 +1,5 @@
 export type CadenceFilter = 'All' | 'Weekly' | 'Daily';
-export type PresetKey = 'CRA' | 'LOMIEN' | 'CTENE';
+export type PresetKey = 'CRA' | 'LOMIEN' | 'CTENE' | 'CUSTOM';
 
 interface MatrixToolbarProps {
   filter: CadenceFilter;
@@ -57,7 +57,7 @@ const CADENCES: ReadonlyArray<{ value: CadenceFilter; icon: React.ReactNode }> =
   },
 ];
 
-const PRESETS: readonly PresetKey[] = ['CRA', 'LOMIEN', 'CTENE'];
+const PRESETS: readonly PresetKey[] = ['CRA', 'LOMIEN', 'CTENE', 'CUSTOM'];
 
 export function MatrixToolbar({
   filter,

--- a/src/components/MuleDetailDrawer/hooks/__tests__/useBossMatrixView.test.tsx
+++ b/src/components/MuleDetailDrawer/hooks/__tests__/useBossMatrixView.test.tsx
@@ -254,17 +254,31 @@ describe('useBossMatrixView', () => {
       expect(result.current.activePill).toBeNull();
     });
 
-    it('is null for CRA + extra non-preset weekly (CUSTOM comes in slice 2)', () => {
-      const arkariumKey = `${ARKARIUM_BOSS.id}:normal:weekly`;
+    it('is "CUSTOM" for CRA + extra non-preset weekly (no canonical match, weekly ≥ 1)', () => {
+      // Black Mage is weekly-cadence and outside every canonical preset.
+      const blackMageKey = `${BLACK_MAGE_BOSS.id}:hard:weekly`;
       const { result } = renderHook(() =>
         useBossMatrixView({
           muleId: 'mule-1',
-          selectedBosses: [...CRA_KEYS, arkariumKey],
+          selectedBosses: [...CRA_KEYS, blackMageKey],
           partySizes: undefined,
           onUpdate: vi.fn(),
         }),
       );
-      expect(result.current.activePill).toBeNull();
+      expect(result.current.activePill).toBe('CUSTOM');
+    });
+
+    it('is "CUSTOM" for a single weekly key on a family no canonical preset covers', () => {
+      const blackMageKey = `${BLACK_MAGE_BOSS.id}:hard:weekly`;
+      const { result } = renderHook(() =>
+        useBossMatrixView({
+          muleId: 'mule-1',
+          selectedBosses: [blackMageKey],
+          partySizes: undefined,
+          onUpdate: vi.fn(),
+        }),
+      );
+      expect(result.current.activePill).toBe('CUSTOM');
     });
 
     it('is "CRA" for an exact CRA selection', () => {
@@ -318,7 +332,7 @@ describe('useBossMatrixView', () => {
       expect(result.current.activePill).toBe('LOMIEN');
     });
 
-    it('is null when only daily keys are selected', () => {
+    it('is null when only daily keys are selected (CUSTOM stays dark for daily-only)', () => {
       const vellumDaily = `${VELLUM_BOSS.id}:normal:daily`;
       const { result } = renderHook(() =>
         useBossMatrixView({
@@ -329,6 +343,75 @@ describe('useBossMatrixView', () => {
         }),
       );
       expect(result.current.activePill).toBeNull();
+    });
+
+    it('is null when a non-preset-family has only a daily key (no weekly anywhere)', () => {
+      const horntailDaily = `${HORNTAIL_BOSS.id}:chaos:daily`;
+      const { result } = renderHook(() =>
+        useBossMatrixView({
+          muleId: 'mule-1',
+          selectedBosses: [horntailDaily],
+          partySizes: undefined,
+          onUpdate: vi.fn(),
+        }),
+      );
+      expect(result.current.activePill).toBeNull();
+    });
+  });
+
+  describe('applyPreset("CUSTOM") — inert click', () => {
+    it('produces zero onUpdate calls when selection is already CUSTOM', () => {
+      const arkariumKey = `${ARKARIUM_BOSS.id}:normal:weekly`;
+      const onUpdate = vi.fn();
+      const { result } = renderHook(() =>
+        useBossMatrixView({
+          muleId: 'mule-1',
+          selectedBosses: [arkariumKey],
+          partySizes: undefined,
+          onUpdate,
+        }),
+      );
+
+      act(() => {
+        result.current.applyPreset('CUSTOM');
+      });
+      expect(onUpdate).not.toHaveBeenCalled();
+    });
+
+    it('produces zero onUpdate calls even when a canonical preset is active', () => {
+      // Pills are apply-only; clicking CUSTOM never rewrites selection, no
+      // matter what's currently selected.
+      const onUpdate = vi.fn();
+      const { result } = renderHook(() =>
+        useBossMatrixView({
+          muleId: 'mule-1',
+          selectedBosses: CRA_KEYS,
+          partySizes: undefined,
+          onUpdate,
+        }),
+      );
+
+      act(() => {
+        result.current.applyPreset('CUSTOM');
+      });
+      expect(onUpdate).not.toHaveBeenCalled();
+    });
+
+    it('produces zero onUpdate calls when selection is empty', () => {
+      const onUpdate = vi.fn();
+      const { result } = renderHook(() =>
+        useBossMatrixView({
+          muleId: 'mule-1',
+          selectedBosses: [],
+          partySizes: undefined,
+          onUpdate,
+        }),
+      );
+
+      act(() => {
+        result.current.applyPreset('CUSTOM');
+      });
+      expect(onUpdate).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/MuleDetailDrawer/hooks/useBossMatrixView.ts
+++ b/src/components/MuleDetailDrawer/hooks/useBossMatrixView.ts
@@ -1,10 +1,10 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { Mule } from '../../../types';
 import { MuleBossSlate, type SlateFamily } from '../../../data/muleBossSlate';
-import { conform, isPresetActive } from '../../../data/bossPresets';
+import { conform, isPresetActive, type CanonicalPresetKey } from '../../../data/bossPresets';
 import type { CadenceFilter, PresetKey } from '../../MatrixToolbar';
 
-const CANONICAL_PRESETS: readonly PresetKey[] = ['CRA', 'LOMIEN', 'CTENE'];
+const CANONICAL_PRESETS: readonly CanonicalPresetKey[] = ['CRA', 'LOMIEN', 'CTENE'];
 
 const PARTY_SIZE_MIN = 1;
 const PARTY_SIZE_MAX = 6;
@@ -81,10 +81,14 @@ export function useBossMatrixView({
     [slate, search, filter],
   );
 
-  const activePill = useMemo<PresetKey | null>(
-    () => CANONICAL_PRESETS.find((p) => isPresetActive(p, selectedBosses)) ?? null,
-    [selectedBosses],
-  );
+  const activePill = useMemo<PresetKey | null>(() => {
+    const canonical = CANONICAL_PRESETS.find((p) => isPresetActive(p, selectedBosses));
+    if (canonical) return canonical;
+    // **Custom Preset**: lights up iff at least one weekly **Slate Key**
+    // exists AND no canonical preset matches. Daily-only selections leave
+    // the pill row empty.
+    return slate.weeklyCount > 0 ? 'CUSTOM' : null;
+  }, [selectedBosses, slate]);
 
   const stablePartySizes = useMemo(() => partySizes ?? {}, [partySizes]);
 
@@ -99,6 +103,9 @@ export function useBossMatrixView({
   const applyPreset = useCallback(
     (preset: PresetKey) => {
       if (!muleId) return;
+      // **Custom Preset** has no entries — the click is purely reflective
+      // and nothing changes.
+      if (preset === 'CUSTOM') return;
       // Re-click on the Active Pill: no state churn, no persist fire.
       if (activePill === preset) return;
       const next = conform(slate.keys, preset);

--- a/src/components/__tests__/MatrixToolbar.test.tsx
+++ b/src/components/__tests__/MatrixToolbar.test.tsx
@@ -212,7 +212,7 @@ describe('MatrixToolbar', () => {
       const buttonNames = Array.from(presetGroup!.querySelectorAll('button')).map((b) =>
         b.textContent?.trim(),
       );
-      expect(buttonNames).toEqual(['CRA', 'LOMIEN', 'CTENE']);
+      expect(buttonNames).toEqual(['CRA', 'LOMIEN', 'CTENE', 'CUSTOM']);
     });
 
     it('separates the preset control from the cadence filter with a .d-toolbar-sep', () => {
@@ -297,6 +297,62 @@ describe('MatrixToolbar', () => {
       expect(screen.getByRole('button', { name: /^cra$/i }).querySelector('svg')).toBeNull();
       expect(screen.getByRole('button', { name: /^lomien$/i }).querySelector('svg')).toBeNull();
       expect(screen.getByRole('button', { name: /^ctene$/i }).querySelector('svg')).toBeNull();
+      expect(screen.getByRole('button', { name: /^custom$/i }).querySelector('svg')).toBeNull();
+    });
+
+    describe('Custom Preset pill', () => {
+      it('renders a CUSTOM button positioned last (after CTENE)', () => {
+        renderToolbar();
+        const cteneBtn = screen.getByRole('button', { name: /^ctene$/i });
+        const customBtn = screen.getByRole('button', { name: /^custom$/i });
+        expect(customBtn).toBeTruthy();
+        expect(
+          cteneBtn.compareDocumentPosition(customBtn) & Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
+      });
+
+      it('lights CUSTOM when activePill === "CUSTOM"', () => {
+        renderToolbar({ activePill: 'CUSTOM' });
+        expect(screen.getByRole('button', { name: /^custom$/i }).classList.contains('on')).toBe(
+          true,
+        );
+        expect(screen.getByRole('button', { name: /^cra$/i }).classList.contains('on')).toBe(false);
+        expect(screen.getByRole('button', { name: /^lomien$/i }).classList.contains('on')).toBe(
+          false,
+        );
+        expect(screen.getByRole('button', { name: /^ctene$/i }).classList.contains('on')).toBe(
+          false,
+        );
+      });
+
+      it('CUSTOM is not lit when another pill is active', () => {
+        renderToolbar({ activePill: 'CRA' });
+        expect(screen.getByRole('button', { name: /^custom$/i }).classList.contains('on')).toBe(
+          false,
+        );
+      });
+
+      it('calls onApplyPreset with "CUSTOM" when CUSTOM is clicked', () => {
+        const onApplyPreset = vi.fn();
+        renderToolbar({ onApplyPreset });
+        fireEvent.click(screen.getByRole('button', { name: /^custom$/i }));
+        expect(onApplyPreset).toHaveBeenCalledWith('CUSTOM');
+      });
+
+      it('CUSTOM pill shares the canonical-pill segmented-control group', () => {
+        const { container } = renderToolbar();
+        const groups = container.querySelectorAll('.d-c-toggle');
+        const presetGroup = Array.from(groups).find((g) => {
+          const names = Array.from(g.querySelectorAll('button')).map((b) => b.textContent?.trim());
+          return names.includes('CUSTOM');
+        });
+        expect(presetGroup).toBeTruthy();
+        const buttonNames = Array.from(presetGroup!.querySelectorAll('button')).map((b) =>
+          b.textContent?.trim(),
+        );
+        // Same shape + same active/inactive treatment as canonical pills.
+        expect(buttonNames).toEqual(['CRA', 'LOMIEN', 'CTENE', 'CUSTOM']);
+      });
     });
   });
 });

--- a/src/data/__tests__/bossPresets.test.ts
+++ b/src/data/__tests__/bossPresets.test.ts
@@ -224,6 +224,13 @@ describe('isPresetActive — Same-Cadence Equality', () => {
       .concat([buildKey(vellum.id, 'normal', 'weekly')]);
     expect(isPresetActive('CRA', keys)).toBe(false);
   });
+
+  it('only accepts canonical preset keys (CUSTOM has no entries list)', () => {
+    // `PRESET_FAMILIES` is typed over `CanonicalPresetKey` — CRA/LOMIEN/CTENE
+    // only — so `CUSTOM` is unreachable by `isPresetActive` at both the
+    // type and value level. Asserting the keys list guards that invariant.
+    expect(Object.keys(PRESET_FAMILIES).sort()).toEqual(['CRA', 'CTENE', 'LOMIEN']);
+  });
 });
 
 describe('conform', () => {

--- a/src/data/bossPresets.ts
+++ b/src/data/bossPresets.ts
@@ -26,7 +26,19 @@ import { getBossByFamily } from './bosses';
  * enforced.
  */
 
-export type PresetKey = 'CRA' | 'LOMIEN' | 'CTENE';
+/**
+ * **Canonical Preset Keys** — the three curated presets that have an entries
+ * list, a **Conform** behaviour, and a **Same-Cadence Equality** match rule.
+ */
+export type CanonicalPresetKey = 'CRA' | 'LOMIEN' | 'CTENE';
+
+/**
+ * **Preset Key** — any **Preset Pill** that can be the **Active Pill**.
+ * `'CUSTOM'` is the reflective fourth pill that lights up when the **Mule's**
+ * weekly selection is non-empty but doesn't match any **Canonical Preset**;
+ * it has no entries and clicking it is inert.
+ */
+export type PresetKey = CanonicalPresetKey | 'CUSTOM';
 
 /** Authoring form for a preset entry; normalized via `normalizeEntry`. */
 export type PresetFamily =
@@ -131,7 +143,7 @@ export const PRESET_FAMILIES = {
     'papulatus',
     'magnus',
   ],
-} as const satisfies Record<PresetKey, readonly PresetFamily[]>;
+} as const satisfies Record<CanonicalPresetKey, readonly PresetFamily[]>;
 
 /** Resolved **Default Tier** selection key for an entry, or `null`. */
 export function presetEntryKey(spec: PresetFamily): string | null {
@@ -158,7 +170,7 @@ function defaultTierKey(entry: PresetEntry): string | null {
  * Build `{ bossId → entry }` for a preset's entries. Entries whose family
  * doesn't resolve are skipped so callers can iterate without null checks.
  */
-function entryByBossId(preset: PresetKey): Map<string, PresetEntry> {
+function entryByBossId(preset: CanonicalPresetKey): Map<string, PresetEntry> {
   const map = new Map<string, PresetEntry>();
   for (const spec of PRESET_FAMILIES[preset]) {
     const entry = normalizeEntry(spec);
@@ -176,7 +188,7 @@ function entryByBossId(preset: PresetKey): Map<string, PresetEntry> {
  * weekly keys exist on families outside the preset's entries. Daily keys
  * are ignored entirely.
  */
-export function isPresetActive(preset: PresetKey, keys: readonly string[]): boolean {
+export function isPresetActive(preset: CanonicalPresetKey, keys: readonly string[]): boolean {
   const entries = entryByBossId(preset);
   const weeklyTierByBossId = new Map<string, string>();
 
@@ -207,7 +219,7 @@ export function isPresetActive(preset: PresetKey, keys: readonly string[]): bool
  *
  * Idempotent on an already-**Active Preset** selection.
  */
-export function conform(keys: readonly string[], preset: PresetKey): string[] {
+export function conform(keys: readonly string[], preset: CanonicalPresetKey): string[] {
   const entries = entryByBossId(preset);
   const next: string[] = [];
   const satisfied = new Set<string>();


### PR DESCRIPTION
## Summary
- Adds the reflective **Custom Preset** pill (4th **Preset Pill**, positioned last after CTENE) that lights up iff the **Mule** has >=1 weekly **Slate Key** and no **Canonical Preset** matches.
- Clicking **CUSTOM** is inert — pills are apply-only and **CUSTOM** has nothing to apply (short-circuits before `onUpdate`).
- `PresetKey` extends to `'CUSTOM'`; introduces a narrower `CanonicalPresetKey` that gates `PRESET_FAMILIES`, `isPresetActive`, and `conform` so **CUSTOM** is unreachable by the canonical machinery at the type level.

## Test plan
- [x] `pnpm test` — all 629 tests green
- [x] `pnpm lint` — clean
- [x] `pnpm exec tsc -b` — clean
- [x] `MatrixToolbar.test.tsx`: 4-pill layout with CUSTOM last, click dispatches `onApplyPreset('CUSTOM')`, highlight toggles on `activePill === 'CUSTOM'`
- [x] `useBossMatrixView.test.tsx`: `activePill === 'CUSTOM'` for CRA + extra weekly, and for a single weekly key on a non-canonical family; `null` for daily-only; `applyPreset('CUSTOM')` produces zero `onUpdate` calls (across empty, CUSTOM, and Active-Pill states)
- [x] `bossPresets.test.ts`: asserts `PRESET_FAMILIES` keys are exactly the three canonical presets

Closes #201